### PR TITLE
[codex] Align store buy tooltip behavior

### DIFF
--- a/mods/game_store/classes/Home.lua
+++ b/mods/game_store/classes/Home.lua
@@ -55,7 +55,6 @@ function HomeOffer:configure(categoryName, offers, scrolling, homePanel, reasons
 	HomeOffer.dailyOffers = dailyOffers
 
 	Offers.reasons = reasons
-	Offers.reasons[#Offers.reasons + 1] = "You don't have money"
 
 	HomeOffer:createOffers()
 	HomeOffer.lastid = 0
@@ -225,19 +224,6 @@ function HomeOffer:createOffers()
 		for i = #offer.offers, 1, -1 do
 			local subOffer = offer.offers[i]
 			-- check price   subOffer.price
-			if subOffer.coinType == COIN_TYPE_DEFAULT then -- normal coin
-				if Store.coins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-				end
-			elseif subOffer.coinType == COIN_TYPE_TRANSFERABLE then -- transfeable coin
-				if Store.transferableCoins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-				end
-			elseif subOffer.coinType == COIN_TYPE_TOURNAMENT then -- tournament coin
-				if Store.tournamentCoins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-				end
-			end
 
 			for _, i in pairs(subOffer.disabledReasons) do
 				subOffer.disabledReason = string.format("%s* %s\n", subOffer.disabledReason, Offers.reasons[i.reasonId])
@@ -395,15 +381,6 @@ function HomeOffer:createDailyOffers()
 		for i = #offer.offers, 1, -1 do
 			local subOffer = offer.offers[i]
 			-- check price   subOffer.price
-			if subOffer.coinType == COIN_TYPE_DEFAULT then -- normal coin
-				if Store.coins < offer.discountPrice then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-				end
-			elseif subOffer.coinType == COIN_TYPE_TRANSFERABLE then -- transfeable coin
-				if Store.transferableCoins < offer.discountPrice then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-				end
-			end
 
 
 			for _, i in pairs(subOffer.disabledReasons) do

--- a/mods/game_store/classes/Offers.lua
+++ b/mods/game_store/classes/Offers.lua
@@ -18,6 +18,49 @@ Offers.coinCheck = nil
 Offers.loadOffersEvent = nil
 Offers.clientOffers = {}
 
+local function removeBuyTooltipOverlay(id)
+	if not Offers.displayPanel then
+		return
+	end
+
+	local overlay = Offers.displayPanel:recursiveGetChildById(id)
+	if overlay then
+		overlay:destroy()
+	end
+end
+
+local function createBuyTooltipOverlay(button, id, disabledReason)
+	removeBuyTooltipOverlay(id)
+
+	if not Offers.displayPanel or not button or not disabledReason or disabledReason == '' then
+		return
+	end
+
+	local overlay = g_ui.createWidget('UIWidget', Offers.displayPanel)
+	overlay:setId(id)
+	overlay:setFocusable(false)
+	overlay:setSize(button:getSize())
+	overlay:setPosition(button:getPosition())
+	overlay:parseColoreDisplayToolTip(string.format(
+		"[color=#ff0000]The product is not available for this character:\n\n%s[/color]",
+		disabledReason
+	))
+	overlay:setOpacity(0)
+	overlay:addAnchor(AnchorLeft, button:getId(), AnchorLeft)
+	overlay:addAnchor(AnchorTop, button:getId(), AnchorTop)
+	overlay:raise()
+end
+
+local function hasEnoughCoins(subOffer)
+	if subOffer.coinType == COIN_TYPE_TRANSFERABLE then
+		return Store.transferableCoins >= subOffer.price
+	elseif subOffer.coinType == COIN_TYPE_TOURNAMENT then
+		return Store.tournamentCoins >= subOffer.price
+	end
+
+	return (Store.coins + Store.transferableCoins) >= subOffer.price
+end
+
 function Offers:stopAllEvents()
 	if HomeOffer.event then
 		HomeOffer.event:cancel()
@@ -57,7 +100,6 @@ function Offers:configure(categoryName, offers, redirect, sortingType, filters, 
 	Offers.currentFilter = currentFilter
 
 	Offers.reasons = reasons
-	Offers.reasons[#Offers.reasons + 1] = "You don't have money"
 	Offers.clientOffers = {}
 	Offers:checkOrder(nil, sortingType, currentFilter)
 end
@@ -219,35 +261,16 @@ function Offers:refreshOffers(displayOffer, redirect, filter)
 				Offers.clientOffers[offer.id] = string.format("<font color=\"#ECAC46\">{star} Valid until %s{star} %d days left<br /></font>", os.date("%Y-%m-%d, %X", subOffer.saleValidUntilTimestamp), daysLeft)
 			end
 
-			local changeCount = #Offers.reasons
 			-- check price   subOffer.price
-			if subOffer.coinType == COIN_TYPE_DEFAULT then -- normal coin
-				if Store.coins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-
-					widget:getChildById("price" .. i):setColor("$var-text-cip-store-red")
-					widget.coinCheck = true
-				end
-			elseif subOffer.coinType == COIN_TYPE_TRANSFERABLE then -- transfeable coin
-				if Store.transferableCoins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-          			local slot = i == 2 and 1 or 2
-					widget:getChildById("price" .. slot):setColor("$var-text-cip-store-red")
-					widget.coinCheck = true
-				end
-			elseif subOffer.coinType == COIN_TYPE_TOURNAMENT then -- tournament coin
-				if Store.tournamentCoins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-					widget:getChildById("price" .. i):setColor("$var-text-cip-store-red")
-					widget.coinCheck = true
-				end
+			if not hasEnoughCoins(subOffer) then
+				local slot = subOffer.coinType == COIN_TYPE_TRANSFERABLE and (i == 2 and 1 or 2) or i
+				widget:getChildById("price" .. slot):setColor("$var-text-cip-store-red")
+				widget.coinCheck = true
 			end
 
 			local canChange = false
 			for _, i in pairs(subOffer.disabledReasons) do
-				if changeCount ~= i.reasonId then
-					canChange = true
-				end
+				canChange = true
 				subOffer.disabledReason = string.format("%s* %s\n", subOffer.disabledReason, Offers.reasons[i.reasonId])
 			end
 
@@ -384,7 +407,7 @@ function Offers:setDisableShader(widget, disabledReason, active, state)
 
 		widget.name:setColor(c_color)
 
-		local color = not string.find(disabledReason, "You don't have money") and "$var-text-cip-store-disabled" or "$var-text-cip-store-red-disabled"
+		local color = "$var-text-cip-store-disabled"
 
 		widget.price1:setColor(color)
 		widget.price2:setColor(color)
@@ -513,26 +536,28 @@ function Offers:onSelectionOffer(_, selectedWidget)
 	end
 
 	local disabled = false
+	removeBuyTooltipOverlay('buy1TooltipOverlay')
+	removeBuyTooltipOverlay('buy2TooltipOverlay')
 	Offers.displayPanel.buy1:setImageSource("/images/store/buybutton")
 	Offers.displayPanel.buy1:setOn(true)
 	Offers.displayPanel.buy1:setTooltip('')
 	Offers.displayPanel.buy2:setTooltip('')
 	Offers.displayPanel.price1.price:setColor("$var-text-cip-color")
 	Offers.displayPanel.price2.price:setColor("$var-text-cip-color")
+	local hasBalance1 = hasEnoughCoins(offer.offers[1])
+	if not hasBalance1 then
+		Offers.displayPanel.price1.price:setColor("$var-text-cip-store-red")
+	end
+
 	if offer.offers[1].disabledReason ~= '' then
 		Offers.displayPanel.buy1.onClick = function() end
-		local msg = {}
-		setStringColor(msg, "The product is not available for this character:\n", "$var-text-cip-store-red")
-		setStringColor(msg, offer.offers[1].disabledReason, "$var-text-cip-store-red")
-		Offers.displayPanel.buy1:setTooltip(msg)
+		createBuyTooltipOverlay(Offers.displayPanel.buy1, 'buy1TooltipOverlay', offer.offers[1].disabledReason)
 		Offers.displayPanel.buy1:setImageSource("/images/store/buybutton")
 		Offers.displayPanel.buy1:setOn(false)
-
-
-		if string.find(offer.offers[1].disabledReason, "You don't have money") then
-			Offers.displayPanel.price1.price:setColor("$var-text-cip-store-red")
-		end
 		disabled = true
+	elseif not hasBalance1 then
+		Offers.displayPanel.buy1.onClick = function() end
+		Offers.displayPanel.buy1:setOn(false)
 	else
 		Offers.displayPanel.buy1.onClick = function() buyStoreOffer(offer, offer.offers[1]) end
 	end
@@ -582,26 +607,27 @@ function Offers:onSelectionOffer(_, selectedWidget)
 
 		Offers.displayPanel.buy2:setImageSource("/images/store/buybutton")
 		Offers.displayPanel.buy2:setOn(true)
+		local hasBalance2 = hasEnoughCoins(offer.offers[2])
+		if not hasBalance2 then
+			Offers.displayPanel.price2.price:setColor("$var-text-cip-store-red")
+		end
+
 		if offer.offers[2].disabledReason ~= '' then
 			Offers.displayPanel.buy2.onClick = function() end
-			local msg = {}
-			setStringColor(msg, "The product is not available for this character:\n", "$var-text-cip-store-red")
-			setStringColor(msg, offer.offers[2].disabledReason, "$var-text-cip-store-red")
 			Offers.displayPanel.buy2:setOn(false)
-			Offers.displayPanel.buy2:setTooltip(msg)
-
-
-			if string.find(offer.offers[2].disabledReason, "You don't have money") then
-				Offers.displayPanel.price2.price:setColor("$var-text-cip-store-red")
-			end
+			createBuyTooltipOverlay(Offers.displayPanel.buy2, 'buy2TooltipOverlay', offer.offers[2].disabledReason)
 
 			disabled = true
+		elseif not hasBalance2 then
+			Offers.displayPanel.buy2.onClick = function() end
+			Offers.displayPanel.buy2:setOn(false)
 		else
 			Offers.displayPanel.buy2.onClick = function() buyStoreOffer(offer, offer.offers[2]) end
 		end
 	else
 		Offers.displayPanel.buy2:setVisible(false)
 		Offers.displayPanel.price2:setVisible(false)
+		removeBuyTooltipOverlay('buy2TooltipOverlay')
 	end
 
 	if disabled then
@@ -847,40 +873,14 @@ function Offers:checkOfferValue()
 		local offer = widget.offer
 		for i = #offer.offers, 1, -1 do
 			local subOffer = offer.offers[i]
-			if subOffer.coinType == COIN_TYPE_DEFAULT then -- normal coin
-				if Store.coins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-
-          local slot = i == 2 and 1 or 2
-          if #offer.offers == 1 then
-          	slot = 1
-          end
-          local priceSlot = widget:getChildById("price" .. slot)
-					priceSlot:setColor(widget.grayHover:isVisible() and "$var-text-cip-store-red-disabled" or "$var-text-cip-store-red")
-					widget.coinCheck = true
+			if not hasEnoughCoins(subOffer) then
+				local slot = i == 2 and 1 or 2
+				if #offer.offers == 1 then
+					slot = 1
 				end
-			elseif subOffer.coinType == COIN_TYPE_TRANSFERABLE then -- transfeable coin
-				if Store.transferableCoins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-          local slot = i == 2 and 1 or 2
-          if #offer.offers == 1 then
-          	slot = 1
-          end
-          local priceSlot = widget:getChildById("price" .. slot)
-					priceSlot:setColor((widget.grayHover:isVisible() and "$var-text-cip-store-red-disabled" or "$var-text-cip-store-red"))
-					widget.coinCheck = true
-				end
-			elseif subOffer.coinType == COIN_TYPE_TOURNAMENT then -- tournament coin
-				if Store.tournamentCoins < subOffer.price then
-					subOffer.disabledReasons[#subOffer.disabledReasons + 1] = {reasonId = #Offers.reasons}
-          local slot = i == 2 and 1 or 2
-          if #offer.offers == 1 then
-          	slot = 1
-          end
-          local priceSlot = widget:getChildById("price" .. slot)
-					priceSlot:setColor(widget.grayHover:isVisible() and "$var-text-cip-store-red-disabled" or "$var-text-cip-store-red")
-					widget.coinCheck = true
-				end
+				local priceSlot = widget:getChildById("price" .. slot)
+				priceSlot:setColor(widget.grayHover:isVisible() and "$var-text-cip-store-red-disabled" or "$var-text-cip-store-red")
+				widget.coinCheck = true
 			end
 
 			if #subOffer.disabledReasons > 0 and not widget.coinCheck then

--- a/modules/corelib/ui/tooltip.lua
+++ b/modules/corelib/ui/tooltip.lua
@@ -60,6 +60,9 @@ local function onWidgetHoverChange(widget, hovered)
         g_tooltip.display(widget)
       end
       currentHoveredWidget = widget
+    elseif widget.parseColoreDisplay and not g_mouse.isPressed() then
+      g_tooltip.parseColoreDisplay(widget.parseColoreDisplay)
+      currentHoveredWidget = widget
     end
   else
     if widget == currentHoveredWidget then
@@ -69,7 +72,7 @@ local function onWidgetHoverChange(widget, hovered)
   end
 
   -- Hotfix
-  if not widget.tooltip then
+  if not widget.tooltip and not widget.parseColoreDisplay then
     g_tooltip.hide()
     currentHoveredWidget = nil
   end
@@ -84,6 +87,27 @@ local function onWidgetStyleApply(widget, styleName, styleNode)
     widget.tooltipFont = styleNode["tooltip-font"]
   elseif styleNode["tooltip-delayed"] then
     widget.tooltipDelayed = styleNode["tooltip-delayed"]
+  end
+
+  local tooltipWidget = widget:getChildById('toolTipWidget')
+  if widget:getId() == 'toolTipWidget' then
+    tooltipWidget = widget
+    widget = widget:getParent()
+  end
+  if tooltipWidget then
+    if widget.tooltip then
+      tooltipWidget.tooltip = widget.tooltip
+      widget.tooltip = nil
+    end
+    if widget.parseColoreDisplay then
+      tooltipWidget.parseColoreDisplay = widget.parseColoreDisplay
+      widget.parseColoreDisplay = nil
+    end
+    if tooltipWidget.tooltip or tooltipWidget.parseColoreDisplay then
+      tooltipWidget:setOpacity(1)
+    else
+      tooltipWidget:setOpacity(0.4)
+    end
   end
 end
 
@@ -178,6 +202,29 @@ function g_tooltip.displayText(text)
   })
 end
 
+function g_tooltip.parseColoreDisplay(text)
+  if not text or text:len() == 0 then return end
+  if not toolTipLabel then return end
+
+  toolTipLabel:setColorText(text)
+  toolTipLabel:setFont("Verdana Bold-11px")
+  toolTipLabel:resizeToText()
+  toolTipLabel:resize(toolTipLabel:getWidth() + 8, toolTipLabel:getHeight() + 4)
+  toolTipLabel:setBackgroundColor("#c0c0c0")
+  toolTipLabel:setColor("#3f3f3f")
+  toolTipLabel:setBorderWidth(1)
+  toolTipLabel:setBorderColor("#000000")
+  toolTipLabel:show()
+  toolTipLabel:raise()
+  toolTipLabel:enable()
+  g_effects.fadeIn(toolTipLabel, 100)
+  moveToolTip(true)
+
+  connect(rootWidget, {
+    onMouseMove = moveToolTip,
+  })
+end
+
 function g_tooltip.hide()
   g_effects.fadeOut(toolTipLabel, 100)
   toolTipLabel:hide()
@@ -190,15 +237,30 @@ end
 
 -- UIWidget extensions
 function UIWidget:setTooltip(text)
-  self.tooltip = text
+  local tooltipWidget = self:getChildById('toolTipWidget')
+  if tooltipWidget then
+    tooltipWidget.tooltip = text
+  else
+    self.tooltip = text
+  end
 end
 
 function UIWidget:setTooltipFont(font)
   self.tooltipFont = font
 end
 
+function UIWidget:parseColoreDisplayToolTip(text)
+  local tooltipWidget = self:getChildById('toolTipWidget')
+  if tooltipWidget then
+    tooltipWidget.parseColoreDisplay = text
+  else
+    self.parseColoreDisplay = text
+  end
+end
+
 function UIWidget:removeTooltip()
   self.tooltip = nil
+  self.parseColoreDisplay = nil
 end
 
 function UIWidget:getTooltip()


### PR DESCRIPTION
## Summary

- Align Store buy-button tooltip handling with `otclient-main`.
- Add transparent tooltip overlays for unavailable Store offers instead of assigning colored tooltip data directly to disabled Buy buttons.
- Stop treating insufficient coin balance as a Store disabled reason; insufficient balance now only marks prices red and leaves Buy inactive, matching the reference behavior.
- Add `parseColoreDisplayToolTip` support in the core tooltip flow needed by the Store overlay pattern.

## Validation

- Ran `git diff --check` for the three changed files.
- Lua syntax parsing was not run because `lua`/`luac` is not installed in this environment.

## Scope

Only these files are included:

- `mods/game_store/classes/Home.lua`
- `mods/game_store/classes/Offers.lua`
- `modules/corelib/ui/tooltip.lua`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refatoração da lógica de verificação de disponibilidade de ofertas baseada em saldo.

* **UI/UX Improvements**
  * Implementação de tooltips coloridos para melhor visualização de informações nas ofertas.
  * Ajuste na apresentação de mensagens de indisponibilidade de ofertas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->