### PR TITLE
[codex] Port task hunt UI

### DIFF
--- a/data/styles/0-vars.otui
+++ b/data/styles/0-vars.otui
@@ -1,36 +1,27 @@
-// Labels-Default
-$var-font: verdana-11px-antialised
-
-// Astra-Label
-$var-cip-font: Verdana Bold-11px
-$var-cip-font-lowspace: Verdana Bold-11px-low-space
-$var-cip-font-off: Verdana-Strikethrough-11px
-$var-cip-font-wheel: Verdana Bold-11px-wheel
-$var-cip-font-mono-rounded: verdana-11px-mono-rounded
-$var-cip-font-rounded: verdana-11px-rounded-lowspace
-$var-cip-font-rounded-lowspace: verdana-11px-rounded-lowspace
-
 // Colors
-$var-text-color: #dfdfdf
-$var-text-color-disabled: #dfdfdf88
-$var-text-cip-color: #c0c0c0
-$var-cip-inactive-color: #707070
-$var-text-cip-color-green: #44ad25
-$var-text-cip-color-green-disabled: #2c4f23
-$var-text-cip-color-white: #f7f7f7
-$var-text-cip-color-highlight: #f4f4f4
-$var-text-cip-color-grey: #909090
-$var-text-cip-color-orange: #ff9854
-$var-text-cip-color-yellow: #ffda34
-$var-text-cip-color-blue: #3fbbca
-$var-text-cip-color-light-red: #f75f5f
-$var-text-cip-store-disabled: #565656
-$var-text-cip-store-red: #D33C3C
-$var-text-cip-store-red-disabled: #562626
-$var-text-cip-store-sale: #f7af48
-$var-text-cip-store-sale-disabled: #664f2e
-$var-text-cip-store-timed: #1872c3
-$var-text-cip-store-timed-disabled: #1d3b55
-$var-textlist-selected: #585858
-$var-textlist-even: #414141
-$var-textlist-odd: #484848
+&var-text-color: #dfdfdf
+&var-text-cip-color-white: #f7f7f7
+&var-text-cip-color-highlight: #f4f4f4
+&var-text-cip-color-grey: #909090
+&var-text-cip-color: #c0c0c0
+&var-cip-inactive-color: #707070
+&var-text-cip-color-green: #44ad25
+&var-text-color-disabled: #dfdfdf88
+&var-text-cip-color-orange: #ff9854
+&var-text-cip-color-yellow: #ffda34
+&var-text-cip-color-light-red: #f75f5f
+&var-text-cip-store-disabled: #565656
+&var-text-cip-store-red: #D33C3C
+&var-text-cip-store-timed: #1872c3
+&var-textlist-selected: #585858
+&var-textlist-even: #414141
+&var-textlist-odd: #484848
+
+
+// Labels
+
+&var-main-font: verdana-11px-antialised
+&var-cip-main-font: Verdana Bold-11px
+&var-cip-font-wheel: Verdana Bold-11px-wheel
+&var-cip-font-mono-rounded: verdana-11px-mono-rounded
+&var-cip-font-rounded-lowspace: verdana-11px-rounded-lowspace

--- a/data/styles/10-buttons.otui
+++ b/data/styles/10-buttons.otui
@@ -1,6 +1,6 @@
 Button < UIButton
   font: cipsoftFont
-  color: #dfdfdfff
+  color: $var-text-color
   size: 43 20
   text-offset: 0 2
   image-source: /images/ui/buttons
@@ -8,7 +8,6 @@ Button < UIButton
   image-border: 1
   padding: 10
   opacity: 1.0
-  click-sound: 2774
 
   $hover !disabled:
     image-clip: 0 0 43 20
@@ -16,7 +15,7 @@ Button < UIButton
   $pressed:
     image-clip: 0 20 43 20
     text-offset: 1 1
-  
+
   $on:
     image-clip: 0 20 43 20
     text-offset: 1 1
@@ -26,40 +25,40 @@ Button < UIButton
     text-offset: 1 1
 
   $disabled:
-    color: #dfdfdf88
+    color: $var-text-color-disabled
     opacity: 0.8
     change-cursor-image: false
 
 TabButton < UIButton
   size: 22 23
   image-source: /images/ui/tabbutton_rounded
-  image-color: #dfdfdf
+  image-color: $var-text-color
   image-clip: 0 0 22 23
   image-border: 3
   text-offset: 0 1
-  icon-color: #dfdfdf
-  color: #dfdfdf
+  icon-color: $var-text-color
+  color: $var-text-color
   change-cursor-image: true
   cursor: pointer
 
   $hover !on:
     image-clip: 0 23 22 23
-    color: #dfdfdf
+    color: $var-text-color
 
   $disabled:
     image-color: #dfdfdf66
-    icon-color: #dfdfdf
+    icon-color: $var-text-color
     change-cursor-image: false
 
   $on:
     image-clip: 0 46 22 23
-    color: #dfdfdf
+    color: $var-text-color
 
 NextButton < UIButton
   size: 12 21
   image-source: /images/ui/arrow_horizontal
   image-clip: 12 0 12 21
-  image-color: #ffffff
+  image-color: $var-text-cip-color-white
   text-offset: 0 1
   change-cursor-image: true
   cursor: pointer
@@ -71,14 +70,14 @@ NextButton < UIButton
     image-clip: 12 21 12 21
 
   $disabled:
-    image-color: #dfdfdf88
+    image-color: $var-text-color-disabled
     change-cursor-image: false
 
 PreviousButton < UIButton
   size: 12 21
   image-source: /images/ui/arrow_horizontal
   image-clip: 0 0 12 21
-  image-color: #ffffff
+  image-color: $var-text-cip-color-white
   text-offset: 0 1
   change-cursor-image: true
   cursor: pointer
@@ -90,7 +89,7 @@ PreviousButton < UIButton
     image-clip: 0 21 12 21
 
   $disabled:
-    image-color: #dfdfdf88
+    image-color: $var-text-color-disabled
     change-cursor-image: false
 
 AddButton < UIButton
@@ -127,37 +126,89 @@ ImageButton < UIButton
   text-offset: 0 1
   color: #e0e0e0
 
-MoveUpButton < UIButton
-  size: 17 17
-  image-source: /images/game/actionbar/arrow-up
-  image-clip: 0 0 17 17
-  !tooltip: tr('Move Up')
+PreviousConsoleQtButton < UIButton
+  size: 18 16
+  image-source: /images/ui/console_direction_button
+  image-clip: 36 0 18 16
 
   $pressed:
-    image-clip: 0 17 17 17
+    image-clip: 18 0 18 16
+
+  $pressed disabled:
+    image-clip: 0 0 18 16
 
   $disabled:
-    image-clip: 0 34 17 17
+    image-clip: 54 0 18 16
 
-MoveDownButton < UIButton
-  size: 17 17
-  image-source: /images/game/actionbar/arrow-down
-  image-clip: 0 0 17 17
-  !tooltip: tr('Move Down')
+PreviousConsoleRedQtButton < UIButton
+  size: 18 16
+  image-source: /images/ui/console_direction_button
+  image-clip: 90 0 18 16
 
   $pressed:
-    image-clip: 0 17 17 17
+    image-clip: 72 0 18 16
+
+  $pressed disabled:
+    image-clip: 0 0 18 16
 
   $disabled:
-    image-clip: 0 34 17 17
+    image-clip: 54 0 18 16
 
-RemoveButton < UIButton
-  size: 20 20
-  image-source: /images/ui/buttons/button-clear-18x18-up
-  tooltip: Remove
+NextConsoleQtButton < UIButton
+  size: 18 16
+  image-source: /images/ui/console_direction_button
+  image-clip: 36 16 18 16
 
   $pressed:
-    image-source: /images/ui/buttons/button-clear-18x18-down
+    image-clip: 18 16 18 16
+
+  $pressed disabled:
+    image-clip: 0 16 18 16
+
+  $disabled:
+    image-clip: 54 16 18 16
+
+NextConsoleRedQtButton < UIButton
+  size: 18 16
+  image-source: /images/ui/console_direction_button
+  image-clip: 90 16 18 16
+
+  $pressed:
+    image-clip: 72 16 18 16
+
+  $pressed disabled:
+    image-clip: 0 16 18 16
+
+  $disabled:
+    image-clip: 54 16 18 16
+
+PreviousQtButton < UIButton
+  size: 16 16
+  image-source: /images/ui/regular_direction_button
+  image-clip: 32 0 16 16
+
+  $pressed:
+    image-clip: 16 0 16 16
+
+  $pressed disabled:
+    image-clip: 0 0 16 16
+
+  $disabled:
+    image-clip: 48 0 16 16
+
+NextQtButton < UIButton
+  size: 16 16
+  image-source: /images/ui/regular_direction_button
+  image-clip: 32 16 16 16
+
+  $pressed:
+    image-clip: 16 16 16 16
+
+  $pressed disabled:
+    image-clip: 0 16 16 16
+
+  $disabled:
+    image-clip: 48 16 16 16
 
 QtButton < UIButton
   font: cipsoftFont
@@ -178,32 +229,52 @@ QtButton < UIButton
     color: white
     opacity: 0.6
 
-CloseButton < Button
-  !text: tr('Close')
+BigPremiumButton < UIButton
+  size: 128 37
+  image-source: /images/ui/getpremium
+  image-clip: 0 0 128 37
+  image-border: 3
+  $pressed:
+    image-clip: 0 37 128 37
+  $!on:
+    image-clip: 0 74 128 37
+  $disabled:
+    color: $var-text-color-disabled
+    opacity: 0.8
 
-CancelButton < Button
-  !text: tr('Cancel')
+MiniPremiumButton < UIButton
+  size: 26 22
+  image-source: /images/ui/miniStoreIcon
+  image-clip: 0 0 26 22
+  $pressed:
+    image-clip: 0 22 26 22
 
-OkButton < Button
-  !text: tr('Ok')
+Button4 < UIButton
+  font: $var-main-font
+  color: white
+  size: 106 23
+  text-offset: 0 1
+  image-source: /images/ui/button
+  image-color: $var-text-color
+  image-clip: 0 0 22 23
+  image-border: 3
+  padding: 5 10 5 10
+  opacity: 1.0
 
-BackButton < Button
-  !text: tr('Back')
+  $hover !disabled:
+    image-clip: 0 23 22 23
 
-ApplyButton < Button
-  !text: tr('Apply')
+  $pressed:
+    image-clip: 0 46 22 23
 
-ClearButton < Button
-  !text: tr('Clear')
+  $disabled:
+    color: $var-text-cip-color
+    text-offset: 1 2
+    image-clip: 0 46 22 23
+    change-cursor-image: false
 
-ResetButton < Button
-  !text: tr('Reset')
-
-RefreshButton < Button
-  !text: tr('Refresh')
-
-SaveButton < Button
-  !text: tr('Save')
+  $on:
+    image-clip: 0 46 22 23
 
 BaseSimpleButtonTemplate < UIWidget
   size: 43 20
@@ -228,3 +299,55 @@ BaseLargeButtonTemplate < UIWidget
     image-clip: 0 20 158 20
   $disabled:
     image-clip: 0 40 158 20
+
+CancelButton < BaseSimpleButtonTemplate
+  image-source: /images/common_buttons/cancel-button
+
+CloseButton < BaseButtonTemplate
+  image-source: /images/common_buttons/close-button
+
+OkButton < BaseButtonTemplate
+  image-source: /images/common_buttons/ok-button
+
+BackButton < BaseSimpleButtonTemplate
+  image-source: /images/common_buttons/back-button
+
+RefreshButton < BaseButtonTemplate
+  image-source: /images/common_buttons/refresh-button
+
+ResetButton < BaseButtonTemplate
+  image-source: /images/common_buttons/reset-button
+
+ClearButton < BaseButtonTemplate
+  image-source: /images/common_buttons/clear-button
+
+SellButton < BaseButtonTemplate
+  image-source: /images/game/npctrade/sell-button
+
+BuyButton < BaseButtonTemplate
+  image-source: /images/game/npctrade/buy-button
+
+SmallApplyButton < BaseButtonTemplate
+  image-source: /images/common_buttons/small-apply-button
+
+SmallNewButton < BaseButtonTemplate
+  image-source: /images/common_buttons/new-button
+
+SmallRenameButton < BaseButtonTemplate
+  image-source: /images/common_buttons/rename-button
+
+ApplyButton < UIWidget
+  image-source: /images/common_buttons/apply-button
+  size: 65 20
+  image-clip: 0 0 65 20
+  $pressed:
+    image-clip: 0 20 65 20
+  $disabled:
+    image-clip: 0 40 65 20
+
+ClearSearch < UIWidget
+  image-source: /images/common_buttons/button-clear-search
+  size: 20 20
+  image-clip: 0 0 20 20
+  $pressed:
+    image-clip: 0 20 20 20

--- a/modules/corelib/ui/uimodaloverlay.lua
+++ b/modules/corelib/ui/uimodaloverlay.lua
@@ -1,0 +1,187 @@
+--[[
+  UI Modal Overlay - alternativa ao lock() de janela.
+
+  Cria um overlay transparente para bloquear interacao com widgets abaixo.
+
+  Uso:
+    UIModalOverlay.show(myWindow)
+    UIModalOverlay.hide(myWindow)
+    UIModalOverlay.destroy(myWindow)
+]]
+
+if not UIModalOverlay then
+  UIModalOverlay = {
+    activeOverlays = {},
+    registeredWindows = {}
+  }
+end
+
+local function getOverlayKey(window, customId)
+  local windowId = window and window:getId() or "global"
+  local id = customId or "default"
+  return windowId .. "_" .. id
+end
+
+function UIModalOverlay.show(window, customId, options)
+  options = options or {}
+  local key = getOverlayKey(window, customId)
+
+  if UIModalOverlay.activeOverlays[key] then
+    local overlay = UIModalOverlay.activeOverlays[key]
+    overlay:raise()
+    overlay:show()
+    if window then
+      window:raise()
+    end
+    return overlay
+  end
+
+  local parent = nil
+  if window then
+    parent = window:getParent()
+  end
+  if not parent then
+    parent = g_ui.getRootWidget()
+  end
+  if not parent then return nil end
+
+  local overlay = g_ui.createWidget('UIWidget', parent)
+  if not overlay then return nil end
+
+  overlay:setId('modalOverlay_' .. key)
+  overlay:fill('parent')
+  overlay:setPhantom(false)
+  overlay:setFocusable(false)
+  overlay:setBackgroundColor(options.backgroundColor or '#00000001')
+
+  overlay.onMousePress = function(widget, mousePos, mouseButton)
+    if options.onClick then
+      options.onClick(widget, mousePos, mouseButton)
+    end
+    return true
+  end
+
+  overlay.onMouseRelease = function()
+    return true
+  end
+
+  UIModalOverlay.activeOverlays[key] = overlay
+
+  overlay:raise()
+  overlay:show()
+  if window then
+    window:raise()
+  end
+
+  return overlay
+end
+
+function UIModalOverlay.hide(window, customId)
+  local key = getOverlayKey(window, customId)
+  local overlay = UIModalOverlay.activeOverlays[key]
+
+  if overlay then
+    overlay:hide()
+  end
+end
+
+function UIModalOverlay.destroy(window, customId)
+  local key = getOverlayKey(window, customId)
+  local overlay = UIModalOverlay.activeOverlays[key]
+
+  if overlay then
+    overlay:destroy()
+    UIModalOverlay.activeOverlays[key] = nil
+  end
+end
+
+function UIModalOverlay.destroyAll()
+  for _, overlay in pairs(UIModalOverlay.activeOverlays) do
+    if overlay and overlay.destroy then
+      overlay:destroy()
+    end
+  end
+  UIModalOverlay.activeOverlays = {}
+end
+
+function UIModalOverlay.isActive(window, customId)
+  local key = getOverlayKey(window, customId)
+  local overlay = UIModalOverlay.activeOverlays[key]
+  return overlay and overlay:isVisible()
+end
+
+function UIModalOverlay.register(window, options)
+  if not window then return false end
+
+  local uniqueKey = tostring(window)
+  if UIModalOverlay.registeredWindows[uniqueKey] then
+    return true
+  end
+
+  local originalShow = window.show
+  local originalHide = window.hide
+  local originalDestroy = window.destroy
+
+  window.show = function(self, ...)
+    if originalShow then
+      originalShow(self, ...)
+    end
+    if self:isVisible() then
+      UIModalOverlay.show(self, nil, options)
+    end
+  end
+
+  window.hide = function(self, ...)
+    UIModalOverlay.hide(self)
+    if originalHide then
+      originalHide(self, ...)
+    end
+  end
+
+  window.destroy = function(self, ...)
+    UIModalOverlay.unregister(self)
+    UIModalOverlay.destroy(self)
+    if originalDestroy then
+      originalDestroy(self, ...)
+    end
+  end
+
+  UIModalOverlay.registeredWindows[uniqueKey] = {
+    window = window,
+    originalShow = originalShow,
+    originalHide = originalHide,
+    originalDestroy = originalDestroy,
+    options = options
+  }
+
+  return true
+end
+
+function UIModalOverlay.unregister(window)
+  if not window then return end
+
+  local uniqueKey = tostring(window)
+  local registration = UIModalOverlay.registeredWindows[uniqueKey]
+
+  if registration then
+    window.show = registration.originalShow
+    window.hide = registration.originalHide
+    window.destroy = registration.originalDestroy
+    UIModalOverlay.registeredWindows[uniqueKey] = nil
+  end
+end
+
+function UIModalOverlay.hasVisibleOverlay()
+  for _, overlay in pairs(UIModalOverlay.activeOverlays) do
+    if overlay and overlay:isVisible() then
+      return true
+    end
+  end
+  return false
+end
+
+function UIModalOverlay.isRegistered(window)
+  if not window then return false end
+  local uniqueKey = tostring(window)
+  return UIModalOverlay.registeredWindows[uniqueKey] ~= nil
+end

--- a/modules/game_interface/interface.otmod
+++ b/modules/game_interface/interface.otmod
@@ -39,6 +39,7 @@ Module
     - game_stash
     - game_store
     - game_blessing
+    - game_mainpanel
     - game_sidebuttons
     - game_unjustifiedpoints
     - game_skills

--- a/modules/game_mainpanel/mainoptionspanel.otui
+++ b/modules/game_mainpanel/mainoptionspanel.otui
@@ -1,0 +1,100 @@
+PhantomMiniWindow
+  id: mainoptionspanel
+  height: 28
+  &panelHeight: 28
+  on: true
+
+  UIWidget
+    id: offPanel
+    anchors.fill: parent
+    margin-top: 8
+    phantom: true
+
+    Button
+      size: 44 20
+      image-source: /images/options/button_enlarge
+      image-clip: 0 0 44 20
+      anchors.top: parent.top
+      anchors.right: parent.right
+      margin-right: 8
+      @onClick: changeOptionsSize()
+
+      $pressed !disabled:
+        image-clip: 0 20 44 20
+
+  UIWidget
+    id: onPanel
+    anchors.fill: parent
+    margin-top: 8
+    phantom: true
+
+    UIWidget
+      id: store
+      image-clip: 0 0 108 20
+      anchors.top: parent.top
+      anchors.left: parent.left
+      margin-left: 8
+      size: 108 20
+      phantom: true
+      layout:
+        type: verticalBox
+        cell-size: 108 20
+        cell-spacing: 2
+        flow: true
+
+      $pressed !disabled:
+        image-clip: 0 20 108 20
+
+    Button
+      id: resizer
+      size: 44 20
+      image-source: /images/options/button_enlarge
+      image-clip: 0 0 44 20
+      anchors.top: parent.top
+      anchors.right: parent.right
+      margin-right: 8
+      @onClick: changeOptionsSize()
+
+      $pressed !disabled:
+        image-clip: 0 20 44 20
+
+    UIWidget
+      id: options
+      anchors.left: store.left
+      anchors.right: store.right
+      anchors.top: store.bottom
+      anchors.bottom: parent.bottom
+      margin-top: 6
+      margin-left: 0
+      margin-right: 0
+      margin-bottom: 0
+      phantom: true
+      layout:
+        type: grid
+        cell-size: 20 20
+        cell-spacing: 2
+        flow: true
+
+    VerticalSeparator
+      anchors.top: options.top
+      anchors.bottom: options.bottom
+      anchors.left: store.right
+      margin-left: 5
+      phantom: true
+
+    UIWidget
+      id: specials
+      anchors.left: resizer.left
+      anchors.right: resizer.right
+      anchors.top: options.top
+      anchors.bottom: parent.bottom
+      margin-top: 0
+      margin-left: 0
+      margin-right: 0
+      margin-bottom: 0
+      phantom: true
+      layout:
+        type: grid
+        cell-size: 20 20
+        cell-spacing: 2
+        flow: true

--- a/modules/game_mainpanel/mainpanel.lua
+++ b/modules/game_mainpanel/mainpanel.lua
@@ -1,0 +1,71 @@
+local panelButtons = {}
+
+local function addButton(id, description, image, callback, front, index)
+  if panelButtons[id] and not panelButtons[id]:isDestroyed() then
+    return panelButtons[id]
+  end
+
+  local button = nil
+  if modules.client_topmenu and modules.client_topmenu.addRightGameToggleButton then
+    button = modules.client_topmenu.addRightGameToggleButton(id, description, image, callback, front, index)
+  elseif modules.client_topmenu and modules.client_topmenu.addLeftGameToggleButton then
+    button = modules.client_topmenu.addLeftGameToggleButton(id, description, image, callback, front, index)
+  end
+
+  if button and type(index) == 'number' then
+    button.index = index
+  end
+
+  panelButtons[id] = button
+  return button
+end
+
+function init()
+end
+
+function terminate()
+  for id, button in pairs(panelButtons) do
+    if button and not button:isDestroyed() then
+      button:destroy()
+    end
+    panelButtons[id] = nil
+  end
+end
+
+function addToggleButton(id, description, image, callback, front, index)
+  return addButton(id, description, image, callback, front, index)
+end
+
+function addSpecialToggleButton(id, description, image, callback, front, index)
+  return addButton(id, description, image, callback, front, index)
+end
+
+function addStoreButton(id, description, image, callback, front, index)
+  return addButton(id, description, image, callback, front, index)
+end
+
+function getButton(id)
+  if panelButtons[id] and not panelButtons[id]:isDestroyed() then
+    return panelButtons[id]
+  end
+
+  if modules.client_topmenu and modules.client_topmenu.getButton then
+    return modules.client_topmenu.getButton(id)
+  end
+
+  return nil
+end
+
+function toggleStore()
+  if modules.game_store and modules.game_store.toggle then
+    modules.game_store.toggle()
+  elseif modules.game_shop and modules.game_shop.toggle then
+    modules.game_shop.toggle()
+  end
+end
+
+function reloadMainPanelSizes()
+end
+
+function toggleExtendedViewButtons()
+end

--- a/modules/game_mainpanel/mainpanel.otmod
+++ b/modules/game_mainpanel/mainpanel.otmod
@@ -1,0 +1,9 @@
+Module
+  name: game_mainpanel
+  description: Main panel
+  author: marcosvf132
+  website: https://github.com/edubart/otclient
+  sandboxed: true
+  scripts: [ mainpanel ]
+  @onLoad: init()
+  @onUnload: terminate()

--- a/modules/game_mainpanel/option_control_buttons.otui
+++ b/modules/game_mainpanel/option_control_buttons.otui
@@ -1,0 +1,148 @@
+UIWidget
+  anchors.fill: parent
+  visible: false
+  QtButton
+    id: reset
+    text: "Reset"
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    @onClick: reset()
+
+  Panel
+    id: panelDisplayedButtons
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
+    size: 502 248
+    border-width-top: 1
+    border-color-top: black
+    border-width-left: 1
+    border-color-left: black
+    border-width-bottom: 1
+    border-color-bottom: #747474
+    border-width-right: 1
+    border-color-right: #747474
+
+    Label
+      id: displayedButtonsLabel
+      !text: tr('Displayed Buttons')
+      anchors.top: parent.top
+      anchors.left: parent.left
+      margin-top: 5
+      margin-left: 10
+      color: #C0C0C0
+
+    TextList
+      id: displayedButtonsList
+      anchors.top: displayedButtonsLabel.bottom
+      anchors.left: parent.left
+      anchors.right: parent.right
+      height: 200
+      margin-top: 5
+      margin-left: 10
+      margin-right: 35
+      vertical-scrollbar: displayedButtonsScrollBar
+      background-color: #404040
+    VerticalQtScrollBar
+      id: displayedButtonsScrollBar
+      anchors.top: displayedButtonsList.top
+      anchors.bottom: displayedButtonsList.bottom
+      anchors.right: displayedButtonsList.right
+      step: 14
+      pixels-scroll: true
+
+    UIButton
+      id: moveToDisplayedAvailableButtonsList
+      anchors.top: displayedButtonsList.top
+      anchors.right: parent.right
+      margin-right: 10
+      image-source: /images/ui/buttons/button-clear-18x18-up
+      image-clip: 0 0 20 20
+      width: 20
+      @onClick: moveToAvailable()
+      $pressed:
+        image-source: /images/ui/buttons/button-clear-18x18-down
+
+    UIButton
+      id: reordenUp
+      anchors.top: prev.bottom
+      anchors.right: parent.right
+      margin-right: 10
+      margin-top: 5
+      image-source: /images/ui/buttons/automap-button-moveup-up
+      image-clip: 0 0 20 20
+      width: 20
+      @onClick: moveButtonUp()
+      $pressed:
+        image-source: /images/ui/buttons/automap-button-moveup-down
+
+    UIButton
+      id: reordenDown
+      anchors.top: prev.bottom
+      anchors.right: parent.right
+      margin-right: 10
+      margin-top: 5
+      image-source: /images/ui/buttons/automap-button-movedown-up
+      image-clip: 0 0 20 20
+      width: 20
+      @onClick: moveButtonDown()
+      $pressed:
+        image-source: /images/ui/buttons/automap-button-movedown-down
+
+  Panel
+    id: panelAvailableButtons
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    size: 508 100
+    margin-top: 10
+    border-width-top: 1
+    border-color-top: black
+    border-width-left: 1
+    border-color-left: black
+    border-width-bottom: 1
+    border-color-bottom: #747474
+    border-width-right: 1
+    border-color-right: #747474
+    Label
+      id: displayedButtonsLabel
+      !text: tr('Available Buttons')
+      anchors.top: parent.top
+      anchors.left: parent.left
+      margin-top: 5
+      margin-left: 10
+      color: #C0C0C0
+
+    TextList
+      id: displayedAvailableButtonsList
+      anchors.top: displayedButtonsLabel.bottom
+      anchors.left: parent.left
+      anchors.right: parent.right
+      height: 74
+      margin-top: 5
+      margin-left: 10
+      margin-right: 35
+      vertical-scrollbar: displayedButtonsScrollBar
+      background-color: #404040
+    VerticalQtScrollBar
+      id: displayedButtonsScrollBar
+      anchors.top: prev.top
+      anchors.bottom: prev.bottom
+      anchors.right: prev.right
+      step: 14
+      pixels-scroll: true
+    UIButton
+      id: moveToDisplayedButtonsList
+      anchors.top: prev.top
+      anchors.right: parent.right
+      margin-right: 10
+      image-source: /images/options/button_control
+      width: 20
+      @onClick: moveToDisplayed()
+      image-clip: 0 0 20 20
+      image-border: 3
+      $pressed:
+        image-clip: 20 0 20 20
+
+      $on:
+        image-clip: 20 0 20 20

--- a/modules/game_task_hunt/classes/bounty-preferred.lua
+++ b/modules/game_task_hunt/classes/bounty-preferred.lua
@@ -88,6 +88,10 @@ end
 
 function BountyPreferred.terminate()
     if preferredWindow then
+        local monsterList = preferredWindow:recursiveGetChildById('monsterList')
+        if monsterList then BatchLoader.cancel(monsterList) end
+    end
+    if preferredWindow then
         preferredWindow:destroy()
         preferredWindow = nil
     end
@@ -152,40 +156,41 @@ function BountyPreferred.populateMonsterList()
 
     table.sort(sortedMonsters, function(a, b) return a.name < b.name end)
 
-    for i, monsterData in ipairs(sortedMonsters) do
-        if not preferredWindow then
-            break
-        end
+    BatchLoader.create({
+        container = monsterList,
+        items = sortedMonsters,
+        createWidget = function(m, i)
+            if not preferredWindow then return end
+            local row = g_ui.createWidget('BountyPreferredMonsterRow', monsterList)
+            local bgColor = (i % 2 == 1) and '$var-textlist-odd' or '$var-textlist-even'
+            row:setBackgroundColor(bgColor)
+            row.rowColor = bgColor
+            row.raceId = m.raceId
 
-        local row = g_ui.createWidget('BountyPreferredMonsterRow', monsterList)
-        local bgColor = (i % 2 == 1) and '$var-textlist-odd' or '$var-textlist-even'
-        row:setBackgroundColor(bgColor)
-        row.rowColor = bgColor
-        row.raceId = monsterData.raceId
+            local creature = row:recursiveGetChildById('creature')
+            if creature and m.raceData and m.raceData.outfit then
+                creature:setOutfit(m.raceData.outfit)
+                creature:getCreature():setStaticWalking(1000)
+                creature:setTooltip(m.name)
+                creature:setPhantom(false)
+            end
 
-        local creature = row:recursiveGetChildById('creature')
-        if creature and monsterData.raceData and monsterData.raceData.outfit then
-            creature:setOutfit(monsterData.raceData.outfit)
-            creature:getCreature():setStaticWalking(1000)
-            creature:setTooltip(monsterData.name)
-            creature:setPhantom(false)
-        end
+            local nameLabel = row:recursiveGetChildById('nameLabel')
+            if nameLabel then
+                nameLabel:setText(m.name)
+            end
 
-        local nameLabel = row:recursiveGetChildById('nameLabel')
-        if nameLabel then
-            nameLabel:setText(monsterData.name)
-        end
-
-        row.onFocusChange = function(widget, focused)
-            if focused then
-                widget:setBackgroundColor('$var-textlist-selected')
-                selectedRaceId = widget.raceId
-                BountyPreferred.updateAssignButtons()
-            else
-                widget:setBackgroundColor(widget.rowColor)
+            row.onFocusChange = function(widget, focused)
+                if focused then
+                    widget:setBackgroundColor('$var-textlist-selected')
+                    selectedRaceId = widget.raceId
+                    BountyPreferred.updateAssignButtons()
+                else
+                    widget:setBackgroundColor(widget.rowColor)
+                end
             end
         end
-    end
+    })
 
     -- Focus searchEdit so no row starts focused
     if searchEdit then
@@ -242,7 +247,7 @@ function BountyPreferred.populateSlots()
 
                     -- Disable unlock button if player lacks bounty task points
                     local player = g_game.getLocalPlayer()
-                    local balance = player and player:getResourceBalance(ResourceTypes.BOUNTY_POINTS) or 0
+                    local balance = player and player:getResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS) or 0
                     unlockBtn:setEnabled(balance >= price)
                 end
 
@@ -305,7 +310,7 @@ function BountyPreferred.setupSlotColumn(col, slotNum, raceId, colType)
         assignBtn.onClick = function()
             if selectedRaceId > 0 then
                 local actionType = isPreferred and ACTION_SET_PREFERRED or ACTION_SET_UNWANTED
-                g_game.bountyPreferredAction(actionType, slotNum - 1, selectedRaceId)
+                g_game.bountyPreferredAction(actionType, slotNum, selectedRaceId)
             end
         end
     end
@@ -314,12 +319,12 @@ function BountyPreferred.setupSlotColumn(col, slotNum, raceId, colType)
     if clearBtn then
         clearBtn:setVisible(hasMonster)
         local player = g_game.getLocalPlayer()
-        local balance = player and player:getResourceBalance(ResourceTypes.BOUNTY_POINTS) or 0
+        local balance = player and player:getResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS) or 0
         local canAfford = balance >= cachedRemoveCost
         clearBtn:setEnabled(canAfford)
         clearBtn.onClick = function()
             local actionType = isPreferred and ACTION_REMOVE_PREFERRED or ACTION_REMOVE_UNWANTED
-            g_game.bountyPreferredAction(actionType, slotNum - 1, 0)
+            g_game.bountyPreferredAction(actionType, slotNum, 0)
         end
     end
 

--- a/modules/game_task_hunt/classes/bounty-tasks.lua
+++ b/modules/game_task_hunt/classes/bounty-tasks.lua
@@ -57,10 +57,6 @@ function TaskBounty.updateTracker(monsters)
         return
     end
 
-    if Tracker.Prey and Tracker.Prey.ensureVisible then
-        Tracker.Prey.ensureVisible()
-    end
-
     local raceId = tonumber(activeMonster.raceId) or 0
     local currentKills = tonumber(activeMonster.currentKills) or 0
     local totalKills = tonumber(activeMonster.totalKills) or 0
@@ -93,7 +89,6 @@ function TaskBounty.onServerData(header, monsters, talisman)
             if panel2 then
                 local m = monsters[1]
                 TaskBounty.populateTaskPanel(panel2, {
-                    taskIndex = tonumber(m.taskIndex) or 0,
                     raceId = tonumber(m.raceId) or 0,
                     currentKills = tonumber(m.currentKills) or 0,
                     totalKills = tonumber(m.totalKills) or 0,
@@ -114,7 +109,6 @@ function TaskBounty.onServerData(header, monsters, talisman)
                     if monsters[i] then
                         local m = monsters[i]
                         TaskBounty.populateTaskPanel(panel, {
-                            taskIndex = tonumber(m.taskIndex) or 0,
                             raceId = tonumber(m.raceId) or 0,
                             currentKills = tonumber(m.currentKills) or 0,
                             totalKills = tonumber(m.totalKills) or 0,
@@ -204,7 +198,7 @@ function TaskBounty.onServerData(header, monsters, talisman)
             scheduleEvent(function()
                 local storeUI = modules.game_store.controllerShop and modules.game_store.controllerShop.ui
                 if storeUI and storeUI.SearchEdit then
-                    storeUI.SearchEdit:setText('Bounty Double Kill Boost (1H)')
+                    storeUI.SearchEdit:setText('Bounty Double Kill Boost')
                     modules.game_store.search()
                 end
             end, 500)
@@ -238,7 +232,6 @@ local RARITY_BACKDROPS = {
 
 function TaskBounty.populateTaskPanel(panel, data)
     local raceId = data.raceId or 0
-    local taskIndex = data.taskIndex or 0
     local rarity = data.rarity or 0
 
     -- Backdrop image and size based on rarity
@@ -303,11 +296,10 @@ function TaskBounty.populateTaskPanel(panel, data)
     local selectBtn = panel:recursiveGetChildById('selectTaskButton')
     if selectBtn then
         if data.isCompleted then
-            selectBtn:setText('Claim Reward')
-            selectBtn:setEnabled(true)
-            selectBtn.onClick = function()
-                TaskBounty.claimReward(raceId)
-            end
+            -- Already completed and reward claimed
+            selectBtn:setText('Completed')
+            selectBtn:setEnabled(false)
+            selectBtn.onClick = nil
         elseif data.isActive and data.currentKills >= data.totalKills then
             -- Task done, ready to claim
             selectBtn:setText('Claim Reward')
@@ -325,7 +317,7 @@ function TaskBounty.populateTaskPanel(panel, data)
             selectBtn:setText('Select Task')
             selectBtn:setEnabled(true)
             selectBtn.onClick = function()
-                TaskBounty.selectTask(taskIndex)
+                TaskBounty.selectTask(raceId)
             end
         end
     end

--- a/modules/game_task_hunt/classes/task-shop.lua
+++ b/modules/game_task_hunt/classes/task-shop.lua
@@ -135,8 +135,7 @@ function TaskShop.parseItem(raw)
             lookFeet = 0
         }
     elseif data.type == "Decoration" then
-        data.clientId = tonumber(raw.clientId) or tonumber(raw.itemId) or 0
-        data.itemId = data.clientId
+        data.itemId = tonumber(raw.itemId) or 0
     elseif data.type == "Bonus" then
         data.bonusType = raw.bonusType or ""
         data.imageSource = bonusTypeImages[data.bonusType] or ""
@@ -210,7 +209,7 @@ function TaskShop.createCard(parent, data)
     end
 
     -- Preview: Outfit or Item
-    if data.outfit and (tonumber(data.outfit.lookType) or 0) > 0 then
+    if data.outfit then
         local creatureWidget = card:recursiveGetChildById('outfitCreature')
         if creatureWidget then
             pcall(function()

--- a/modules/game_task_hunt/classes/weekly-tasks.lua
+++ b/modules/game_task_hunt/classes/weekly-tasks.lua
@@ -10,28 +10,6 @@ local ACTION_REFRESH_DATA = 2
 local THRESHOLDS = { 0, 4, 8, 12, 16, 18 }
 local SECTIONS = #THRESHOLDS - 1
 
-local function openStoreSearch(searchText)
-    modules.game_store.show()
-    scheduleEvent(function()
-        local storeUI = modules.game_store.controllerShop and modules.game_store.controllerShop.ui
-        if storeUI and storeUI.SearchEdit then
-            storeUI.SearchEdit:setText(searchText)
-            modules.game_store.search()
-        end
-    end, 500)
-end
-
-local function requestSoulsealData()
-    if modules.game_soulseal and modules.game_soulseal.request then
-        modules.game_soulseal.request()
-        return
-    end
-
-    if g_game.soulsealRequest then
-        g_game.soulsealRequest()
-    end
-end
-
 function TaskWeekly.requestRefresh()
     g_game.weeklyTaskAction(ACTION_REFRESH_DATA, 0)
 end
@@ -61,39 +39,15 @@ function TaskWeekly.init()
             icon:setImageSource('/images/game/task_hunt/icon-currency-soulseals')
             icon:setSize({ width = 9, height = 9 })
         end
-
-        rewardSoulPanel.onClick = function()
-            requestSoulsealData()
-        end
-        rewardSoulPanel:setTooltip(tr('Open the Soulseals list.'))
-    end
-
-    local rewardSoulInfo = taskHuntWindow:recursiveGetChildById('rewardSoulSealsInfo')
-    if rewardSoulInfo then
-        rewardSoulInfo.onClick = function()
-            requestSoulsealData()
-        end
     end
 end
 
 -- ─── Server data handler ─────────────────────────────────────────────
 
 function TaskWeekly.onServerData(header, monsters, items, difficulties)
-    g_logger.debug(string.format(
-        '[WeeklyTask][Lua][onServerData] headerDifficulty=%s monsters=%d items=%d difficulties=%d',
-        tostring(header and header.difficulty),
-        monsters and #monsters or 0,
-        items and #items or 0,
-        difficulties and #difficulties or 0
-    ))
-
     -- Always update the kill tracker
     if Tracker and Tracker.Weekly then
         Tracker.Weekly.loadFromServerData(monsters)
-    end
-
-    if monsters and #monsters > 0 and Tracker and Tracker.Prey and Tracker.Prey.ensureVisible then
-        Tracker.Prey.ensureVisible()
     end
 
     if not taskHuntWindow then
@@ -137,7 +91,6 @@ function TaskWeekly.onServerData(header, monsters, items, difficulties)
         table.insert(data.items, {
             type      = "item",
             itemId    = tonumber(it.itemId) or 0,
-            clientId  = tonumber(it.clientId) or tonumber(it.itemId) or 0,
             current   = tonumber(it.current) or 0,
             total     = tonumber(it.total) or 0,
             delivered = (tonumber(it.claimed) or 0) == 1,
@@ -155,10 +108,8 @@ function TaskWeekly.onServerData(header, monsters, items, difficulties)
         })
     end
 
-    -- Determine if difficulty selection modal should show.
-    -- Show only when no tasks exist yet (monsters list is empty),
-    -- even if difficulty == 0 (level 8 Beginner always gets unlockedDifficulty=0 from server).
-    data.selectedTaskDifficulty = (data.difficulty == 0) and (#data.monsters == 0)
+    -- Determine if difficulty selection modal should show
+    data.selectedTaskDifficulty = (data.difficulty == 0)
 
     TaskWeekly.loadData(data)
 end
@@ -233,22 +184,19 @@ end
 function TaskWeekly.loadData(data)
     TaskWeekly.clearDynamicWidgets()
 
-    g_logger.debug(string.format(
-        '[WeeklyTask][Lua][loadData] difficulty=%d selectedTaskDifficulty=%s monsters=%d items=%d completedKill=%d completedDelivery=%d',
-        data.difficulty,
-        tostring(data.selectedTaskDifficulty),
-        #data.monsters,
-        #data.items,
-        data.completedKillTasks,
-        data.completedDeliveryTasks
-    ))
-
     -- Boost Kills button - opens store for Weekly Double Kill Boost
     local boostKillsBtn = taskHuntWindow:recursiveGetChildById('boostKillsWeekly')
     if boostKillsBtn and not boostKillsBtn._bound then
         boostKillsBtn._bound = true
         boostKillsBtn.onClick = function()
-            openStoreSearch('Weekly Double Kill Boost (1H)')
+            modules.game_store.show()
+            scheduleEvent(function()
+                local storeUI = modules.game_store.controllerShop and modules.game_store.controllerShop.ui
+                if storeUI and storeUI.SearchEdit then
+                    storeUI.SearchEdit:setText('Weekly Double Kill Boost')
+                    modules.game_store.search()
+                end
+            end, 500)
         end
     end
 
@@ -257,23 +205,14 @@ function TaskWeekly.loadData(data)
     if reduceItemsBtn and not reduceItemsBtn._bound then
         reduceItemsBtn._bound = true
         reduceItemsBtn.onClick = function()
-            openStoreSearch('Reduced Weekly Bounty Items')
-        end
-    end
-
-    local killPermBtn = taskHuntWindow:recursiveGetChildById('killShopPermButton')
-    if killPermBtn and not killPermBtn._bound then
-        killPermBtn._bound = true
-        killPermBtn.onClick = function()
-            openStoreSearch('Unlock Permanently')
-        end
-    end
-
-    local deliveryPermBtn = taskHuntWindow:recursiveGetChildById('deliveryShopPermButton')
-    if deliveryPermBtn and not deliveryPermBtn._bound then
-        deliveryPermBtn._bound = true
-        deliveryPermBtn.onClick = function()
-            openStoreSearch('Unlock Permanently')
+            modules.game_store.show()
+            scheduleEvent(function()
+                local storeUI = modules.game_store.controllerShop and modules.game_store.controllerShop.ui
+                if storeUI and storeUI.SearchEdit then
+                    storeUI.SearchEdit:setText('Reduced Weekly Bounty Items')
+                    modules.game_store.search()
+                end
+            end, 500)
         end
     end
 
@@ -281,7 +220,6 @@ function TaskWeekly.loadData(data)
     local killGrid = taskHuntWindow:recursiveGetChildById('killTasksGrid')
     if killGrid then
         local monsterCount = #data.monsters
-        local visibleKillCards = 0
 
         -- Disable grid layout updates to prevent cascading side effects
         local killLayout = killGrid:getLayout()
@@ -294,10 +232,8 @@ function TaskWeekly.loadData(data)
             if i > monsterCount then
                 card:setVisible(false)
             else
-                visibleKillCards = visibleKillCards + 1
                 local monsterData = data.monsters[i]
                 card:setVisible(true)
-                card.taskRaceId = monsterData.raceId
                 card:setText(i)
                 local currentLabel = card:recursiveGetChildById('currentLabel')
                 if currentLabel then currentLabel:setText(monsterData.current) end
@@ -355,19 +291,12 @@ function TaskWeekly.loadData(data)
             killLayout:enableUpdates()
             killLayout:update()
         end
-
-        g_logger.debug(string.format(
-            '[WeeklyTask][Lua][loadData] killGridCardsVisible=%d totalGridCards=%d',
-            visibleKillCards,
-            killGrid:getChildCount()
-        ))
     end
 
     -- Fill delivery task cards
     local deliveryGrid = taskHuntWindow:recursiveGetChildById('deliveryTasksGrid')
     if deliveryGrid then
         local itemCount = #data.items
-        local visibleDeliveryCards = 0
 
         -- Disable grid layout updates to prevent cascading internalUpdate()
         -- side effects that swap visibility between cards
@@ -381,12 +310,9 @@ function TaskWeekly.loadData(data)
             if i > itemCount then
                 card:setVisible(false)
             else
-                visibleDeliveryCards = visibleDeliveryCards + 1
                 local itemData = data.items[i]
-                local previewItemId = itemData.clientId > 0 and itemData.clientId or itemData.itemId
                 card:setVisible(true)
-                card.taskItemId = previewItemId
-                local itemName = getItemServerName(previewItemId)
+                local itemName = getItemServerName(itemData.itemId)
                 card:setText(short_text(itemName, 20))
                 local currentLabel = card:recursiveGetChildById('currentLabel')
                 if currentLabel then currentLabel:setText(itemData.current) end
@@ -394,8 +320,8 @@ function TaskWeekly.loadData(data)
                 if totalLabel then totalLabel:setText(itemData.total) end
 
                 local itemDisplay = card:recursiveGetChildById('itemDisplay')
-                if itemDisplay and previewItemId > 0 then
-                    itemDisplay:setItemId(previewItemId)
+                if itemDisplay and itemData.itemId then
+                    itemDisplay:setItemId(itemData.itemId)
                     if itemName and itemName ~= "" then
                         itemDisplay:setTooltip(itemName)
                     end
@@ -408,19 +334,19 @@ function TaskWeekly.loadData(data)
                 if modules.game_quickloot and modules.game_quickloot.QuickLoot then
                     local ql = modules.game_quickloot.QuickLoot
                     local activeFilter = ql.data and ql.data.filter or 1
-                    if activeFilter == 1 and ql.lootExists(previewItemId, 1) then
+                    if activeFilter == 1 and ql.lootExists(itemData.itemId, 1) then
                         quickLootWarning = true
                         quickLootTooltip = tr('This item is marked as skipped in Quick Loot.')
-                    elseif activeFilter == 2 and not ql.lootExists(previewItemId, 2) then
+                    elseif activeFilter == 2 and not ql.lootExists(itemData.itemId, 2) then
                         quickLootWarning = true
                         quickLootTooltip = tr(
                             'This item is not in the Accepted Loot list\nand will not be automatically looted.')
                     end
                 end
 
-                local isNotInNpcBlacklist = modules.game_npctrader
-                    and modules.game_npctrader.inWhiteList
-                    and not modules.game_npctrader.inWhiteList(previewItemId)
+                local isNotInNpcBlacklist = modules.game_npctrade
+                    and modules.game_npctrade.inWhiteList
+                    and not modules.game_npctrade.inWhiteList(itemData.itemId)
 
                 if previewPanel and quickLootWarning then
                     local redIcon = g_ui.createWidget('UIWidget', previewPanel)
@@ -448,7 +374,7 @@ function TaskWeekly.loadData(data)
 
                 -- Right-click context menu on item display
                 if itemDisplay then
-                    local itemId = previewItemId
+                    local itemId = itemData.itemId
                     itemDisplay.onMouseRelease = function(self, mousePos, mouseButton)
                         if mouseButton == MouseRightButton or (mouseButton == MouseLeftButton and g_keyboard.isCtrlPressed()) then
                             local menu = g_ui.createWidget('PopupMenu')
@@ -516,12 +442,6 @@ function TaskWeekly.loadData(data)
             layout:enableUpdates()
             layout:update()
         end
-
-        g_logger.debug(string.format(
-            '[WeeklyTask][Lua][loadData] deliveryGridCardsVisible=%d totalGridCards=%d',
-            visibleDeliveryCards,
-            deliveryGrid:getChildCount()
-        ))
     end
 
     -- XP label
@@ -722,7 +642,6 @@ function TaskWeekly.showDifficultyModal(data)
         btn.onClick = function()
             if not btn:isOn() then return end
             -- Send difficulty selection to server
-            g_logger.debug(string.format('[WeeklyTask][Lua][selectDifficulty] id=%d name=%s minLevel=%d playerLevel=%d', diff.id, diff.name, diff.minLevel, data.currentPlayerLevel))
             g_game.weeklyTaskAction(ACTION_SELECT_DIFFICULTY, diff.id)
             TaskWeekly.destroyModal()
         end
@@ -782,29 +701,57 @@ function TaskWeekly.onKillUpdate(raceId, currentKills, totalKills, isCompleted)
 
         local currentLabel = card:recursiveGetChildById('currentLabel')
         if currentLabel and currentLabel:isVisible() then
-            if (card.taskRaceId or -1) == raceId then
-                currentLabel:setText(currentKills)
-                if isCompleted == 1 then
-                    currentLabel:setVisible(false)
-                    local ofLabel = card:recursiveGetChildById('ofLabel')
-                    if ofLabel then ofLabel:setVisible(false) end
-                    local totalLabel = card:recursiveGetChildById('totalLabel')
-                    if totalLabel then totalLabel:setVisible(false) end
+            -- We need to identify which card corresponds to this raceId
+            -- The card order matches the monster data order from onServerData
+            -- We'll update by matching the current/total values or creature
+            local creature = card:recursiveGetChildById('creature')
+            if creature and creature:isVisible() then
+                local outfit = creature:getOutfit()
+                local raceData = g_things.getRaceData(raceId)
+                if raceData and raceData.outfit and outfit and outfit.type == raceData.outfit.type then
+                    currentLabel:setText(currentKills)
+                    if isCompleted == 1 then
+                        currentLabel:setVisible(false)
+                        local ofLabel = card:recursiveGetChildById('ofLabel')
+                        if ofLabel then ofLabel:setVisible(false) end
+                        local totalLabel = card:recursiveGetChildById('totalLabel')
+                        if totalLabel then totalLabel:setVisible(false) end
 
-                    local existingIcon = card:getChildById('finishedIcon')
-                    if existingIcon then
-                        existingIcon:destroy()
+                        local checkIcon = g_ui.createWidget('UIWidget', card)
+                        checkIcon:setId('finishedIcon')
+                        checkIcon:setSize({ width = 12, height = 9 })
+                        checkIcon:setImageSource('/images/ui/icon-yes')
+                        checkIcon:addAnchor(AnchorHorizontalCenter, 'currentLabel', AnchorHorizontalCenter)
+                        checkIcon:addAnchor(AnchorVerticalCenter, 'previewPanel', AnchorVerticalCenter)
+                        checkIcon:setPhantom(true)
                     end
-
-                    local checkIcon = g_ui.createWidget('UIWidget', card)
-                    checkIcon:setId('finishedIcon')
-                    checkIcon:setSize({ width = 12, height = 9 })
-                    checkIcon:setImageSource('/images/ui/icon-yes')
-                    checkIcon:addAnchor(AnchorHorizontalCenter, 'currentLabel', AnchorHorizontalCenter)
-                    checkIcon:addAnchor(AnchorVerticalCenter, 'previewPanel', AnchorVerticalCenter)
-                    checkIcon:setPhantom(true)
+                    return
                 end
-                return
+            elseif raceId == 0 then
+                -- "Any Creature" slot: no creature widget visible, has anyCreatureIcon
+                local previewPanel = card:recursiveGetChildById('previewPanel')
+                if previewPanel then
+                    local anyIcon = previewPanel:getChildById('anyCreatureIcon')
+                    if anyIcon then
+                        currentLabel:setText(currentKills)
+                        if isCompleted == 1 then
+                            currentLabel:setVisible(false)
+                            local ofLabel = card:recursiveGetChildById('ofLabel')
+                            if ofLabel then ofLabel:setVisible(false) end
+                            local totalLabel = card:recursiveGetChildById('totalLabel')
+                            if totalLabel then totalLabel:setVisible(false) end
+
+                            local checkIcon = g_ui.createWidget('UIWidget', card)
+                            checkIcon:setId('finishedIcon')
+                            checkIcon:setSize({ width = 12, height = 9 })
+                            checkIcon:setImageSource('/images/ui/icon-yes')
+                            checkIcon:addAnchor(AnchorHorizontalCenter, 'currentLabel', AnchorHorizontalCenter)
+                            checkIcon:addAnchor(AnchorVerticalCenter, 'previewPanel', AnchorVerticalCenter)
+                            checkIcon:setPhantom(true)
+                        end
+                        return
+                    end
+                end
             end
         end
     end

--- a/modules/game_task_hunt/styles/bounty-preferred.otui
+++ b/modules/game_task_hunt/styles/bounty-preferred.otui
@@ -18,7 +18,7 @@ BountyPreferredMonsterRow < Panel
     anchors.left: creature.right
     anchors.right: parent.right
     margin-left: 6
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text: Monster
     phantom: true
@@ -27,7 +27,7 @@ BountyPreferredSlot < Panel
   height: 74
   padding: 4
 
-  // â”€â”€â”€ Unlocked: Preferred column â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  // ─── Unlocked: Preferred column ─────────────────────────
   Panel
     id: preferredCol
     anchors.top: parent.top
@@ -91,12 +91,12 @@ BountyPreferredSlot < Panel
         anchors.right: costIcon.left
         anchors.bottom: parent.bottom
         margin-right: 2
-        font: $var-cip-font
+        font: $var-cip-main-font
         color: $var-text-cip-color
         text-align: right
         text: 10
 
-  // â”€â”€â”€ Unlocked: Unwanted column â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  // ─── Unlocked: Unwanted column ──────────────────────────
   Panel
     id: unwantedCol
     anchors.top: parent.top
@@ -161,12 +161,12 @@ BountyPreferredSlot < Panel
         anchors.right: costIcon.left
         anchors.bottom: parent.bottom
         margin-right: 2
-        font: $var-cip-font
+        font: $var-cip-main-font
         color: $var-text-cip-color
         text-align: right
         text: 10
 
-  // â”€â”€â”€ Locked state (two lines) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  // ─── Locked state (two lines) ──────────────────────────
   Panel
     id: lockedContainer
     width: 257
@@ -181,7 +181,7 @@ BountyPreferredSlot < Panel
       anchors.top: parent.top
       anchors.horizontalCenter: parent.horizontalCenter
       margin-top: 8
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-auto-resize: true
       !text: tr('Additional Slots')
@@ -230,7 +230,7 @@ BountyPreferredSlot < Panel
         anchors.right: unlockCostIcon.left
         anchors.bottom: parent.bottom
         margin-right: 2
-        font: $var-cip-font
+        font: $var-cip-main-font
         color: $var-text-cip-color
         text-align: right
         text: 0
@@ -247,7 +247,7 @@ BountyPreferredWindow < Window
   draggable: false
   !text: tr('Preferred List')
 
-  // â”€â”€â”€ Left panel: Monster list â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  // ─── Left panel: Monster list ───────────────────────────
   Panel
     id: leftPanel
     anchors.top: parent.top
@@ -310,7 +310,7 @@ BountyPreferredWindow < Window
         step: 28
         pixels-scroll: true
 
-  // â”€â”€â”€ Right panel: Slots â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+  // ─── Right panel: Slots ─────────────────────────────────
   Panel
     id: rightPanel
     anchors.top: parent.top
@@ -332,7 +332,7 @@ BountyPreferredWindow < Window
       anchors.left: parent.left
       margin-top: 2
       margin-left: 40
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-auto-resize: true
       !text: tr('Preferred')
@@ -352,7 +352,7 @@ BountyPreferredWindow < Window
       anchors.left: parent.horizontalCenter
       margin-top: 2
       margin-left: 20
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-auto-resize: true
       !text: tr('Unwanted')

--- a/modules/game_task_hunt/styles/bounty-tasks.otui
+++ b/modules/game_task_hunt/styles/bounty-tasks.otui
@@ -27,7 +27,7 @@ BountySetupWindow < StaticWindow
     anchors.verticalCenter: parent.verticalCenter
     anchors.left: prev.right
     margin-left: 25
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
     !text: tr('Task Difficulty')
@@ -93,7 +93,7 @@ BountySetupWindow < StaticWindow
       anchors.right: claimDailyIcon.left
       anchors.bottom: parent.bottom
       margin-right: 2
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: right
       text: 0
@@ -146,7 +146,7 @@ BountySetupWindow < StaticWindow
       id: btnLabel
       anchors.centerIn: parent
       margin-left: 12
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color-white
       text-align: center
       !text: tr('Boost Kills')
@@ -171,7 +171,7 @@ BountyTaskPanel < Panel
       anchors.left: parent.left
       anchors.right: parent.right
       anchors.verticalCenter: parent.verticalCenter
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
       text: Monstro 1
@@ -197,7 +197,7 @@ BountyTaskPanel < Panel
     anchors.top: previewPanel.bottom
     anchors.horizontalCenter: parent.horizontalCenter
     margin-top: 4
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
     text-align: center
@@ -217,7 +217,7 @@ BountyTaskPanel < Panel
     anchors.left: parent.left
     margin-top: 2
     margin-left: 10
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
     text: Reward:
@@ -228,7 +228,7 @@ BountyTaskPanel < Panel
     anchors.left: parent.left
     margin-top: 8
     margin-left: 20
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
     text: 160 XP
@@ -238,7 +238,7 @@ BountyTaskPanel < Panel
     anchors.verticalCenter: rewardXpLabel.verticalCenter
     anchors.left: parent.left
     margin-left: 12
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text: *
     phantom: true
@@ -249,7 +249,7 @@ BountyTaskPanel < Panel
     anchors.left: parent.left
     margin-top: 2
     margin-left: 20
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
     text: 3
@@ -259,7 +259,7 @@ BountyTaskPanel < Panel
     anchors.verticalCenter: rewardPointsLabel.verticalCenter
     anchors.left: parent.left
     margin-left: 12
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text: *
     phantom: true
@@ -279,7 +279,7 @@ BountyTaskPanel < Panel
     anchors.left: parent.left
     margin-top: 2
     margin-left: 20
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
     text: 3
@@ -289,7 +289,7 @@ BountyTaskPanel < Panel
     anchors.verticalCenter: rewardRerollLabel.verticalCenter
     anchors.left: parent.left
     margin-left: 12
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text: *
     phantom: true
@@ -358,7 +358,7 @@ TalismanEntry < Panel
     anchors.top: entryIcon.top
     anchors.left: entryIcon.right
     margin-left: 6
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
 
@@ -367,7 +367,7 @@ TalismanEntry < Panel
     anchors.top: entryTitle.bottom
     anchors.left: entryTitle.left
     margin-top: 6
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-auto-resize: true
 
@@ -405,7 +405,7 @@ TalismanEntry < Panel
       anchors.right: costIcon.left
       anchors.bottom: parent.bottom
       margin-right: 2
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: right
       text: 0

--- a/modules/game_task_hunt/styles/task-shop.otui
+++ b/modules/game_task_hunt/styles/task-shop.otui
@@ -51,7 +51,7 @@ ShopItemCard < Window
     anchors.bottom: previewPanel.bottom
     margin-left: 4
     margin-right: 4
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: topLeft
     text-wrap: true

--- a/modules/game_task_hunt/styles/weekly-tasks.otui
+++ b/modules/game_task_hunt/styles/weekly-tasks.otui
@@ -30,7 +30,7 @@ KillTaskCard < Window
     margin-left: 2
     margin-top: 10
     height: 16
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: #ff0000
     text-align: center
     text: 0
@@ -42,7 +42,7 @@ KillTaskCard < Window
     anchors.top: currentLabel.bottom
     margin-left: 2
     height: 14
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: center
     text: of
@@ -54,7 +54,7 @@ KillTaskCard < Window
     anchors.top: ofLabel.bottom
     margin-left: 2
     height: 16
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: center
     text: 0
@@ -91,7 +91,7 @@ DeliveryTaskCard < Window
     anchors.top: previewPanel.top
     margin-left: 2
     height: 16
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: #ff0000
     text-align: center
     text: 0
@@ -103,7 +103,7 @@ DeliveryTaskCard < Window
     anchors.top: currentLabel.bottom
     margin-left: 2
     height: 14
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: center
     text: of
@@ -115,7 +115,7 @@ DeliveryTaskCard < Window
     anchors.top: ofLabel.bottom
     margin-left: 2
     height: 16
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: center
     text: 0
@@ -154,7 +154,7 @@ ShopPermButton < UIWidget
   Label
     id: unlockLabel
     anchors.centerIn: parent
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color-white
     text-align: center
     !text: tr('Unlock permanently')
@@ -191,7 +191,7 @@ WeeklyProgressWindow < StaticWindow
     anchors.left: parent.left
     width: 130
     height: 18
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: left
 
@@ -202,7 +202,7 @@ WeeklyProgressWindow < StaticWindow
     anchors.left: parent.left
     width: 130
     height: 18
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: left
 
@@ -220,27 +220,27 @@ WeeklyProgressWindow < StaticWindow
 
     Label
       text: x1
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
       text: x2
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
       text: x3
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
       text: x5
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
       text: x8
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
 
@@ -303,7 +303,7 @@ WeeklyProgressWindow < StaticWindow
       anchors.bottom: parent.bottom
       anchors.left: parent.left
       width: 30
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: left
     Label
@@ -313,7 +313,7 @@ WeeklyProgressWindow < StaticWindow
       anchors.left: parent.left
       margin-left: 112
       width: 30
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
@@ -323,7 +323,7 @@ WeeklyProgressWindow < StaticWindow
       anchors.left: parent.left
       margin-left: 239
       width: 30
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
@@ -333,7 +333,7 @@ WeeklyProgressWindow < StaticWindow
       anchors.left: parent.left
       margin-left: 366
       width: 30
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
@@ -343,7 +343,7 @@ WeeklyProgressWindow < StaticWindow
       anchors.left: parent.left
       margin-left: 493
       width: 30
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
     Label
@@ -352,7 +352,7 @@ WeeklyProgressWindow < StaticWindow
       anchors.bottom: parent.bottom
       anchors.right: parent.right
       width: 30
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: right
 
@@ -404,7 +404,7 @@ WeeklyRewardsWindow < Window
     anchors.left: parent.left
     anchors.right: parent.right
     height: 16
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: center
     !text: tr('7 day(s) remaining')
@@ -450,7 +450,7 @@ WeeklyDifficultyModal < StaticWindow
       anchors.left: parent.left
       anchors.right: parent.right
       height: 16
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
 
@@ -460,7 +460,7 @@ WeeklyDifficultyModal < StaticWindow
       anchors.left: parent.left
       anchors.right: parent.right
       height: 16
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
 
@@ -471,7 +471,7 @@ WeeklyDifficultyModal < StaticWindow
       anchors.right: parent.right
       margin-top: 2
       height: 16
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       text-align: center
 
@@ -482,7 +482,7 @@ WeeklyDifficultyModal < StaticWindow
     anchors.right: parent.right
     margin-top: 20
     height: 30
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: center
     !text: tr('Select the difficulty for your next tasks.')

--- a/modules/game_task_hunt/tasks.lua
+++ b/modules/game_task_hunt/tasks.lua
@@ -1,8 +1,6 @@
 taskHuntWindow = nil
 taskHuntButton = nil
 
-local TASK_BOARD_AUX_OPCODE = 205
-
 local tabButtons = {}
 local contentPanels = {}
 
@@ -37,15 +35,9 @@ function init()
     g_ui.importStyle('styles/weekly-tasks')
 
     taskHuntWindow = g_ui.displayUI('tasks')
-    if not taskHuntWindow then
-        g_logger.error("[game_task_hunt] Failed to load tasks.otui")
-        return
-    end
     taskHuntWindow:hide()
 
-    if UIModalOverlay and UIModalOverlay.register then
-        UIModalOverlay.register(taskHuntWindow)
-    end
+    UIModalOverlay.register(taskHuntWindow)
 
     for i, config in ipairs(tabConfig) do
         local btn = taskHuntWindow:recursiveGetChildById(config.buttonId)
@@ -92,19 +84,15 @@ function init()
         TaskShop.init(shopPanel)
     end
 
-    if not taskHuntButton and modules.client_topmenu and modules.client_topmenu.addRightGameToggleButton then
-        taskHuntButton = modules.client_topmenu.addRightGameToggleButton(
+    if not taskHuntButton then
+        taskHuntButton = modules.game_mainpanel.addToggleButton(
             "taskHuntButton",
             tr("Task Hunt"),
-            "/images/topbuttons/taskHuntDialog",
+            "/images/options/button_taskboard",
             toggle,
             false,
             1006
         )
-    end
-
-    if ProtocolGame and ProtocolGame.registerExtendedOpcode then
-        ProtocolGame.registerExtendedOpcode(TASK_BOARD_AUX_OPCODE, onTaskBoardAuxOpcode)
     end
 
     connect(g_game, {
@@ -137,10 +125,6 @@ function terminate()
     tabButtons = {}
     contentPanels = {}
 
-    if ProtocolGame and ProtocolGame.unregisterExtendedOpcode then
-        ProtocolGame.unregisterExtendedOpcode(TASK_BOARD_AUX_OPCODE)
-    end
-
     disconnect(g_game, {
         onResourcesBalanceChange = onResourceBalance,
         onTaskHuntingShopData = TaskShop.onShopData,
@@ -152,26 +136,6 @@ function terminate()
         onBountyPreferredData = BountyPreferred.onServerData,
         onGameEnd = hide,
     })
-end
-
-function onTaskBoardAuxOpcode(protocol, opcode, buffer)
-    local ok, payload = pcall(json.decode, buffer)
-    if not ok or not payload or not payload.action then
-        return
-    end
-
-    local action = payload.action
-    local data = payload.data or {}
-
-    if action == 'shopResult' then
-        g_game.onTaskHuntingShopResult(data.itemId or 0, data.result or 0)
-    elseif action == 'bountyKillUpdate' then
-        g_game.onBountyKillUpdate(data.raceId or 0, data.currentKills or 0, data.totalKills or 0, data.isCompleted or 0)
-    elseif action == 'weeklyKillUpdate' then
-        g_game.onWeeklyKillUpdate(data.raceId or 0, data.currentKills or 0, data.totalKills or 0, data.isCompleted or 0)
-    elseif action == 'soulsealData' then
-        g_game.onSoulsealsData(data.entries or {})
-    end
 end
 
 function show()
@@ -260,7 +224,7 @@ function onResourceBalance(balance, oldBalance, resourceType)
         TaskShop.updateBalance(balance)
     end
 
-    if resourceType == ResourceTypes.SOULSEALS then
+    if resourceType == ResourceTypes.SOULSEAL_POINTS then
         local panel = taskHuntWindow:recursiveGetChildById('soulpitPoints')
         if panel then
             local label = panel:recursiveGetChildById('panelLabel')
@@ -268,7 +232,7 @@ function onResourceBalance(balance, oldBalance, resourceType)
         end
     end
 
-    if resourceType == ResourceTypes.BOUNTY_POINTS then
+    if resourceType == ResourceTypes.BOUNTY_TASK_POINTS then
         local panel = taskHuntWindow:recursiveGetChildById('bountyPoints')
         if panel then
             local label = panel:recursiveGetChildById('panelLabel')

--- a/modules/game_task_hunt/tasks.otui
+++ b/modules/game_task_hunt/tasks.otui
@@ -22,7 +22,7 @@ InfoPanel < Panel
     anchors.right: panelIcon.left
     anchors.bottom: parent.bottom
     margin-right: 2
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     text-align: right
     text: 0
@@ -31,7 +31,7 @@ TaskHuntTabButton < UIButton
   height: 33
   image-source: /images/ui/2pixel_up_frame_borderimage
   image-border: 30
-  font: $var-cip-font
+  font: $var-cip-main-font
   color: $var-text-cip-color
   phantom: false
 
@@ -50,7 +50,7 @@ TaskHuntTabButton < UIButton
     anchors.right: parent.right
     anchors.bottom: parent.bottom
     text-align: center
-    font: $var-cip-font
+    font: $var-cip-main-font
     color: $var-text-cip-color
     phantom: true
 
@@ -187,7 +187,7 @@ NewMainWindow
         Label
           id: btnLabel
           anchors.centerIn: parent
-          font: $var-cip-font
+          font: $var-cip-main-font
           color: $var-text-cip-color-white
           text-align: center
           !text: tr('Boost Kills')
@@ -267,7 +267,7 @@ NewMainWindow
         Label
           id: btnLabel
           anchors.centerIn: parent
-          font: $var-cip-font
+          font: $var-cip-main-font
           color: $var-text-cip-color-white
           text-align: center
           !text: tr('Reduce Item Amount')
@@ -319,7 +319,7 @@ NewMainWindow
       margin-right: 10
       height: 16
       text-align: center
-      font: $var-cip-font
+      font: $var-cip-main-font
       color: $var-text-cip-color
       !text: tr('Each task rewards you with %d XP.', 0)
 

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -439,6 +439,9 @@ void Application::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_ui", "isDrawingDebugBoxes", &UIManager::isDrawingDebugBoxes, &g_ui);
     g_lua.bindSingletonFunction("g_ui", "isMouseGrabbed", &UIManager::isMouseGrabbed, &g_ui);
     g_lua.bindSingletonFunction("g_ui", "isKeyboardGrabbed", &UIManager::isKeyboardGrabbed, &g_ui);
+    g_lua.bindSingletonFunction("g_ui", "setGlobalVariable", &UIManager::setGlobalVariable, &g_ui);
+    g_lua.bindSingletonFunction("g_ui", "getGlobalVariable", &UIManager::getGlobalVariable, &g_ui);
+    g_lua.bindSingletonFunction("g_ui", "clearGlobalVariables", &UIManager::clearGlobalVariables, &g_ui);
     g_lua.bindSingletonFunction("g_ui", "hasOTUIVar", &UIManager::hasOTUIVar, &g_ui);
     g_lua.bindSingletonFunction("g_ui", "getOTUIVar", &UIManager::getOTUIVar, &g_ui);
     g_lua.bindSingletonFunction("g_ui", "getOTUIVarSafe", &UIManager::getOTUIVarSafe, &g_ui);

--- a/src/framework/otml/otmlparser.cpp
+++ b/src/framework/otml/otmlparser.cpp
@@ -23,6 +23,7 @@
 #include "otmlparser.h"
 #include "otmldocument.h"
 #include "otmlexception.h"
+#include <framework/ui/uimanager.h>
 #include <boost/tokenizer.hpp>
 
 OTMLParser::OTMLParser(OTMLDocumentPtr doc, std::istream& in) :
@@ -197,6 +198,11 @@ void OTMLParser::parseNode(const std::string& data)
             }
         } else
             node->setValue(value);
+    }
+
+    if((stdext::starts_with(tag, "$var-") || stdext::starts_with(tag, "&var-")) && !value.empty()) {
+        g_ui.setGlobalVariable(tag.substr(5), value);
+        return;
     }
 
     currentParent->addChild(node);

--- a/src/framework/ui/uimanager.cpp
+++ b/src/framework/ui/uimanager.cpp
@@ -62,6 +62,32 @@ void UIManager::terminate()
     m_hoveredText.clear();
 }
 
+void UIManager::setGlobalVariable(const std::string& name, const std::string& value)
+{
+    if(stdext::starts_with(name, "$var-") || stdext::starts_with(name, "&var-"))
+        addOTUIVar(name.substr(5), value);
+    else
+        addOTUIVar(name, value);
+}
+
+std::string UIManager::getGlobalVariable(const std::string& name)
+{
+    std::string key = name;
+    if(stdext::starts_with(key, "$var-") || stdext::starts_with(key, "&var-"))
+        key = key.substr(5);
+
+    const auto it = m_vars.find(key);
+    if(it == m_vars.end())
+        return "";
+
+    return it->second;
+}
+
+void UIManager::clearGlobalVariables()
+{
+    m_vars.clear();
+}
+
 void UIManager::render(Fw::DrawPane drawPane)
 {
     m_rootWidget->draw(m_rootWidget->getRect(), drawPane);
@@ -386,6 +412,7 @@ void UIManager::onWidgetDestroy(const UIWidgetPtr& widget)
 void UIManager::clearStyles()
 {
     m_styles.clear();
+    clearGlobalVariables();
 }
 
 bool UIManager::importStyle(std::string file)
@@ -422,7 +449,7 @@ void UIManager::importStyleFromOTML(const OTMLNodePtr& styleNode)
     std::string tag = styleNode->tag();
 
     // parse otui variable
-    if (stdext::starts_with(tag, "$var-")) {
+    if (stdext::starts_with(tag, "$var-") || stdext::starts_with(tag, "&var-")) {
         std::string var = tag.substr(5);
         addOTUIVar(var, styleNode->rawValue());
         return;
@@ -541,7 +568,7 @@ UIWidgetPtr UIManager::loadUI(std::string file, const UIWidgetPtr& parent)
         for(const OTMLNodePtr& node : doc->children()) {
             std::string tag = node->tag();
             // parse otui variable
-            if (stdext::starts_with(tag, "$var-")) {
+            if (stdext::starts_with(tag, "$var-") || stdext::starts_with(tag, "&var-")) {
                 std::string var = tag.substr(5);
                 addOTUIVar(var, node->rawValue());
                 continue;
@@ -620,7 +647,7 @@ void UIManager::mergeStyle(std::string file, const UIWidgetPtr& widget)
         for (const OTMLNodePtr& node : doc->children()) {
             std::string tag = node->tag();
             // parse otui variable
-            if (stdext::starts_with(tag, "$var-")) {
+            if (stdext::starts_with(tag, "$var-") || stdext::starts_with(tag, "&var-")) {
                 std::string var = tag.substr(5);
                 addOTUIVar(var, node->rawValue());
                 continue;

--- a/src/framework/ui/uimanager.h
+++ b/src/framework/ui/uimanager.h
@@ -76,6 +76,10 @@ public:
 
     bool isDrawingDebugBoxes() { return m_drawDebugBoxes; }
 
+    void setGlobalVariable(const std::string& name, const std::string& value);
+    std::string getGlobalVariable(const std::string& name);
+    void clearGlobalVariables();
+
     const OTUIVars& getOTUIVars() {
         return m_vars;
     }
@@ -83,10 +87,16 @@ public:
         if (stdext::starts_with(key, "$var-")) {
             return m_vars.find(key.substr(5)) != m_vars.end();
         }
+        if (stdext::starts_with(key, "&var-")) {
+            return m_vars.find(key.substr(5)) != m_vars.end();
+        }
         return m_vars.find(key) != m_vars.end();
     }
     std::string getOTUIVar(const std::string& key) {
         if (stdext::starts_with(key, "$var-")) {
+            return m_vars[key.substr(5)];
+        }
+        if (stdext::starts_with(key, "&var-")) {
             return m_vars[key.substr(5)];
         }
         return m_vars[key];
@@ -96,6 +106,9 @@ public:
             return key;
         }
         if (stdext::starts_with(key, "$var-")) {
+            return m_vars[key.substr(5)];
+        }
+        if (stdext::starts_with(key, "&var-")) {
             return m_vars[key.substr(5)];
         }
         return m_vars[key];

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -648,6 +648,15 @@ void UIWidget::applyStyle(const OTMLNodePtr& styleNode)
             }
         }
 
+        for(const OTMLNodePtr& node : styleNode->children()) {
+            const std::string rawValue = node->rawValue();
+            if(stdext::starts_with(rawValue, "$var-")) {
+                const std::string value = g_ui.getGlobalVariable(rawValue.substr(5));
+                if(!value.empty())
+                    node->setValue(value);
+            }
+        }
+
         onStyleApply(styleNode->tag(), styleNode);
         callLuaField("onStyleApply", styleNode->tag(), styleNode);
 


### PR DESCRIPTION
## What changed

- Ported the task hunt UI/styles/assets from the referenced otclient task hunt commit.
- Added OTUI global variable support so `$var-*` references resolve from `&var-*` definitions before style and Lua color casts.
- Added `UIModalOverlay` support and a local-compatible `game_mainpanel` shim so the task hunt module loads in AstraClient's existing UI architecture.
- Wired `game_mainpanel` into `game_interface` load order.

## Why

The task hunt module depended on UI runtime pieces from the reference fork that were not present or not compatible with this AstraClient checkout. Without these adaptations, startup failed on unresolved `$var-*` colors, missing `UIModalOverlay`, and missing `modules.game_mainpanel`.

## Validation

- `git diff --cached --check`
- `MSBuild vc17/otclient.sln /m /p:Configuration=DirectX /p:Platform=x64 /v:minimal`

MSBuild completed successfully and generated `otclient_dx_x64.exe`; the only warning was the existing duplicate vcpkg import warning (`MSB4011`).