### PR TITLE
fix(game_helper): correct inverted vocation ID mapping

### DIFF
--- a/mods/game_helper/classes/auto_haste.lua
+++ b/mods/game_helper/classes/auto_haste.lua
@@ -389,7 +389,7 @@ _Helper.AutoHaste.onSetupDropSupport = function(widget, spellData)
   local helperConfig = _Helper.getHelperConfig and _Helper.getHelperConfig()
   if not helperConfig then return end
 
-  if table.contains(spellData.vocations, playerVocation) then
+  if table.contains(spellData.vocations, player:getVocation()) then
     _Helper.setSpellIcon(widget, spellData.id)
     widget:setBorderColorTop("#1b1b1b")
     widget:setBorderColorLeft("#1b1b1b")

--- a/mods/game_helper/helper.lua
+++ b/mods/game_helper/helper.lua
@@ -642,21 +642,25 @@ local bothCastTypeSpells = {
 --             HelperSpellData.getHasteWhiteList()
 
 -- Converte diferentes representações de vocação em um ID padronizado
--- Retornos esperados: 0=rook, 5=MS, 6=ED, 7=RP, 8=EK, 9=EM (custom)
+-- Retornos: 0=rook, 1=Knight, 2=Paladin, 3=Sorcerer, 4=Druid, 5=Monk
 function translateVocation(v)
   local map = {
     [0] = 0,
-    [1] = 1,
+    [4] = 1,
+    [8] = 1,
     [11] = 1, -- Knight + EK
-    [2] = 2,
+    [3] = 2,
+    [7] = 2,
     [12] = 2, -- Paladin + RP
-    [3] = 3,
+    [1] = 3,
+    [5] = 3,
     [13] = 3, -- Sorcerer + MS
-    [4] = 4,
+    [2] = 4,
+    [6] = 4,
     [14] = 4, -- Druid + ED
-    [5] = 5,
+    [9] = 5,
+    [10] = 5,
     [15] = 5, -- Monk + promo
-    [9] = 9,  -- EM/custom se usar
   }
 
   if type(v) == 'number' then
@@ -6237,7 +6241,7 @@ end
 
 function onSetupDropSpell(button, spellData, groups, tableToAssign)
   local groupIds = Spells.getGroupIds(spellData)
-  local playerVocation = translateVocation(player:getVocation())
+  local playerVocation = player:getVocation()
   local profile = getShooterProfile()
 
   if containsAnyGroup(groupIds, groups) and table.contains(spellData.vocations, playerVocation) and not HelperSpellData.getIgnoredSpellsIds()[spellData.id] then

--- a/mods/game_helper/tools_panel.lua
+++ b/mods/game_helper/tools_panel.lua
@@ -113,19 +113,19 @@ local function getHelperWindow()
 end
 
 -- Get player vocation ID (normalized to base vocation)
--- Client IDs: Knight=1, Paladin=2, Sorcerer=3, Druid=4, Monk=5
--- Promoted: EliteKnight=11, RoyalPaladin=12, MasterSorcerer=13, ElderDruid=14, ExaltedMonk=15
+-- Game client IDs: Sorcerer=1, Druid=2, Paladin=3, Knight=4, Monk=9
+-- Promoted: MasterSorcerer=5/13, ElderDruid=6/14, RoyalPaladin=7/12, EliteKnight=8/11, ExaltedMonk=10/15
 -- Returns normalized ID: Knight=1, Paladin=2, Sorcerer=3, Druid=4, Monk=5
 local function getPlayerVocationId()
   local player = getPlayer()
   if not player then return 0 end
   local voc = player:getVocation()
   -- Normalize to base vocation (remove promotion)
-  if voc == 1 or voc == 11 then return 1 end -- Knight / Elite Knight
-  if voc == 2 or voc == 12 then return 2 end -- Paladin / Royal Paladin
-  if voc == 3 or voc == 13 then return 3 end -- Sorcerer / Master Sorcerer
-  if voc == 4 or voc == 14 then return 4 end -- Druid / Elder Druid
-  if voc == 5 or voc == 15 then return 5 end -- Monk / Exalted Monk
+  if voc == 4 or voc == 8 or voc == 11 then return 1 end -- Knight / Elite Knight
+  if voc == 3 or voc == 7 or voc == 12 then return 2 end -- Paladin / Royal Paladin
+  if voc == 1 or voc == 5 or voc == 13 then return 3 end -- Sorcerer / Master Sorcerer
+  if voc == 2 or voc == 6 or voc == 14 then return 4 end -- Druid / Elder Druid
+  if voc == 9 or voc == 10 or voc == 15 then return 5 end -- Monk / Exalted Monk
   return voc
 end
 

--- a/mods/game_helper/tools_panel.lua
+++ b/mods/game_helper/tools_panel.lua
@@ -628,7 +628,7 @@ local QUIVER_REFILL_COOLDOWN_MS = 500
 function tools.clampQuiverMin(newMin, currentRefillValue)
   if not newMin or newMin < 1 then return 1 end
   if currentRefillValue and newMin >= currentRefillValue then
-    return currentRefillValue - 1
+    return math.max(1, currentRefillValue - 1)
   end
   return newMin
 end
@@ -1180,12 +1180,12 @@ end
 
 -- Getter for exercise dummies
 function tools.getExerciseDummies()
-  return exerciseDummies
+  return ExerciseDummies
 end
 
 -- Getter for exercise items
 function tools.getExercises()
-  return exercises
+  return ExerciseIds
 end
 
 -- Getter for toolsPanel


### PR DESCRIPTION
Game client uses Sorcerer=1, Druid=2, Paladin=3, Knight=4, but getPlayerVocationId() and translateVocation() were mapping as if Knight=1, Paladin=2, Sorcerer=3, Druid=4.

This caused Druids to see Paladin spells and the quiver refill panel, Sorcerers to see Knight spells, and vice versa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorado o reconhecimento automático da vocação do jogador, corrigindo a visibilidade dos painéis de classe.

* **Refactor**
  * Reorganização de código interno mantendo todas as funcionalidades de Auto Haste, ouro automático, treinamento de exercício e proteção mágica.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->