### PR TITLE
[codex] Add right-click NPC talk option

### DIFF
--- a/data/default-config.otml
+++ b/data/default-config.otml
@@ -123,6 +123,7 @@ layout: default
 hidePlayerBars: false
 walkTeleportDelay: 200
 autoChaseOverride: true
+talkOnRightClick: false
 displayHealthOnTop: false
 displayHealth: true
 ctrlDragCheckBox: false

--- a/mods/client_settings/classes/dataset.lua
+++ b/mods/client_settings/classes/dataset.lua
@@ -481,6 +481,10 @@ return {
 		value = true,
 	},
 
+	talkOnRightClick = {
+		value = false,
+	},
+
 	stayLoggedInforSession = {
 		value = false,
 	},

--- a/mods/client_settings/options/gameplay.otui
+++ b/mods/client_settings/options/gameplay.otui
@@ -80,6 +80,39 @@ GameplayWindow < Panel
     margin-right: 4
 
     SettingsCheckBox
+      id: talkOnRightClick
+      size: 12 12
+      !text: tr('Right-click talk to NPC')
+      font: $var-cip-font
+      text-auto-resize: true
+      color: $var-text-cip-color
+      text-offset: 14 -2
+      anchors.left: parent.left
+      anchors.top: parent.top
+      margin-top: 5
+      margin-left: 4
+      image-source: /images/ui/checkbox
+      image-clip: 0 0 12 12
+
+    UIWidget
+      size: 12 12
+      anchors.top: parent.top
+      anchors.right: parent.right
+      margin-right: 5
+      margin-top: 5
+      image-source: /images/skin/show-gui-help-grey
+      !tooltip: tr('When enabled, right-clicking an NPC nearby says "hi" instead of using the regular mouse action.')
+
+  FlatPanel
+    size: 505 22
+    anchors.top: prev.bottom
+    anchors.right: parent.right
+    anchors.left: parent.left
+    margin-top: 5
+    margin-left: 4
+    margin-right: 4
+
+    SettingsCheckBox
       id: quickAllCorpses
       size: 12 12
       !text: tr('Quick Loot All Corpses')

--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -578,11 +578,9 @@ function onBattleButtonMouseRelease(self, mousePosition, mouseButton)
         end
       elseif isNpc then
         menu:addOption(tr('Talk'), function()
-          local distance = math.max(math.abs(player:getPosition().x - creature:getPosition().x), math.abs(player:getPosition().y - creature:getPosition().y))
-          if distance > 3 then
+          if not m_interface.talkToNpc(creature) then
             return modules.game_textmessage.displayFailureMessage(tr('You are too far away.'))
           end
-		  g_game.sendNPCTalk(creature:getId())
         end)
       end
       menu:addOption(tr('Follow'), function() g_game.follow(creature) end)

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -35,6 +35,35 @@ local keybindClearOldMessage = KeyBind:getKeyBind("Misc.", "Clear oldest message
 
 local widgetItem
 local lastAction = 0
+local npcTalkMaxDistance = 3
+
+function canTalkToNpc(creature)
+  if not creature or not creature:isNpc() then
+    return false
+  end
+
+  local player = g_game.getLocalPlayer()
+  if not player then
+    return false
+  end
+
+  local playerPos = player:getPosition()
+  local npcPos = creature:getPosition()
+  if not playerPos or not npcPos or playerPos.z ~= npcPos.z then
+    return false
+  end
+
+  return math.max(math.abs(playerPos.x - npcPos.x), math.abs(playerPos.y - npcPos.y)) <= npcTalkMaxDistance
+end
+
+function talkToNpc(creature)
+  if not canTalkToNpc(creature) then
+    return false
+  end
+
+  g_game.talk("hi")
+  return true
+end
 
 function init()
   g_ui.importStyle('styles/countwindow')
@@ -1144,12 +1173,9 @@ function createThingMenu(tile, menuPosition, lookThing, useThing, creatureThing)
         end
 
       if creatureThing:isNpc() and creatureThing:getPosition().z == localPosition.z then
-            menu:addOption(tr('Talk'), function()
-            if math.abs(localPosition.x - creatureThing:getPosition().x) > 4 or math.abs(localPosition.y - creatureThing:getPosition().y) > 4 then
-              return
-            end
-			g_game.sendNPCTalk(creatureThing:getId())
-          end, shortcut)
+        menu:addOption(tr('Talk'), function()
+          talkToNpc(creatureThing)
+        end, shortcut)
       end
 
         if g_game.getFollowingCreature() ~= creatureThing then
@@ -1440,10 +1466,7 @@ function processSmartControl(tile, menuPosition, mouseButton, autoWalkPos, lookT
   if keyboardModifiers == KeyboardNoModifier then
     if creatureThing and mouseButton == MouseLeftButton then
       if creatureThing:isNpc() then
-        local distance = math.max(math.abs(player:getPosition().x - creatureThing:getPosition().x), math.abs(player:getPosition().y - creatureThing:getPosition().y))
-        if distance <= 3 then
-          g_game.sendNPCTalk(creatureThing:getId())
-        end
+        talkToNpc(creatureThing)
       else
         g_game.attack(creatureThing)
       end
@@ -1492,6 +1515,14 @@ function processSmartControl(tile, menuPosition, mouseButton, autoWalkPos, lookT
 end
 
 function processMouseAction(tile, menuPosition, mouseButton, autoWalkPos, lookThing, useThing, creatureThing, attackCreature, marking)
+  if not g_app.isMobile()
+      and mouseButton == MouseRightButton
+      and g_keyboard.getModifiers() == KeyboardNoModifier
+      and m_settings.getOption('talkOnRightClick')
+      and talkToNpc(creatureThing) then
+    return true
+  end
+
   local gameControl = tonumber(m_settings.getOption('classicControl')) or 1
   if gameControl < 1 or gameControl > 3 then
     gameControl = 1


### PR DESCRIPTION
## Summary

Adds a configurable client option to talk to nearby NPCs with right-click by sending the normal `hi` speech message.

## Details

- Registers `talkOnRightClick` with a disabled-by-default setting.
- Adds the `Right-click talk to NPC` checkbox in the Gameplay options panel.
- Reuses one NPC talk helper in the game interface for same-floor and distance checks.
- Replaces modern/custom `sendNPCTalk` usage in the map and battle-list Talk actions with `g_game.talk("hi")`, which matches the 8.60 server behavior.

## Validation

- `git diff --check -- data/default-config.otml mods/client_settings/classes/dataset.lua mods/client_settings/options/gameplay.otui modules/game_interface/gameinterface.lua modules/game_battle/battle.lua`
- Confirmed the 8.60 server handles normal `ClientTalk`/`parseSay` and NPC scripts use `hi`/`hello` greet keywords.

`lua`, `luac`, and `luajit` were not available in PATH for a Lua syntax check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **New Features**
  * Adicionada nova opção de configuração para falar com NPCs ao clicar com o botão direito do mouse.
  * Interface aprimorada com validação de distância máxima e verificação de andar para interações com NPCs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->