### PR TITLE
[codex] Fix store coin balance rendering and gifting

### DIFF
--- a/mods/game_store/classes/Gift.lua
+++ b/mods/game_store/classes/Gift.lua
@@ -5,22 +5,23 @@ end
 
 function GiftCoins:onGiftWindow()
 	closeStore()
-	local count = g_game.getTransferableTibiaCoins()
+	local count = Store.transferableCoins or 0
+	local coinsPacketSize = Store.coinsPacketSize or 25
 
 	giftWindow = g_ui.createWidget('GiftWindow', rootWidget)
 	g_client.setInputLockWidget(giftWindow)
 	local scrollbar = giftWindow.contentPanel:getChildById('countScrollBar')
 	scrollbar:setMaximum(count)
-	scrollbar:setMinimum(Store.coinsPacketSize)
-	scrollbar:setStep(Store.coinsPacketSize)
-	scrollbar:setValue(Store.coinsPacketSize)
-	giftWindow.contentPanel.currentAmount:setText(Store.coinsPacketSize)
+	scrollbar:setMinimum(coinsPacketSize)
+	scrollbar:setStep(coinsPacketSize)
+	scrollbar:setValue(coinsPacketSize)
+	giftWindow.contentPanel.currentAmount:setText(coinsPacketSize)
 
 	local spinbox = giftWindow.contentPanel.spinBox
 	spinbox:setMaximum(count)
-	spinbox:setMinimum(Store.coinsPacketSize)
-	spinbox:setValue(Store.coinsPacketSize)
-	spinbox:setStep(Store.coinsPacketSize)
+	spinbox:setMinimum(coinsPacketSize)
+	spinbox:setValue(coinsPacketSize)
+	spinbox:setStep(coinsPacketSize)
 	spinbox:hideButtons()
 	spinbox:focus()
 	spinbox.firstEdit = true
@@ -29,7 +30,7 @@ function GiftCoins:onGiftWindow()
 
 	local spinBoxValueChange = function(self, value)
 		spinbox.firstEdit = false
-		value = math.cround(value, Store.coinsPacketSize)
+		value = math.cround(value, coinsPacketSize)
 		scrollbar:setValue(value)
 	end
 	spinbox.onValueChange = spinBoxValueChange
@@ -44,8 +45,8 @@ function GiftCoins:onGiftWindow()
 	g_keyboard.bindKeyPress("Down", function() check() spinbox:down() end, spinbox)
 	g_keyboard.bindKeyPress("Right", function() check() spinbox:up() end, spinbox)
 	g_keyboard.bindKeyPress("Left", function() check() spinbox:down() end, spinbox)
-	g_keyboard.bindKeyPress("PageUp", function() check() spinbox:setValue(spinbox:getValue()+Store.coinsPacketSize) end, spinbox)
-	g_keyboard.bindKeyPress("PageDown", function() check() spinbox:setValue(spinbox:getValue()-Store.coinsPacketSize) end, spinbox)
+	g_keyboard.bindKeyPress("PageUp", function() check() spinbox:setValue(spinbox:getValue()+coinsPacketSize) end, spinbox)
+	g_keyboard.bindKeyPress("PageDown", function() check() spinbox:setValue(spinbox:getValue()-coinsPacketSize) end, spinbox)
 	g_keyboard.bindKeyPress("Enter", function() moveFunc() end, spinbox)
 
 	scrollbar.onValueChange = function(self, value)

--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -217,11 +217,38 @@ function closeStore()
   Offers:stopAllEvents()
 end
 
+local function updateCoinBalanceWidgets(refreshOffers)
+  if not StoreWindow or not StoreWindow.coinsStatus then
+    return
+  end
+
+  if not ((SucessOfferWindow and SucessOfferWindow:isVisible()) or StoreWindow:isVisible()) then
+    return
+  end
+
+  local coins = Store.coins or 0
+  local transferableCoins = Store.transferableCoins or 0
+
+  StoreWindow.coinsStatus.tibiacoin:setText(formatMoney(coins, ","))
+  local coinsText = string.format(" (%s: %s ", (GameInfo.CoinName and GameInfo.CoinName or "Astra Coins"), formatMoney(transferableCoins, ","))
+  StoreWindow.coinsStatus.tibiacointransferable:setText(coinsText)
+
+  if bazaarWindow then
+    bazaarWindow.contentPanel.rulesPanel:recursiveGetChildById('coin'):setText(formatMoney(transferableCoins, ","))
+    bazaarWindow.contentPanel.characterPanel:recursiveGetChildById('coin'):setText(formatMoney(transferableCoins, ","))
+  end
+
+  if refreshOffers then
+    Offers:refreshOffers(Offers.displayOffer, Offers.redirect, Offers.filter)
+  end
+end
+
 function showStoreWindow()
   StoreWindow:show(true)
   StoreWindow:raise()
   StoreWindow:focus()
   g_client.setInputLockWidget(StoreWindow)
+  updateCoinBalanceWidgets(false)
 
   if Offers.completePurchaseEvent then
     Offers.completePurchaseEvent:cancel()
@@ -245,16 +272,7 @@ function onCoinBalance(coins, transferableCoins, reservedCoins)
   Store.coins = coins or 0
   Store.transferableCoins = transferableCoins or 0
 
-  if (SucessOfferWindow and SucessOfferWindow:isVisible()) or StoreWindow:isVisible() then
-    StoreWindow.coinsStatus.tibiacoin:setText(formatMoney(Store.coins, ","))
-    local coinsText = string.format(" (%s: %s ", (GameInfo.CoinName and GameInfo.CoinName or "Astra Coins"), formatMoney(Store.transferableCoins, ","))
-    StoreWindow.coinsStatus.tibiacointransferable:setText(coinsText)
-
-    bazaarWindow.contentPanel.rulesPanel:recursiveGetChildById('coin'):setText(formatMoney(Store.transferableCoins, ","))
-    bazaarWindow.contentPanel.characterPanel:recursiveGetChildById('coin'):setText(formatMoney(Store.transferableCoins, ","))
-
-    Offers:refreshOffers(Offers.displayOffer, Offers.redirect, Offers.filter)
-  end
+  updateCoinBalanceWidgets(true)
 end
 
 function onStoreHomeOffers(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
@@ -295,7 +313,10 @@ end
 
 
 function onGiftWindow()
-  if g_game.getTransferableTibiaCoins() < Store.coinsPacketSize then
+  local transferableCoins = Store.transferableCoins or 0
+  local coinsPacketSize = Store.coinsPacketSize or 25
+
+  if transferableCoins < coinsPacketSize then
     return showError('Gifting not possible', 'You don\'t have enough coins to gift.')
   end
 


### PR DESCRIPTION
## Summary

Finishes the custom Store coin balance fix after PR #6 by making the rendered footer and gifting flow use the balance received through Astra's custom Store protocol.

## Root Cause

PR #6 made `onCoinBalance` persist the Store balance, but the Store footer could still keep its initial zero labels when the balance packet arrived before the window was shown.

The gift flow also still checked `g_game.getTransferableTibiaCoins()`. That native client balance is not populated by Astra's custom Store protocol, so gifting could show "Gifting not possible" even while purchases worked.

## Changes

- Adds a shared Store coin footer refresh helper and calls it when the Store window is shown.
- Keeps offer refresh tied to actual `onCoinBalance` updates.
- Uses `Store.transferableCoins` for gift validation and gift amount limits.

## Validation

- Compared against `D:\otclient-main`: the reference client uses official player resource balances, while Astra's custom Store uses `onCoinBalance` and `Store.transferableCoins`.
- Confirmed `D:\forgottenserver-downgrade-1.8-8.60` already sends/debits/transfers `accounts.tibia_coins` through `player:getTibiaCoins()` / `player:setTibiaCoins()`.
- `git diff --check upstream/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Correções de Bugs**
  * Otimizado o sistema de atualização de saldos de moedas na janela de loja para melhor sincronização.
  * Aprimorada a verificação de moedas transferíveis ao habilitar funcionalidade de presente.

* **Melhorias**
  * Centralizado o processamento de atualizações de saldos de moedas para maior consistência.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->