### PR TITLE
[codex] Persist store coin balance before rendering

### DIFF
--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -242,16 +242,16 @@ function onStoreCategories(categories)
 end
 
 function onCoinBalance(coins, transferableCoins, reservedCoins)
+  Store.coins = coins or 0
+  Store.transferableCoins = transferableCoins or 0
+
   if (SucessOfferWindow and SucessOfferWindow:isVisible()) or StoreWindow:isVisible() then
-    StoreWindow.coinsStatus.tibiacoin:setText(formatMoney(coins, ","))
-    local coinsText = string.format(" (%s: %s ", (GameInfo.CoinName and GameInfo.CoinName or "Astra Coins"), formatMoney(transferableCoins, ","))
+    StoreWindow.coinsStatus.tibiacoin:setText(formatMoney(Store.coins, ","))
+    local coinsText = string.format(" (%s: %s ", (GameInfo.CoinName and GameInfo.CoinName or "Astra Coins"), formatMoney(Store.transferableCoins, ","))
     StoreWindow.coinsStatus.tibiacointransferable:setText(coinsText)
 
-    Store.coins = coins
-    Store.transferableCoins = transferableCoins
-
-    bazaarWindow.contentPanel.rulesPanel:recursiveGetChildById('coin'):setText(formatMoney(transferableCoins, ","))
-    bazaarWindow.contentPanel.characterPanel:recursiveGetChildById('coin'):setText(formatMoney(transferableCoins, ","))
+    bazaarWindow.contentPanel.rulesPanel:recursiveGetChildById('coin'):setText(formatMoney(Store.transferableCoins, ","))
+    bazaarWindow.contentPanel.characterPanel:recursiveGetChildById('coin'):setText(formatMoney(Store.transferableCoins, ","))
 
     Offers:refreshOffers(Offers.displayOffer, Offers.redirect, Offers.filter)
   end


### PR DESCRIPTION
## Summary

Updates the Store coin balance handler so received balances are persisted even when the Store window is not visible yet.

## Root Cause

The custom Store protocol sends the account Tibia Coins before the Store UI is shown. `onCoinBalance` previously only updated `Store.coins` and `Store.transferableCoins` while the Store or success window was visible, so the initial balance packet could be discarded.

## Impact

Astra now keeps the balance received from the OTServer for Store logic.

## Validation

- `git diff --check -- mods/game_store/store.lua`
- Confirmed `D:\forgottenserver-downgrade-1.8-8.60` sends and debits `player:getTibiaCoins()` / `player:setTibiaCoins()` from `accounts.tibia_coins`.