### PR TITLE
Fix store balances and monk inventory mirror

### DIFF
--- a/mods/game_store/classes/Gift.lua
+++ b/mods/game_store/classes/Gift.lua
@@ -7,6 +7,9 @@ function GiftCoins:onGiftWindow()
 	closeStore()
 	local count = Store.transferableCoins or 0
 	local coinsPacketSize = Store.coinsPacketSize or 25
+	if count < coinsPacketSize then
+		return
+	end
 
 	giftWindow = g_ui.createWidget('GiftWindow', rootWidget)
 	g_client.setInputLockWidget(giftWindow)

--- a/mods/game_store/classes/Gift.lua
+++ b/mods/game_store/classes/Gift.lua
@@ -5,22 +5,23 @@ end
 
 function GiftCoins:onGiftWindow()
 	closeStore()
-	local count = g_game.getTransferableTibiaCoins()
+	local count = Store.transferableCoins or 0
+	local coinsPacketSize = Store.coinsPacketSize or 25
 
 	giftWindow = g_ui.createWidget('GiftWindow', rootWidget)
 	g_client.setInputLockWidget(giftWindow)
 	local scrollbar = giftWindow.contentPanel:getChildById('countScrollBar')
 	scrollbar:setMaximum(count)
-	scrollbar:setMinimum(Store.coinsPacketSize)
-	scrollbar:setStep(Store.coinsPacketSize)
-	scrollbar:setValue(Store.coinsPacketSize)
-	giftWindow.contentPanel.currentAmount:setText(Store.coinsPacketSize)
+	scrollbar:setMinimum(coinsPacketSize)
+	scrollbar:setStep(coinsPacketSize)
+	scrollbar:setValue(coinsPacketSize)
+	giftWindow.contentPanel.currentAmount:setText(coinsPacketSize)
 
 	local spinbox = giftWindow.contentPanel.spinBox
 	spinbox:setMaximum(count)
-	spinbox:setMinimum(Store.coinsPacketSize)
-	spinbox:setValue(Store.coinsPacketSize)
-	spinbox:setStep(Store.coinsPacketSize)
+	spinbox:setMinimum(coinsPacketSize)
+	spinbox:setValue(coinsPacketSize)
+	spinbox:setStep(coinsPacketSize)
 	spinbox:hideButtons()
 	spinbox:focus()
 	spinbox.firstEdit = true
@@ -29,7 +30,7 @@ function GiftCoins:onGiftWindow()
 
 	local spinBoxValueChange = function(self, value)
 		spinbox.firstEdit = false
-		value = math.cround(value, Store.coinsPacketSize)
+		value = math.cround(value, coinsPacketSize)
 		scrollbar:setValue(value)
 	end
 	spinbox.onValueChange = spinBoxValueChange
@@ -44,8 +45,8 @@ function GiftCoins:onGiftWindow()
 	g_keyboard.bindKeyPress("Down", function() check() spinbox:down() end, spinbox)
 	g_keyboard.bindKeyPress("Right", function() check() spinbox:up() end, spinbox)
 	g_keyboard.bindKeyPress("Left", function() check() spinbox:down() end, spinbox)
-	g_keyboard.bindKeyPress("PageUp", function() check() spinbox:setValue(spinbox:getValue()+Store.coinsPacketSize) end, spinbox)
-	g_keyboard.bindKeyPress("PageDown", function() check() spinbox:setValue(spinbox:getValue()-Store.coinsPacketSize) end, spinbox)
+	g_keyboard.bindKeyPress("PageUp", function() check() spinbox:setValue(spinbox:getValue()+coinsPacketSize) end, spinbox)
+	g_keyboard.bindKeyPress("PageDown", function() check() spinbox:setValue(spinbox:getValue()-coinsPacketSize) end, spinbox)
 	g_keyboard.bindKeyPress("Enter", function() moveFunc() end, spinbox)
 
 	scrollbar.onValueChange = function(self, value)

--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -217,11 +217,38 @@ function closeStore()
   Offers:stopAllEvents()
 end
 
+local function updateCoinBalanceWidgets(refreshOffers)
+  if not StoreWindow or not StoreWindow.coinsStatus then
+    return
+  end
+
+  if not ((SucessOfferWindow and SucessOfferWindow:isVisible()) or StoreWindow:isVisible()) then
+    return
+  end
+
+  local coins = Store.coins or 0
+  local transferableCoins = Store.transferableCoins or 0
+
+  StoreWindow.coinsStatus.tibiacoin:setText(formatMoney(coins, ","))
+  local coinsText = string.format(" (%s: %s ", (GameInfo.CoinName and GameInfo.CoinName or "Astra Coins"), formatMoney(transferableCoins, ","))
+  StoreWindow.coinsStatus.tibiacointransferable:setText(coinsText)
+
+  if bazaarWindow then
+    bazaarWindow.contentPanel.rulesPanel:recursiveGetChildById('coin'):setText(formatMoney(transferableCoins, ","))
+    bazaarWindow.contentPanel.characterPanel:recursiveGetChildById('coin'):setText(formatMoney(transferableCoins, ","))
+  end
+
+  if refreshOffers then
+    Offers:refreshOffers(Offers.displayOffer, Offers.redirect, Offers.filter)
+  end
+end
+
 function showStoreWindow()
   StoreWindow:show(true)
   StoreWindow:raise()
   StoreWindow:focus()
   g_client.setInputLockWidget(StoreWindow)
+  updateCoinBalanceWidgets(false)
 
   if Offers.completePurchaseEvent then
     Offers.completePurchaseEvent:cancel()
@@ -245,16 +272,7 @@ function onCoinBalance(coins, transferableCoins, reservedCoins)
   Store.coins = coins or 0
   Store.transferableCoins = transferableCoins or 0
 
-  if (SucessOfferWindow and SucessOfferWindow:isVisible()) or StoreWindow:isVisible() then
-    StoreWindow.coinsStatus.tibiacoin:setText(formatMoney(Store.coins, ","))
-    local coinsText = string.format(" (%s: %s ", (GameInfo.CoinName and GameInfo.CoinName or "Astra Coins"), formatMoney(Store.transferableCoins, ","))
-    StoreWindow.coinsStatus.tibiacointransferable:setText(coinsText)
-
-    bazaarWindow.contentPanel.rulesPanel:recursiveGetChildById('coin'):setText(formatMoney(Store.transferableCoins, ","))
-    bazaarWindow.contentPanel.characterPanel:recursiveGetChildById('coin'):setText(formatMoney(Store.transferableCoins, ","))
-
-    Offers:refreshOffers(Offers.displayOffer, Offers.redirect, Offers.filter)
-  end
+  updateCoinBalanceWidgets(true)
 end
 
 function onStoreHomeOffers(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
@@ -295,7 +313,10 @@ end
 
 
 function onGiftWindow()
-  if g_game.getTransferableTibiaCoins() < Store.coinsPacketSize then
+  local transferableCoins = Store.transferableCoins or 0
+  local coinsPacketSize = Store.coinsPacketSize or 25
+
+  if transferableCoins < coinsPacketSize then
     return showError('Gifting not possible', 'You don\'t have enough coins to gift.')
   end
 

--- a/modules/game_inventory/inventory.lua
+++ b/modules/game_inventory/inventory.lua
@@ -40,10 +40,16 @@ whiteModeWidget = nil
 yellowModeWidget = nil
 redModeWidget = nil
 
+local function isPlayerMonk()
+  local player = g_game.getLocalPlayer()
+  return player and player.isMonk and player:isMonk() or false
+end
+
 function init()
   connect(LocalPlayer, {
     onInventoryChange = onInventoryChange,
-    onBlessingsChange = onBlessingsChange
+    onBlessingsChange = onBlessingsChange,
+    onVocationChange = onVocationChange
   })
 
   inventoryWindow = g_ui.loadUI('inventory', m_interface.getRightPanel())
@@ -151,7 +157,8 @@ end
 function terminate()
   disconnect(LocalPlayer, {
     onInventoryChange = onInventoryChange,
-    onBlessingsChange = onBlessingsChange
+    onBlessingsChange = onBlessingsChange,
+    onVocationChange = onVocationChange
   })
 
   -- controls
@@ -250,36 +257,57 @@ end
 
 function configureMirror()
   local itemWidget = inventoryPanel:getChildById('slot6')
+  if not itemWidget then
+    return
+  end
   local item = itemWidget:getItem()
 
   local itemWidgetMirror = inventoryPanel:getChildById('slot5')
-  itemWidgetMirror:setFlipDirection(Flip.None)
-  itemWidgetMirror.slot5Dual:setVisible(false)
-  itemWidgetMirror:setPhantom(false)
+  if not itemWidgetMirror then
+    return
+  end
 
-  if not item and itemWidgetMirror.clone then
+  local function clearMirror()
     itemWidgetMirror:setStyle(InventorySlotStyles[5])
     itemWidgetMirror:setItem(nil)
+    itemWidgetMirror:setOpacity(1.0)
+    itemWidgetMirror:setDraggable(true)
+    itemWidgetMirror:setEnabled(true)
+    itemWidgetMirror:setFlipDirection(FlipDirection.None)
+    itemWidgetMirror.slot5Dual:setVisible(false)
+    itemWidgetMirror:setPhantom(false)
     itemWidgetMirror.clone = false
-    return
-  elseif not item then
+  end
+
+  if not isPlayerMonk() then
+    if itemWidgetMirror.clone then
+      clearMirror()
+    end
     return
   end
 
-  if not itemWidgetMirror.clone and itemWidgetMirror:getItem() then
+  if not item then
+    if itemWidgetMirror.clone then
+      clearMirror()
+    end
     return
   end
 
-  if item:isDualWielding() ~= 1 then
-    itemWidgetMirror:setStyle(InventorySlotStyles[5])
-    itemWidgetMirror:setItem(nil)
-    itemWidgetMirror.clone = false
+  local player = g_game.getLocalPlayer()
+  local realRightItem = player and player:getInventoryItem(InventorySlotRight)
+  if realRightItem then
+    if itemWidgetMirror.clone then
+      clearMirror()
+    end
     return
   end
 
-  itemWidgetMirror:setItemId(item:getId())
+  itemWidgetMirror:setItem(item)
   itemWidgetMirror:setStyle('NoneInventoryItem')
-  itemWidgetMirror:setFlipDirection(Flip.Horizontal)
+  itemWidgetMirror:setOpacity(0.5)
+  itemWidgetMirror:setDraggable(false)
+  itemWidgetMirror:setEnabled(false)
+  itemWidgetMirror:setFlipDirection(FlipDirection.Horizontal)
   itemWidgetMirror.slot5Dual:setVisible(true)
   itemWidgetMirror:setPhantom(true)
   itemWidgetMirror.clone = true
@@ -315,6 +343,10 @@ function onInventoryChange(player, slot, item, oldItem)
     if slot == 6 then
       addEvent(function()  configureMirror() end, 100)
     elseif slot == 5 then
+      itemWidget:setOpacity(1.0)
+      itemWidget:setDraggable(true)
+      itemWidget:setEnabled(true)
+      itemWidget:setFlipDirection(FlipDirection.None)
       itemWidget.clone = false
     end
     updateFlags(item, itemWidget)
@@ -330,6 +362,10 @@ function onInventoryChange(player, slot, item, oldItem)
   end
   ItemsDatabase.setTier(itemWidget, item)
   slotValue[slot] = item
+end
+
+function onVocationChange()
+  addEvent(function() configureMirror() end, 100)
 end
 
 function SlotValue()

--- a/modules/game_inventory/inventory.lua
+++ b/modules/game_inventory/inventory.lua
@@ -313,7 +313,7 @@ function configureMirror()
   itemWidgetMirror.clone = true
 end
 
-function copyLeftHandToMirror()
+function scheduleMonkMirrorUpdate()
   local itemWidget = inventoryPanel:getChildById('slot6')
   local item = itemWidget:getItem()
   if not item then
@@ -354,7 +354,7 @@ function onInventoryChange(player, slot, item, oldItem)
     if slot == 6 then
       addEvent(function() configureMirror() end, 100)
     elseif slot == 5 then
-      copyLeftHandToMirror()
+      scheduleMonkMirrorUpdate()
     end
     itemWidget:setStyle(InventorySlotStyles[slot])
     itemWidget.quicklootflags:setVisible(false)

--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -97,6 +97,7 @@ Flip = {
   Horizontal = 1,
   Vertical = 2,
 }
+FlipDirection = Flip
 
 Skill = {
   Fist = 0,

--- a/modules/gamelib/creature.lua
+++ b/modules/gamelib/creature.lua
@@ -219,21 +219,21 @@ if not Creature.hasIcon then
 end
 
 function Creature:isDruid()
-  return self:getVocation() == 4 or self:getVocation() == 14
+  return self:getVocation() == 2 or self:getVocation() == 6 or self:getVocation() == 14
 end
 
 function Creature:isSorcerer()
-  return self:getVocation() == 3 or self:getVocation() == 13
+  return self:getVocation() == 1 or self:getVocation() == 5 or self:getVocation() == 13
 end
 
 function Creature:isPaladin()
-  return self:getVocation() == 2 or self:getVocation() == 12
+  return self:getVocation() == 3 or self:getVocation() == 7 or self:getVocation() == 12
 end
 
 function Creature:isKnight()
-  return self:getVocation() == 1 or self:getVocation() == 11
+  return self:getVocation() == 4 or self:getVocation() == 8 or self:getVocation() == 11
 end
 
 function Creature:isMonk()
-  return self:getVocation() == 5 or self:getVocation() == 15
+  return self:getVocation() == 9 or self:getVocation() == 10 or self:getVocation() == 15
 end

--- a/modules/gamelib/game.lua
+++ b/modules/gamelib/game.lua
@@ -92,15 +92,25 @@ end
 
 function g_game.getVocationName(vocationId)
   if vocationId == 1 then
-    return "Knight"
-  elseif vocationId == 2 then
-    return "Paladin"
-  elseif vocationId == 3 then
     return "Sorcerer"
-  elseif vocationId == 4 then
+  elseif vocationId == 2 then
     return "Druid"
+  elseif vocationId == 3 then
+    return "Paladin"
+  elseif vocationId == 4 then
+    return "Knight"
   elseif vocationId == 5 then
+    return "Master Sorcerer"
+  elseif vocationId == 6 then
+    return "Elder Druid"
+  elseif vocationId == 7 then
+    return "Royal Paladin"
+  elseif vocationId == 8 then
+    return "Elite Knight"
+  elseif vocationId == 9 then
     return "Monk"
+  elseif vocationId == 10 then
+    return "Exalted Monk"
   elseif vocationId == 11 then
     return "Elite Knight"
   elseif vocationId == 12 then
@@ -117,15 +127,15 @@ function g_game.getVocationName(vocationId)
 end
 
 function g_game.getVocationNameBase(vocationId)
-  if vocationId == 1 or vocationId == 11 then
-    return "Knight"
-  elseif vocationId == 2 or vocationId == 12 then
-    return "Paladin"
-  elseif vocationId == 3 or vocationId == 13 then
+  if vocationId == 1 or vocationId == 5 or vocationId == 13 then
     return "Sorcerer"
-  elseif vocationId == 4 or vocationId == 14 then
+  elseif vocationId == 2 or vocationId == 6 or vocationId == 14 then
     return "Druid"
-  elseif vocationId == 5 or vocationId == 15 then
+  elseif vocationId == 3 or vocationId == 7 or vocationId == 12 then
+    return "Paladin"
+  elseif vocationId == 4 or vocationId == 8 or vocationId == 11 then
+    return "Knight"
+  elseif vocationId == 9 or vocationId == 10 or vocationId == 15 then
     return "Monk"
   else
     return "None"

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -967,6 +967,8 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<UIItem>("isVirtual", &UIItem::isVirtual);
     g_lua.bindClassMemberFunction<UIItem>("isItemVisible", &UIItem::isItemVisible);
     g_lua.bindClassMemberFunction<UIItem>("setHash", &UIItem::setHash);
+    g_lua.bindClassMemberFunction<UIItem>("setFlipDirection", &UIItem::setFlipDirection);
+    g_lua.bindClassMemberFunction<UIItem>("getFlipDirection", &UIItem::getFlipDirection);
 
     g_lua.registerClass<UISprite, UIWidget>();
     g_lua.bindClassStaticFunction<UISprite>("create", []{ return std::make_shared<UISprite>(); });

--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -288,7 +288,7 @@ void MapView::drawMapForeground(const Rect& rect)
     }
 
     if (m_lightView) {
-        g_drawQueue->add(m_lightView.release());
+        g_drawQueue->add(std::move(m_lightView));
     }
 
     // texts

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -32,6 +32,7 @@
 #include <framework/graphics/image.h>
 #include <framework/graphics/framebuffermanager.h>
 #include <framework/graphics/shadermanager.h>
+#include <memory>
 
 Outfit::Outfit()
 {
@@ -303,8 +304,7 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
                     continue;
                 if (yPattern == 0)
                     center = outfitParams->dest.center();
-                DrawQueueItemTexturedRect* outfit = new DrawQueueItemOutfitWithShader(outfitParams->dest, outfitParams->texture, outfitParams->src, outfitParams->offset, center, 0, m_shader);
-                g_drawQueue->add(outfit);
+                g_drawQueue->add(std::make_unique<DrawQueueItemOutfitWithShader>(outfitParams->dest, outfitParams->texture, outfitParams->src, outfitParams->offset, center, 0, m_shader));
                 continue;
             }
             type->draw(dest, 0, direction, yPattern, zPattern, animationPhase, Color::white, lightView);
@@ -316,15 +316,13 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
         if (!outfitParams)
             continue;
 
-        DrawQueueItemTexturedRect* outfit = nullptr;
-        if (m_shader.empty())
-            outfit = new DrawQueueItemOutfit(outfitParams->dest, outfitParams->texture, outfitParams->src, outfitParams->offset, colors, outfitParams->color);
-        else {
+        if (m_shader.empty()) {
+            g_drawQueue->add(std::make_unique<DrawQueueItemOutfit>(outfitParams->dest, outfitParams->texture, outfitParams->src, outfitParams->offset, colors, outfitParams->color));
+        } else {
             if (yPattern == 0)
                 center = outfitParams->dest.center();
-            outfit = new DrawQueueItemOutfitWithShader(outfitParams->dest, outfitParams->texture, outfitParams->src, outfitParams->offset, center, colors, m_shader);
+            g_drawQueue->add(std::make_unique<DrawQueueItemOutfitWithShader>(outfitParams->dest, outfitParams->texture, outfitParams->src, outfitParams->offset, center, colors, m_shader));
         }
-        g_drawQueue->add(outfit);
     }
 
     if (m_wings && (direction == Otc::North || direction == Otc::West)) {

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -486,13 +486,13 @@ void DrawQueueItemOutfitWithShader::draw()
     if (useFramebuffer) {
         g_painter->drawTexturedRect(Rect(0, 0, m_src.size()), m_texture, m_src);
     } else {
-        g_painter->drawTexturedRect(m_dest, m_texture, m_src);
+        g_painter->drawTexturedRect(m_dest, m_texture, m_src, m_flipDirection);
     }
     g_painter->resetShaderProgram();
 
     if (useFramebuffer) {
         g_framebuffers.getTemporaryFrameBuffer()->release();
         g_painter->resetColor();
-        g_framebuffers.getTemporaryFrameBuffer()->draw(m_dest);
+        g_framebuffers.getTemporaryFrameBuffer()->draw(m_dest, m_flipDirection);
     }
 }

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -930,13 +930,13 @@ void DrawQueueItemThingWithShader::draw()
         g_painter->drawTexturedRect(Rect(0, 0, m_src.size()), m_texture, m_src);
     }
     else {
-        g_painter->drawTexturedRect(m_dest, m_texture, m_src);
+        g_painter->drawTexturedRect(m_dest, m_texture, m_src, m_flipDirection);
     }
     g_painter->resetShaderProgram();
 
     if (useFramebuffer) {
         g_framebuffers.getTemporaryFrameBuffer()->release();
         g_painter->resetColor();
-        g_framebuffers.getTemporaryFrameBuffer()->draw(m_dest);
+        g_framebuffers.getTemporaryFrameBuffer()->draw(m_dest, m_flipDirection);
     }
 }

--- a/src/client/thingtype.cpp
+++ b/src/client/thingtype.cpp
@@ -34,6 +34,7 @@
 #include <framework/graphics/shadermanager.h>
 #include <framework/core/filestream.h>
 #include <framework/otml/otml.h>
+#include <memory>
 
 ThingType::ThingType()
 {
@@ -675,8 +676,7 @@ void ThingType::drawWithShader(const Point& dest, int layer, int xPattern, int y
     if (lightView && hasLight())
         lightView->addLight(screenRect.center(), getLight());
 
-    DrawQueueItemTexturedRect* thing = new DrawQueueItemThingWithShader(screenRect, texture, textureRect, textureOffset, screenRect.center(), 0, shader);
-    g_drawQueue->add(thing);
+    g_drawQueue->add(std::make_unique<DrawQueueItemThingWithShader>(screenRect, texture, textureRect, textureOffset, screenRect.center(), 0, shader));
 
     //return g_drawQueue->addTexturedRect(screenRect, texture, textureRect, color);
 }
@@ -719,8 +719,7 @@ void ThingType::drawWithShader(const Rect& dest, int layer, int xPattern, int yP
     float scale = std::min<float>((float)dest.width() / size.width(), (float)dest.height() / size.height());
 
     Rect screenRect = Rect(dest.topLeft() + (textureOffset * scale), textureRect.size() * scale);
-    DrawQueueItemTexturedRect* thing = new DrawQueueItemThingWithShader(screenRect, texture, textureRect, textureOffset, screenRect.center(), 0, shader);
-    g_drawQueue->add(thing);
+    g_drawQueue->add(std::make_unique<DrawQueueItemThingWithShader>(screenRect, texture, textureRect, textureOffset, screenRect.center(), 0, shader));
 
     //return g_drawQueue->addTexturedRect(Rect(dest.topLeft() + (textureOffset * scale), textureRect.size() * scale), texture, textureRect, color);
 }

--- a/src/client/uiitem.cpp
+++ b/src/client/uiitem.cpp
@@ -23,6 +23,7 @@
 #include "uiitem.h"
 #include "spritemanager.h"
 #include "game.h"
+#include <framework/core/graphicalapplication.h>
 #include <framework/otml/otml.h>
 #include <framework/graphics/graphics.h>
 #include <framework/graphics/fontmanager.h>
@@ -58,7 +59,11 @@ void UIItem::drawSelf(Fw::DrawPane drawPane)
             return;
 
         m_item->setColor(m_itemColor);
+        const auto itemDrawQueueStart = g_drawQueue->size();
         m_item->draw(drawRect);
+        if (m_flipDirection != 0) {
+            g_drawQueue->setFlip(itemDrawQueueStart, drawRect.center(), m_flipDirection);
+        }
 
         if(m_font && m_showCount && (!m_virtualCount.empty() || m_showCountAlways || (m_item->isStackable() || m_item->isChargeable() || m_item->isQuiver()) && m_item->getCountOrSubType() > 1)) {
             g_drawQueue->addText(m_font, m_virtualCount.empty() ? m_countText : m_virtualCount, Rect(drawRect.topLeft(), drawRect.bottomRight() - Point(3, 0)), Fw::AlignBottomRight, m_color);
@@ -146,6 +151,15 @@ void UIItem::setItemShader(const std::string& str)
     }
 }
 
+void UIItem::setFlipDirection(uint8_t direction)
+{
+    if (m_flipDirection == direction)
+        return;
+
+    m_flipDirection = direction;
+    g_app.repaint();
+}
+
 void UIItem::onStyleApply(const std::string& styleName, const OTMLNodePtr& styleNode)
 {
     UIWidget::onStyleApply(styleName, styleNode);
@@ -167,6 +181,8 @@ void UIItem::onStyleApply(const std::string& styleName, const OTMLNodePtr& style
             setItemColor(node->value<Color>());
         else if(node->tag() == "item-always-show-count")
             setShowCountAlways(node->value<bool>());
+        else if(node->tag() == "flip-direction")
+            setFlipDirection(node->value<uint8_t>());
     }
 }
 

--- a/src/client/uiitem.h
+++ b/src/client/uiitem.h
@@ -46,6 +46,7 @@ public:
     void setItemShader(const std::string& str);
     void setItemColor(const Color& color) { m_itemColor = color; }
     void setHash(const std::string& hash) { if(m_item) m_item->setHash(hash); }
+    void setFlipDirection(uint8_t direction);
 
     int getItemId() { return m_item ? m_item->getId() : 0; }
     int getItemCount() { return m_item ? m_item->getCount() : 0; }
@@ -54,6 +55,7 @@ public:
     ItemPtr getItem() { return m_item; }
     bool isVirtual() { return m_virtual; }
     bool isItemVisible() { return m_itemVisible; }
+    uint8_t getFlipDirection() { return m_flipDirection; }
 
 protected:
     void onStyleApply(const std::string& styleName, const OTMLNodePtr& styleNode);
@@ -69,6 +71,7 @@ protected:
     std::string m_shader;
     std::string m_countText;
     std::string m_virtualCount;
+    uint8_t m_flipDirection = 0;
 
     ticks_t m_lastDecayUpdate;
     std::string m_decayText;

--- a/src/client/uiitem.h
+++ b/src/client/uiitem.h
@@ -55,7 +55,7 @@ public:
     ItemPtr getItem() { return m_item; }
     bool isVirtual() { return m_virtual; }
     bool isItemVisible() { return m_itemVisible; }
-    uint8_t getFlipDirection() { return m_flipDirection; }
+    uint8_t getFlipDirection() { return m_flipDirection; } // NOSONAR: Lua binder does not support const member functions.
 
 protected:
     void onStyleApply(const std::string& styleName, const OTMLNodePtr& styleNode);

--- a/src/framework/graphics/coordsbuffer.h
+++ b/src/framework/graphics/coordsbuffer.h
@@ -74,6 +74,18 @@ public:
         m_vertexArray->addQuad(dest);
         m_textureCoordArray->addQuad(src);
     }
+    void addHorizontallyFlippedQuad(const Rect& dest, const Rect& src) {
+        if (m_locked)
+            unlock();
+        m_vertexArray->addQuad(dest);
+        m_textureCoordArray->addHorizontallyFlippedQuad(src);
+    }
+    void addVerticallyFlippedQuad(const Rect& dest, const Rect& src) {
+        if (m_locked)
+            unlock();
+        m_vertexArray->addQuad(dest);
+        m_textureCoordArray->addVerticallyFlippedQuad(src);
+    }
     void addUpsideDownQuad(const Rect& dest, const Rect& src) {
         if (m_locked)
             unlock();

--- a/src/framework/graphics/drawcache.cpp
+++ b/src/framework/graphics/drawcache.cpp
@@ -41,6 +41,14 @@ void DrawCache::addTexturedRect(const Rect& dest, const Rect& src, const Color& 
     m_size += 6;
 }
 
+void DrawCache::addTexturedRect(const Rect& dest, const Rect& src, const Color& color, uint8_t flipDirection)
+{
+    addRectRaw(m_destCoord.data() + (m_size * 2), dest);
+    addFlippedRectRaw(m_srcCoord.data() + (m_size * 2), src, flipDirection);
+    addColorRaw(color, 6);
+    m_size += 6;
+}
+
 void DrawCache::addCoords(CoordsBuffer& coords, const Color& color)
 {
     int size = coords.getVertexCount();

--- a/src/framework/graphics/drawcache.h
+++ b/src/framework/graphics/drawcache.h
@@ -20,6 +20,7 @@ public:
     inline int getSize() { return m_size; }
     void addRect(const Rect& dest, const Color& color);
     void addTexturedRect(const Rect& dest, const Rect& src, const Color& color);
+    void addTexturedRect(const Rect& dest, const Rect& src, const Color& color, uint8_t flipDirection);
     void addCoords(CoordsBuffer& coords, const Color& color);
     void addTexturedCoords(CoordsBuffer& coords, const Point& offset, const Color& color);
 
@@ -30,6 +31,40 @@ private:
         dest[1] = dest[3] = dest[9] = rect.top();
         dest[2] = dest[8] = dest[10] = rect.right() + 1;
         dest[5] = dest[7] = dest[11] = rect.bottom() + 1;
+    }
+    inline void addFlippedRectRaw(float* dest, const Rect& rect, uint8_t flipDirection)
+    {
+        if (flipDirection == 1) {
+            const float top = rect.top();
+            const float right = rect.right() + 1;
+            const float bottom = rect.bottom() + 1;
+            const float left = rect.left();
+
+            dest[0] = right; dest[1] = top;
+            dest[2] = left; dest[3] = top;
+            dest[4] = right; dest[5] = bottom;
+            dest[6] = right; dest[7] = bottom;
+            dest[8] = left; dest[9] = top;
+            dest[10] = left; dest[11] = bottom;
+            return;
+        }
+
+        if (flipDirection == 2) {
+            const float top = rect.top();
+            const float right = rect.right() + 1;
+            const float bottom = rect.bottom() + 1;
+            const float left = rect.left();
+
+            dest[0] = left; dest[1] = bottom;
+            dest[2] = right; dest[3] = bottom;
+            dest[4] = left; dest[5] = top;
+            dest[6] = left; dest[7] = top;
+            dest[8] = right; dest[9] = bottom;
+            dest[10] = right; dest[11] = top;
+            return;
+        }
+
+        addRectRaw(dest, rect);
     }
     inline void addColorRaw(const Color& color, int count)
     {

--- a/src/framework/graphics/drawqueue.cpp
+++ b/src/framework/graphics/drawqueue.cpp
@@ -13,23 +13,38 @@
 
 std::shared_ptr<DrawQueue> g_drawQueue;
 
+namespace {
+
+bool beginFlip(uint8_t direction, const Point& center)
+{
+    if (direction == 0 || direction > 2)
+        return false;
+
+    g_painter->pushTransformMatrix();
+    g_painter->translate(-center.x, -center.y);
+    if (direction == 1) {
+        g_painter->scale(-1.f, 1.f);
+    } else if (direction == 2) {
+        g_painter->scale(1.f, -1.f);
+    }
+    g_painter->translate(center);
+    return true;
+}
+
+void endFlip(bool flipped)
+{
+    if (flipped)
+        g_painter->popTransformMatrix();
+}
+
+}
+
 void DrawQueueItemTextureCoords::draw()
 {
     g_painter->setColor(m_color);
-    if (m_flipDirection != 0) {
-        g_painter->pushTransformMatrix();
-        g_painter->translate(-m_flipCenter.x, -m_flipCenter.y);
-        if (m_flipDirection == 1) {
-            g_painter->scale(-1.f, 1.f);
-        } else if (m_flipDirection == 2) {
-            g_painter->scale(1.f, -1.f);
-        }
-        g_painter->translate(m_flipCenter);
-    }
+    const auto flipped = beginFlip(m_flipDirection, m_flipCenter);
     g_painter->drawTextureCoords(m_coordsBuffer, m_texture);
-    if (m_flipDirection != 0) {
-        g_painter->popTransformMatrix();
-    }
+    endFlip(flipped);
 }
 
 bool DrawQueueItemTextureCoords::cache()
@@ -63,20 +78,9 @@ void DrawQueueItemTextureCoords::draw(const Point& pos)
 
 void DrawQueueItemColoredTextureCoords::draw()
 {
-    if (m_flipDirection != 0) {
-        g_painter->pushTransformMatrix();
-        g_painter->translate(-m_flipCenter.x, -m_flipCenter.y);
-        if (m_flipDirection == 1) {
-            g_painter->scale(-1.f, 1.f);
-        } else if (m_flipDirection == 2) {
-            g_painter->scale(1.f, -1.f);
-        }
-        g_painter->translate(m_flipCenter);
-    }
+    const auto flipped = beginFlip(m_flipDirection, m_flipCenter);
     g_painter->drawTextureCoords(m_coordsBuffer, m_texture, &m_colors);
-    if (m_flipDirection != 0) {
-        g_painter->popTransformMatrix();
-    }
+    endFlip(flipped);
 }
 
 void DrawQueueItemImageWithShader::draw()
@@ -88,20 +92,9 @@ void DrawQueueItemImageWithShader::draw()
     g_painter->setShaderProgram(shader);
     shader->bindMultiTextures();
     g_painter->setColor(m_color);
-    if (m_flipDirection != 0) {
-        g_painter->pushTransformMatrix();
-        g_painter->translate(-m_flipCenter.x, -m_flipCenter.y);
-        if (m_flipDirection == 1) {
-            g_painter->scale(-1.f, 1.f);
-        } else if (m_flipDirection == 2) {
-            g_painter->scale(1.f, -1.f);
-        }
-        g_painter->translate(m_flipCenter);
-    }
+    const auto flipped = beginFlip(m_flipDirection, m_flipCenter);
     g_painter->drawTextureCoords(m_coordsBuffer, m_texture);
-    if (m_flipDirection != 0) {
-        g_painter->popTransformMatrix();
-    }
+    endFlip(flipped);
     g_painter->resetShaderProgram();
 }
 
@@ -230,7 +223,7 @@ void DrawQueueConditionMark::end(DrawQueue* queue)
     g_painter->setDrawColorOnTextureShaderProgram();
     g_painter->setColor(m_color);
     for (size_t i = m_start; i < m_end; ++i) {
-        DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(queue->m_queue[i].get());
+        auto* texture = dynamic_cast<DrawQueueItemTexturedRect*>(queue->m_queue[i].get());
         if (texture)
             g_painter->drawTexturedRect(texture->m_dest, texture->m_texture, texture->m_src, texture->m_flipDirection);
     }
@@ -275,7 +268,7 @@ void DrawQueue::correctOutfit(const Rect& dest, int fromPos, bool oldScaling, bo
         int centerX = 0;
         int centerY = 0;
         for (size_t i = fromPos; i < m_queue.size(); ++i) {
-            if (DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i].get())) {
+            if (auto* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i].get())) {
                 rects.push_back(&texture->m_dest);
 
                 if (center) {
@@ -294,7 +287,7 @@ void DrawQueue::correctOutfit(const Rect& dest, int fromPos, bool oldScaling, bo
     }
     else {
         for (size_t i = fromPos; i < m_queue.size(); ++i) {
-            if (DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i].get()))
+            if (auto* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i].get()))
                 rects.push_back(&texture->m_dest);
         }
 
@@ -325,7 +318,7 @@ void DrawQueue::draw(DrawType drawType)
         start = mapPosition;
     }
 
-    std::sort(m_conditions.begin(), m_conditions.end(), [](const auto& a, const auto& b) -> bool {
+    std::sort(m_conditions.begin(), m_conditions.end(), [](const auto& a, const auto& b) -> bool { // NOSONAR: project is C++17.
         return a->m_start == b->m_start ? a->m_end < b->m_end : a->m_start < b->m_start;
     });
 

--- a/src/framework/graphics/drawqueue.cpp
+++ b/src/framework/graphics/drawqueue.cpp
@@ -16,11 +16,27 @@ std::shared_ptr<DrawQueue> g_drawQueue;
 void DrawQueueItemTextureCoords::draw()
 {
     g_painter->setColor(m_color);
+    if (m_flipDirection != 0) {
+        g_painter->pushTransformMatrix();
+        g_painter->translate(-m_flipCenter.x, -m_flipCenter.y);
+        if (m_flipDirection == 1) {
+            g_painter->scale(-1.f, 1.f);
+        } else if (m_flipDirection == 2) {
+            g_painter->scale(1.f, -1.f);
+        }
+        g_painter->translate(m_flipCenter);
+    }
     g_painter->drawTextureCoords(m_coordsBuffer, m_texture);
+    if (m_flipDirection != 0) {
+        g_painter->popTransformMatrix();
+    }
 }
 
 bool DrawQueueItemTextureCoords::cache()
 {
+    if (m_flipDirection != 0)
+        return false;
+
     if (!m_texture->canCache())
         return false;
     m_texture->update();
@@ -42,12 +58,25 @@ bool DrawQueueItemTextureCoords::cache()
 void DrawQueueItemTextureCoords::draw(const Point& pos)
 {
     g_painter->resetColor();
-    g_painter->drawTexturedRect(Rect(pos, m_texture->getSize()), m_texture);
+    g_painter->drawTexturedRect(Rect(pos, m_texture->getSize()), m_texture, Rect(Point(0, 0), m_texture->getSize()), m_flipDirection);
 }
 
 void DrawQueueItemColoredTextureCoords::draw()
 {
+    if (m_flipDirection != 0) {
+        g_painter->pushTransformMatrix();
+        g_painter->translate(-m_flipCenter.x, -m_flipCenter.y);
+        if (m_flipDirection == 1) {
+            g_painter->scale(-1.f, 1.f);
+        } else if (m_flipDirection == 2) {
+            g_painter->scale(1.f, -1.f);
+        }
+        g_painter->translate(m_flipCenter);
+    }
     g_painter->drawTextureCoords(m_coordsBuffer, m_texture, &m_colors);
+    if (m_flipDirection != 0) {
+        g_painter->popTransformMatrix();
+    }
 }
 
 void DrawQueueItemImageWithShader::draw()
@@ -59,7 +88,20 @@ void DrawQueueItemImageWithShader::draw()
     g_painter->setShaderProgram(shader);
     shader->bindMultiTextures();
     g_painter->setColor(m_color);
+    if (m_flipDirection != 0) {
+        g_painter->pushTransformMatrix();
+        g_painter->translate(-m_flipCenter.x, -m_flipCenter.y);
+        if (m_flipDirection == 1) {
+            g_painter->scale(-1.f, 1.f);
+        } else if (m_flipDirection == 2) {
+            g_painter->scale(1.f, -1.f);
+        }
+        g_painter->translate(m_flipCenter);
+    }
     g_painter->drawTextureCoords(m_coordsBuffer, m_texture);
+    if (m_flipDirection != 0) {
+        g_painter->popTransformMatrix();
+    }
     g_painter->resetShaderProgram();
 }
 
@@ -72,7 +114,7 @@ void DrawQueueItemImageWithShader::draw(const Point& pos)
     g_painter->setShaderProgram(shader);
     shader->bindMultiTextures();
     g_painter->resetColor();
-    g_painter->drawTexturedRect(Rect(pos, m_texture->getSize()), m_texture);
+    g_painter->drawTexturedRect(Rect(pos, m_texture->getSize()), m_texture, Rect(Point(0, 0), m_texture->getSize()), m_flipDirection);
     g_painter->resetShaderProgram();
 }
 
@@ -106,7 +148,7 @@ bool DrawQueueItemTexturedRect::cache()
 void DrawQueueItemTexturedRect::draw(const Point& pos)
 {
     g_painter->resetColor();
-    g_painter->drawTexturedRect(Rect(pos, m_texture->getSize()), m_texture);
+    g_painter->drawTexturedRect(Rect(pos, m_texture->getSize()), m_texture, Rect(Point(0, 0), m_texture->getSize()), m_flipDirection);
 }
 
 
@@ -188,9 +230,9 @@ void DrawQueueConditionMark::end(DrawQueue* queue)
     g_painter->setDrawColorOnTextureShaderProgram();
     g_painter->setColor(m_color);
     for (size_t i = m_start; i < m_end; ++i) {
-        DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(queue->m_queue[i]);
+        DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(queue->m_queue[i].get());
         if (texture)
-            g_painter->drawTexturedRect(texture->m_dest, texture->m_texture, texture->m_src);
+            g_painter->drawTexturedRect(texture->m_dest, texture->m_texture, texture->m_src, texture->m_flipDirection);
     }
     g_painter->resetShaderProgram();
 }
@@ -216,14 +258,14 @@ void DrawQueue::addText(BitmapFontPtr font, const std::string& text, const Rect&
 {
     if (!font || text.empty()) return;
     uint64_t hash = g_text.addText(font, text, screenCoords.size(), align);
-    m_queue.push_back(new DrawQueueItemText(screenCoords.topLeft(), font->getTexture(), hash, color, shadow));
+    m_queue.push_back(std::make_unique<DrawQueueItemText>(screenCoords.topLeft(), font->getTexture(), hash, color, shadow));
 }
 
 void DrawQueue::addColoredText(BitmapFontPtr font, const std::string& text, const Rect& screenCoords, Fw::AlignmentFlag align, const std::vector<std::pair<int, Color>>& colors, bool shadow)
 {
     if (!font || text.empty()) return;
     uint64_t hash = g_text.addText(font, text, screenCoords.size(), align);
-    m_queue.push_back(new DrawQueueItemTextColored(screenCoords.topLeft(), font->getTexture(), hash, colors, shadow));
+    m_queue.push_back(std::make_unique<DrawQueueItemTextColored>(screenCoords.topLeft(), font->getTexture(), hash, colors, shadow));
 }
 
 void DrawQueue::correctOutfit(const Rect& dest, int fromPos, bool oldScaling, bool center)
@@ -233,7 +275,7 @@ void DrawQueue::correctOutfit(const Rect& dest, int fromPos, bool oldScaling, bo
         int centerX = 0;
         int centerY = 0;
         for (size_t i = fromPos; i < m_queue.size(); ++i) {
-            if (DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i])) {
+            if (DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i].get())) {
                 rects.push_back(&texture->m_dest);
 
                 if (center) {
@@ -252,7 +294,7 @@ void DrawQueue::correctOutfit(const Rect& dest, int fromPos, bool oldScaling, bo
     }
     else {
         for (size_t i = fromPos; i < m_queue.size(); ++i) {
-            if (DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i]))
+            if (DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i].get()))
                 rects.push_back(&texture->m_dest);
         }
 
@@ -283,7 +325,7 @@ void DrawQueue::draw(DrawType drawType)
         start = mapPosition;
     }
 
-    std::sort(m_conditions.begin(), m_conditions.end(), [](const DrawQueueCondition* a, const DrawQueueCondition* b) -> bool {
+    std::sort(m_conditions.begin(), m_conditions.end(), [](const auto& a, const auto& b) -> bool {
         return a->m_start == b->m_start ? a->m_end < b->m_end : a->m_start < b->m_start;
     });
 
@@ -313,7 +355,7 @@ void DrawQueue::draw(DrawType drawType)
         while (condition != m_conditions.end() && (*condition)->m_start <= i) {
             g_drawCache.draw();
             (*condition)->start(this);
-            activeConditions.push(*condition);
+            activeConditions.push(condition->get());
             ++condition;
         }
 

--- a/src/framework/graphics/drawqueue.cpp
+++ b/src/framework/graphics/drawqueue.cpp
@@ -79,7 +79,7 @@ void DrawQueueItemImageWithShader::draw(const Point& pos)
 void DrawQueueItemTexturedRect::draw()
 {
     g_painter->setColor(m_color);
-    g_painter->drawTexturedRect(m_dest, m_texture, m_src);
+    g_painter->drawTexturedRect(m_dest, m_texture, m_src, m_flipDirection);
 }
 
 bool DrawQueueItemTexturedRect::cache()
@@ -99,7 +99,7 @@ bool DrawQueueItemTexturedRect::cache()
     if (!g_drawCache.hasSpace(6))
         return false;
 
-    g_drawCache.addTexturedRect(m_dest, m_src + atlasPos, m_color);
+    g_drawCache.addTexturedRect(m_dest, m_src + atlasPos, m_color, m_flipDirection);
     return true;
 }
 

--- a/src/framework/graphics/drawqueue.h
+++ b/src/framework/graphics/drawqueue.h
@@ -40,9 +40,12 @@ struct DrawQueueItemTexturedRect : public DrawQueueItem {
     virtual void draw();
     virtual void draw(const Point& pos);
     virtual bool cache();
+    void setFlipDirection(uint8_t direction) { m_flipDirection = direction; }
+    uint8_t getFlipDirection() const { return m_flipDirection; }
 
     Rect m_dest;
     Rect m_src;
+    uint8_t m_flipDirection = 0;
 };
 
 struct DrawQueueItemTextureCoords : public DrawQueueItem {
@@ -303,6 +306,17 @@ public:
     {
         if (start == m_queue.size() || angle == 0) return;
         m_conditions.push_back(new DrawQueueConditionRotation(start, m_queue.size(), center, angle));
+    }
+
+    void setFlip(size_t start, const Point& center, uint8_t direction)
+    {
+        (void)center;
+        if (start == m_queue.size()) return;
+        for (size_t i = start; i < m_queue.size(); ++i) {
+            if (auto textured = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i])) {
+                textured->setFlipDirection(direction);
+            }
+        }
     }
 
     void setMark(size_t start, const Color& color)

--- a/src/framework/graphics/drawqueue.h
+++ b/src/framework/graphics/drawqueue.h
@@ -27,7 +27,10 @@ struct DrawQueueItem {
     virtual void draw() {}
     virtual void draw(const Point& pos) {}
     virtual bool cache() { return false; }
-    virtual void setFlipDirection(uint8_t, const Point&) {}
+    virtual void setFlipDirection(uint8_t, const Point&)
+    {
+        // Non-textured queue items do not own texture coordinates to flip.
+    }
 
     TexturePtr m_texture;
     Color m_color;
@@ -42,7 +45,15 @@ struct DrawQueueItemTexturedRect : public DrawQueueItem {
     virtual void draw();
     virtual void draw(const Point& pos);
     virtual bool cache();
-    void setFlipDirection(uint8_t direction, const Point&) override { m_flipDirection = direction; }
+    void setFlipDirection(uint8_t direction, const Point& center) override
+    {
+        m_flipDirection = direction;
+        if (direction == 1) {
+            m_dest.moveLeft(2 * center.x - m_dest.right() + 1);
+        } else if (direction == 2) {
+            m_dest.moveTop(2 * center.y - m_dest.bottom() + 1);
+        }
+    }
     uint8_t getFlipDirection() const { return m_flipDirection; }
 
     Rect m_dest;

--- a/src/framework/graphics/drawqueue.h
+++ b/src/framework/graphics/drawqueue.h
@@ -1,6 +1,7 @@
 #ifndef DRAWQUEUE_H
 #define DRAWQUEUE_H
 
+#include <memory>
 #include <vector>
 #include <framework/graphics/declarations.h>
 #include <framework/graphics/coordsbuffer.h>
@@ -26,6 +27,7 @@ struct DrawQueueItem {
     virtual void draw() {}
     virtual void draw(const Point& pos) {}
     virtual bool cache() { return false; }
+    virtual void setFlipDirection(uint8_t, const Point&) {}
 
     TexturePtr m_texture;
     Color m_color;
@@ -40,7 +42,7 @@ struct DrawQueueItemTexturedRect : public DrawQueueItem {
     virtual void draw();
     virtual void draw(const Point& pos);
     virtual bool cache();
-    void setFlipDirection(uint8_t direction) { m_flipDirection = direction; }
+    void setFlipDirection(uint8_t direction, const Point&) override { m_flipDirection = direction; }
     uint8_t getFlipDirection() const { return m_flipDirection; }
 
     Rect m_dest;
@@ -56,8 +58,15 @@ struct DrawQueueItemTextureCoords : public DrawQueueItem {
     void draw();
     void draw(const Point& pos);
     bool cache();
+    void setFlipDirection(uint8_t direction, const Point& center) override
+    {
+        m_flipDirection = direction;
+        m_flipCenter = center;
+    }
 
     CoordsBuffer m_coordsBuffer;
+    uint8_t m_flipDirection = 0;
+    Point m_flipCenter;
 };
 
 struct DrawQueueItemColoredTextureCoords : public DrawQueueItem {
@@ -66,9 +75,20 @@ struct DrawQueueItemColoredTextureCoords : public DrawQueueItem {
     {};
 
     void draw();
+    bool cache() override
+    {
+        return false;
+    }
+    void setFlipDirection(uint8_t direction, const Point& center) override
+    {
+        m_flipDirection = direction;
+        m_flipCenter = center;
+    }
 
     CoordsBuffer m_coordsBuffer;
     std::vector<std::pair<int, Color>> m_colors;
+    uint8_t m_flipDirection = 0;
+    Point m_flipCenter;
 };
 
 struct DrawQueueItemImageWithShader : public DrawQueueItemTextureCoords {
@@ -194,47 +214,41 @@ public:
     DrawQueue() = default;
     DrawQueue(const DrawQueue&) = delete;
     DrawQueue& operator= (const DrawQueue&) = delete;
-    ~DrawQueue() {
-        for (auto& item : m_queue)
-            delete item;
-        m_queue.clear();
-        for (auto& condition : m_conditions)
-            delete condition;
-        m_conditions.clear();
-    }
+    ~DrawQueue() = default;
 
     void draw(DrawType drawType = DRAW_ALL);
 
-    void add(DrawQueueItem* item)
+    void add(std::unique_ptr<DrawQueueItem> item)
     {
         if (!item) return;
-        m_queue.push_back(item);
+        m_queue.push_back(std::move(item));
     }
     DrawQueueItemTexturedRect* addTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, const Color& color = Color::white)
     {
-        DrawQueueItemTexturedRect* item(new DrawQueueItemTexturedRect(dest, texture, src, color));
-        m_queue.push_back(item);
-        return item;
+        auto item = std::make_unique<DrawQueueItemTexturedRect>(dest, texture, src, color);
+        auto* itemPtr = item.get();
+        m_queue.push_back(std::move(item));
+        return itemPtr;
     }
     void addTextureCoords(CoordsBuffer& coords, const TexturePtr& texture, const Color& color = Color::white)
     {
-        m_queue.push_back(new DrawQueueItemTextureCoords(coords, texture, color));
+        m_queue.push_back(std::make_unique<DrawQueueItemTextureCoords>(coords, texture, color));
     }
     void addColoredTextureCoords(CoordsBuffer& coords, const TexturePtr& texture, const std::vector<std::pair<int, Color>>& colors)
     {
-        m_queue.push_back(new DrawQueueItemColoredTextureCoords(coords, texture, colors));
+        m_queue.push_back(std::make_unique<DrawQueueItemColoredTextureCoords>(coords, texture, colors));
     }
     void addFilledRect(const Rect& dest, const Color& color = Color::white)
     {
-        m_queue.push_back(new DrawQueueItemFilledRect(dest, color));
+        m_queue.push_back(std::make_unique<DrawQueueItemFilledRect>(dest, color));
     }
     void addFillCoords(CoordsBuffer& coords, const Color& color = Color::white)
     {
-        m_queue.push_back(new DrawQueueItemFillCoords(coords, color));
+        m_queue.push_back(std::make_unique<DrawQueueItemFillCoords>(coords, color));
     }
     void addClearRect(const Rect& dest, const Color& color = Color::white)
     {
-        m_queue.push_back(new DrawQueueItemClearRect(dest, color));
+        m_queue.push_back(std::make_unique<DrawQueueItemClearRect>(dest, color));
     }
     void addText(BitmapFontPtr font, const std::string& text, const Rect& screenCoords, Fw::AlignmentFlag align = Fw::AlignTopLeft, const Color& color = Color::white, bool shadow = false);
     void addColoredText(BitmapFontPtr font, const std::string& text, const Rect& screenCoords, Fw::AlignmentFlag align, const std::vector<std::pair<int, Color>>& colors, bool shadow = false);
@@ -263,7 +277,7 @@ public:
         if (points.empty() || width < 0)
             return;
 
-        m_queue.push_back(new DrawQueueItemLine(points, width, color));
+        m_queue.push_back(std::make_unique<DrawQueueItemLine>(points, width, color));
     }
 
     void setFrameBuffer(const Rect& dest, const Size& size, const Rect& src);
@@ -299,30 +313,27 @@ public:
     void setClip(size_t start, const Rect& clip)
     {
         if (start == m_queue.size()) return;
-        m_conditions.push_back(new DrawQueueConditionClip(start, m_queue.size(), clip));
+        m_conditions.push_back(std::make_unique<DrawQueueConditionClip>(start, m_queue.size(), clip));
     }
 
     void setRotation(size_t start, const Point& center, float angle)
     {
         if (start == m_queue.size() || angle == 0) return;
-        m_conditions.push_back(new DrawQueueConditionRotation(start, m_queue.size(), center, angle));
+        m_conditions.push_back(std::make_unique<DrawQueueConditionRotation>(start, m_queue.size(), center, angle));
     }
 
     void setFlip(size_t start, const Point& center, uint8_t direction)
     {
-        (void)center;
         if (start == m_queue.size()) return;
         for (size_t i = start; i < m_queue.size(); ++i) {
-            if (auto textured = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i])) {
-                textured->setFlipDirection(direction);
-            }
+            m_queue[i]->setFlipDirection(direction, center);
         }
     }
 
     void setMark(size_t start, const Color& color)
     {
         if (start == m_queue.size()) return;
-        m_conditions.push_back(new DrawQueueConditionMark(start, m_queue.size(), color));
+        m_conditions.push_back(std::make_unique<DrawQueueConditionMark>(start, m_queue.size(), color));
     }
 
     void markMapPosition()
@@ -352,8 +363,8 @@ public:
     }
 
 private:
-    std::vector<DrawQueueItem*> m_queue;
-    std::vector<DrawQueueCondition*> m_conditions;
+    std::vector<std::unique_ptr<DrawQueueItem>> m_queue;
+    std::vector<std::unique_ptr<DrawQueueCondition>> m_conditions;
     Size m_frameBufferSize;
     Rect m_frameBufferDest, m_frameBufferSrc;
     size_t mapPosition = 0;

--- a/src/framework/graphics/framebuffer.cpp
+++ b/src/framework/graphics/framebuffer.cpp
@@ -146,9 +146,19 @@ void FrameBuffer::draw(const Rect& dest, const Rect& src)
     g_painter->drawTexturedRect(dest, m_texture, src);
 }
 
+void FrameBuffer::draw(const Rect& dest, const Rect& src, uint8_t flipDirection)
+{
+    g_painter->drawTexturedRect(dest, m_texture, src, flipDirection);
+}
+
 void FrameBuffer::draw(const Rect& dest)
 {
     g_painter->drawTexturedRect(dest, m_texture, Rect(0, 0, getSize()));
+}
+
+void FrameBuffer::draw(const Rect& dest, uint8_t flipDirection)
+{
+    g_painter->drawTexturedRect(dest, m_texture, Rect(0, 0, getSize()), flipDirection);
 }
 
 std::vector<uint32_t> FrameBuffer::readPixels()

--- a/src/framework/graphics/framebuffer.h
+++ b/src/framework/graphics/framebuffer.h
@@ -42,7 +42,9 @@ public:
     void release();
     void draw();
     void draw(const Rect& dest);
+    void draw(const Rect& dest, uint8_t flipDirection);
     void draw(const Rect& dest, const Rect& src);
+    void draw(const Rect& dest, const Rect& src, uint8_t flipDirection);
 
     void setSmooth(bool enabled);
 

--- a/src/framework/graphics/painter.cpp
+++ b/src/framework/graphics/painter.cpp
@@ -571,6 +571,30 @@ void Painter::drawTexturedRect(const Rect& dest, const TexturePtr& texture, cons
     drawCoords(m_coordsBuffer, TriangleStrip);
 }
 
+void Painter::drawTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, uint8_t flipDirection)
+{
+    if (flipDirection == 0) {
+        drawTexturedRect(dest, texture, src);
+        return;
+    }
+
+    if (dest.isEmpty() || src.isEmpty() || texture->isEmpty())
+        return;
+
+    setDrawProgram(m_shaderProgram ? m_shaderProgram : m_drawTexturedProgram.get());
+    setTexture(texture);
+
+    m_coordsBuffer.clear();
+    if (flipDirection == 1) {
+        m_coordsBuffer.addHorizontallyFlippedQuad(dest, src);
+    } else if (flipDirection == 2) {
+        m_coordsBuffer.addVerticallyFlippedQuad(dest, src);
+    } else {
+        m_coordsBuffer.addQuad(dest, src);
+    }
+    drawCoords(m_coordsBuffer, TriangleStrip);
+}
+
 void Painter::drawColorOnTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src)
 {
     if (dest.isEmpty() || src.isEmpty() || texture->isEmpty())

--- a/src/framework/graphics/painter.h
+++ b/src/framework/graphics/painter.h
@@ -137,6 +137,7 @@ public:
     void drawFillCoords(CoordsBuffer& coordsBuffer);
     void drawTextureCoords(CoordsBuffer& coordsBuffer, const TexturePtr& texture, const std::vector<std::pair<int, Color>>* colors = nullptr);
     void drawTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src);
+    void drawTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src, uint8_t flipDirection);
     inline void drawTexturedRect(const Rect& dest, const TexturePtr& texture) { drawTexturedRect(dest, texture, Rect(Point(0, 0), texture->getSize())); }
     void drawColorOnTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src);
     void drawUpsideDownTexturedRect(const Rect& dest, const TexturePtr& texture, const Rect& src);

--- a/src/framework/graphics/vertexarray.h
+++ b/src/framework/graphics/vertexarray.h
@@ -34,12 +34,15 @@ class VertexArray
         CACHE_MIN_VERTICES_COUNT = 48
     };
 public:
-    VertexArray() {}
-    ~VertexArray() = default;
-    VertexArray(VertexArray& c) : m_buffer(c.m_buffer)
+    VertexArray() = default;
+    ~VertexArray()
+    {
+        m_hardwareBuffer.reset();
+    }
+    VertexArray(const VertexArray& c) : m_buffer(c.m_buffer)
     {
     }
-    VertexArray& operator=(VertexArray& c) = delete;
+    VertexArray& operator=(const VertexArray&) = delete;
 
     inline void addVertex(float x, float y) { m_buffer << x << y; }
     inline void addTriangle(const Point& a, const Point& b, const Point& c) {
@@ -118,10 +121,10 @@ public:
         float bottom = rect.bottom()+1;
         float left = rect.left();
 
-        addVertex(left, bottom);
         addVertex(right, bottom);
-        addVertex(left, top);
+        addVertex(left, bottom);
         addVertex(right, top);
+        addVertex(left, top);
     }
 
     void clear() { m_buffer.reset(); }

--- a/src/framework/graphics/vertexarray.h
+++ b/src/framework/graphics/vertexarray.h
@@ -26,6 +26,7 @@
 #include "declarations.h"
 #include "hardwarebuffer.h"
 #include <framework/util/databuffer.h>
+#include <memory>
 
 class VertexArray
 {
@@ -34,14 +35,9 @@ class VertexArray
     };
 public:
     VertexArray() {}
-    ~VertexArray()
-    {
-        if (m_hardwareBuffer)
-            delete m_hardwareBuffer;
-    }
+    ~VertexArray() = default;
     VertexArray(VertexArray& c) : m_buffer(c.m_buffer)
     {
-        m_hardwareBuffer = nullptr;
     }
     VertexArray& operator=(VertexArray& c) = delete;
 
@@ -138,16 +134,16 @@ public:
     {
         if (m_buffer.size() < CACHE_MIN_VERTICES_COUNT) return;
         if (m_hardwareBuffer) return;
-        m_hardwareBuffer = new HardwareBuffer(HardwareBuffer::VertexBuffer);
+        m_hardwareBuffer = std::make_unique<HardwareBuffer>(HardwareBuffer::VertexBuffer);
         m_hardwareBuffer->bind();
         m_hardwareBuffer->write((void*)m_buffer.data(), m_buffer.size() * sizeof(float), HardwareBuffer::StaticDraw);
     }
     bool isCached() { return m_hardwareBuffer != nullptr; }
-    HardwareBuffer* getHardwareCache() { return m_hardwareBuffer; }
+    HardwareBuffer* getHardwareCache() { return m_hardwareBuffer.get(); }
 
 private:
     DataBuffer<float> m_buffer;
-    HardwareBuffer* m_hardwareBuffer = nullptr;
+    std::unique_ptr<HardwareBuffer> m_hardwareBuffer;
 };
 
 #endif

--- a/src/framework/graphics/vertexarray.h
+++ b/src/framework/graphics/vertexarray.h
@@ -92,6 +92,30 @@ public:
         addVertex(right, bottom);
     }
 
+    inline void addHorizontallyFlippedQuad(const Rect& rect) {
+        float top = rect.top();
+        float right = rect.right()+1;
+        float bottom = rect.bottom()+1;
+        float left = rect.left();
+
+        addVertex(right, top);
+        addVertex(left, top);
+        addVertex(right, bottom);
+        addVertex(left, bottom);
+    }
+
+    inline void addVerticallyFlippedQuad(const Rect& rect) {
+        float top = rect.top();
+        float right = rect.right()+1;
+        float bottom = rect.bottom()+1;
+        float left = rect.left();
+
+        addVertex(left, bottom);
+        addVertex(right, bottom);
+        addVertex(left, top);
+        addVertex(right, top);
+    }
+
     inline void addUpsideDownQuad(const Rect& rect) {
         float top = rect.top();
         float right = rect.right()+1;

--- a/src/framework/ui/uiwidgetimage.cpp
+++ b/src/framework/ui/uiwidgetimage.cpp
@@ -27,6 +27,7 @@
 #include <framework/graphics/texturemanager.h>
 #include <framework/graphics/graphics.h>
 #include <framework/util/crypt.h>
+#include <memory>
 
 void UIWidget::initImage()
 {
@@ -179,8 +180,7 @@ void UIWidget::drawImage(const Rect& screenCoords)
 
     m_imageTexture->setSmooth(m_imageSmooth);
     if (!m_shader.empty()) {
-        DrawQueueItemTextureCoords* thing = new DrawQueueItemImageWithShader(m_imageCoordsBuffer, m_imageTexture, m_imageColor, m_shader);
-        g_drawQueue->add(thing);
+        g_drawQueue->add(std::make_unique<DrawQueueItemImageWithShader>(m_imageCoordsBuffer, m_imageTexture, m_imageColor, m_shader));
     }
     else {
         g_drawQueue->addTextureCoords(m_imageCoordsBuffer, m_imageTexture, m_imageColor);


### PR DESCRIPTION
## What changed

- Keeps Store coin balance state synchronized before rendering the footer and gifting checks.
- Updates Store gifting to use the synchronized transfer balance instead of direct stale reads.
- Adds native `UIItem` flip support and mirrored texture-coordinate rendering paths.
- Makes the Monk inventory mirror follow the upstream behavior: when a Monk has an item in the left hand and the right hand is empty, the right slot shows a disabled, semi-transparent, horizontally mirrored visual copy.
- Aligns Astra vocation helpers with the active server vocation IDs, including Monk `9/10`.

## Why

The Store footer could show stale/zero coin balances even when purchases worked, and the Monk mirror from opentibiabr/otclient#1542 did not behave correctly in Astra because the local inventory logic still depended on item `dualWield` state and the render path lacked real UIItem flip support.

## Validation

- Ran `git diff --check` for the changed code paths.
- Verified the PR diff against `Mateuzkl/AstraClient:main` includes only the intended code changes.
- Full local MSVC build was not run from this shell because `msbuild`/`cl` are not available in PATH here; Visual Studio previously reached link stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Monk vocation with distinct progression tiers.
  * Implemented item flip/mirror rendering for enhanced visual customization.

* **Bug Fixes**
  * Enhanced validation for coin transfer operations to prevent insufficient balance transfers.

* **Refactor**
  * Optimized internal memory management and rendering pipeline for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->