### PR TITLE
feat: Task Board native byte protocol — fix parsers and remove JSON dependency

### DIFF
--- a/modules/game_task_hunt/classes/bounty-tasks.lua
+++ b/modules/game_task_hunt/classes/bounty-tasks.lua
@@ -132,6 +132,11 @@ function TaskBounty.onServerData(header, monsters, talisman, preferreds)
     monsters = monsters or {}
     talisman = talisman or {}
 
+    -- Forward preferred data to BountyPreferred module
+    if preferreds and BountyPreferred and BountyPreferred.onServerData then
+        BountyPreferred.onServerData(preferreds, 0, {})
+    end
+
     -- Always update the kill tracker
     TaskBounty.updateTracker(monsters)
 

--- a/modules/game_task_hunt/classes/task-shop.lua
+++ b/modules/game_task_hunt/classes/task-shop.lua
@@ -38,30 +38,10 @@ function TaskShop.onShopData(items)
 end
 
 function TaskShop.onShopResult(itemId, result)
-    if result == 0 then
-        -- success; server will send updated ShopData automatically
-        return
-    end
-
-    local errorMessages = {
-        [1] = "Item not found.",
-        [2] = "Already purchased.",
-        [3] = "Not enough Hunting Task Points.",
-        [4] = "You need the base outfit first.",
-        [5] = "Store inbox error."
-    }
-
-    local msg = errorMessages[result] or ("Purchase failed (code " .. result .. ").")
-    local errorBox
-    local function closeCallback()
-        if errorBox then
-            errorBox:destroy()
-            errorBox = nil
-        end
-    end
-    errorBox = displayGeneralBox(tr('Purchase Failed'), msg,
-        { { text = tr('Ok'), callback = closeCallback } },
-        closeCallback, closeCallback)
+    -- Native protocol: server sends full shop data refresh after purchase.
+    -- This function is kept as a no-op stub for compatibility.
+    -- Error display is handled by the server sending updated shop data
+    -- where the item's "bought" status reflects the result.
 end
 
 function TaskShop.rebuild()

--- a/modules/game_task_hunt/tasks.lua
+++ b/modules/game_task_hunt/tasks.lua
@@ -1,8 +1,6 @@
 taskHuntWindow = nil
 taskHuntButton = nil
 
-local TASK_BOARD_AUX_OPCODE = 205
-
 local tabButtons = {}
 local contentPanels = {}
 
@@ -97,17 +95,11 @@ function init()
         )
     end
 
-    ProtocolGame.registerExtendedOpcode(TASK_BOARD_AUX_OPCODE, onTaskBoardAuxOpcode)
-
     connect(g_game, {
         onResourceBalance = onResourceBalance,
         onTaskHuntingShopData = TaskShop.onShopData,
-        onTaskHuntingShopResult = TaskShop.onShopResult,
         onWeeklyTaskData = TaskWeekly.onServerData,
         onBountyTaskData = TaskBounty.onServerData,
-        onBountyKillUpdate = TaskBounty.onKillUpdate,
-        onWeeklyKillUpdate = TaskWeekly.onKillUpdate,
-        onBountyPreferredData = BountyPreferred.onServerData,
         onGameEnd = hide,
     })
 end
@@ -129,70 +121,13 @@ function terminate()
     tabButtons = {}
     contentPanels = {}
 
-    ProtocolGame.unregisterExtendedOpcode(TASK_BOARD_AUX_OPCODE)
-
     disconnect(g_game, {
         onResourceBalance = onResourceBalance,
         onTaskHuntingShopData = TaskShop.onShopData,
-        onTaskHuntingShopResult = TaskShop.onShopResult,
         onWeeklyTaskData = TaskWeekly.onServerData,
         onBountyTaskData = TaskBounty.onServerData,
-        onBountyKillUpdate = TaskBounty.onKillUpdate,
-        onWeeklyKillUpdate = TaskWeekly.onKillUpdate,
-        onBountyPreferredData = BountyPreferred.onServerData,
         onGameEnd = hide,
     })
-end
-
-function onTaskBoardAuxOpcode(protocol, opcode, buffer)
-    local ok, payload = pcall(json.decode, buffer)
-    if not ok or type(payload) ~= 'table' or not payload.action then
-        return
-    end
-
-    local function firstTable(...)
-        for i = 1, select('#', ...) do
-            local value = select(i, ...)
-            if type(value) == 'table' then
-                return value
-            end
-        end
-        return {}
-    end
-
-    local action = payload.action
-    local data = firstTable(payload.data)
-
-    if action == 'bountyTaskData' or action == 'bountyData' then
-        g_game.onBountyTaskData(
-            firstTable(data.header),
-            firstTable(data.monsters, data.tasks),
-            firstTable(data.talisman, data.talismans, data.bountyTalisman),
-            firstTable(data.preferreds, data.preferred)
-        )
-    elseif action == 'preferredData' then
-        g_game.onBountyPreferredData(
-            firstTable(data.slots),
-            tonumber(data.removeCost) or 0,
-            firstTable(data.availableRaceIds)
-        )
-    elseif action == 'shopResult' then
-        g_game.onTaskHuntingShopResult(tonumber(data.itemId) or 0, tonumber(data.result) or 0)
-    elseif action == 'bountyKillUpdate' then
-        g_game.onBountyKillUpdate(
-            tonumber(data.raceId) or 0,
-            tonumber(data.currentKills) or 0,
-            tonumber(data.totalKills) or 0,
-            tonumber(data.isCompleted) or 0
-        )
-    elseif action == 'weeklyKillUpdate' then
-        g_game.onWeeklyKillUpdate(
-            tonumber(data.raceId) or 0,
-            tonumber(data.currentKills) or 0,
-            tonumber(data.totalKills) or 0,
-            tonumber(data.isCompleted) or 0
-        )
-    end
 end
 
 function show()

--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -325,6 +325,7 @@ namespace Proto {
         ClientImbuementAction               = 178,
         ClientWeaponProficiency             = 179,
         ClientPreyHuntingAction             = 186,
+        ClientTaskBoardAction               = 95,
         ClientCancelAttackAndFollow         = 190,
         ClientUpdateTile                    = 201,
         ClientRefreshContainer              = 202,

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -132,6 +132,7 @@ public:
     void sendPreyAction(int slot, int actionType, int index);
     void sendPreyHuntingAction(int slot, int actionType, bool upgrade, int raceId);
     void sendTaskBoardCommand(const std::string& action, const std::string& data = "{}");
+    void sendTaskBoardAction(uint8_t option, uint16_t value = 0, uint16_t extraValue = 0);
     void sendBountyTaskAction(int actionType, int param);
     void sendWeeklyTaskAction(int actionType, int param);
     void sendTaskHuntingShopRequest();

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4618,55 +4618,69 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
     };
 
     if (mode == 0) {
+        // --- Bounty Task Data ---
         std::vector<std::map<std::string, std::string>> monsters;
         const uint8_t slotCount = msg->getU8();
         monsters.reserve(slotCount);
         for (uint8_t i = 0; i < slotCount; ++i) {
-            msg->getU8();
+            const uint8_t taskIndex = msg->getU8();
             const uint16_t raceId = msg->getU16();
-            const uint16_t totalKills = msg->getU16();
+            const uint16_t requiredKills = msg->getU16();
             const uint32_t rewardXp = msg->getU32();
             const uint8_t rewardPoints = msg->getU8();
             const uint16_t currentKills = msg->getU16();
-            const uint8_t buttonState = msg->getU8();
-            const uint8_t rarity = msg->getU8();
+            const uint8_t claimState = msg->getU8();
+            const uint8_t grade = msg->getU8();
 
             std::map<std::string, std::string> entry;
+            entry["taskIndex"] = stringify(taskIndex);
             entry["raceId"] = stringify(raceId);
-            entry["totalKills"] = stringify(totalKills);
+            entry["totalKills"] = stringify(requiredKills);
             entry["rewardXp"] = stringify(rewardXp);
             entry["rewardPoints"] = stringify(rewardPoints);
             entry["rewardReroll"] = "1";
             entry["currentKills"] = stringify(currentKills);
-            entry["isActive"] = buttonState > 0 ? "1" : "0";
-            entry["isCompleted"] = "0";
-            entry["rarity"] = stringify(rarity);
+            entry["isActive"] = (claimState == 1 || claimState == 2) ? "1" : "0";
+            entry["isCompleted"] = claimState == 2 ? "1" : "0";
+            entry["rarity"] = stringify(grade);
             monsters.emplace_back(std::move(entry));
         }
 
         std::map<std::string, std::string> header;
         header["rerollPoints"] = stringify(msg->getU8());
-        const uint8_t rerollState = msg->getU8();
-        header["claimDaily"] = rerollState == 0 ? "1" : "0";
+        const uint8_t rerollMode = msg->getU8();
+        header["claimDaily"] = rerollMode == 0 ? "1" : "0";
         header["difficulty"] = stringify(msg->getU8() + 1);
 
         std::vector<std::map<std::string, std::string>> talisman;
         talisman.reserve(4);
         for (uint8_t i = 0; i < 4; ++i) {
-            const uint16_t currentValue = msg->getU16();
-            const bool canUpgrade = msg->getU8() != 0;
+            const uint8_t currentLevel = msg->getU8();
+            msg->getU8(); // multiplier2 unused
+            const uint8_t isActiveUpgrade = msg->getU8();
             const uint16_t upgradeCost = msg->getU16();
 
+            // Compute currentValue from level using the same formula as Mehah
+            auto computeBonus = [](uint8_t level, uint8_t path) -> uint16_t {
+                if (level == 0) return 0;
+                if (path < 3) {
+                    if (level <= 26) return static_cast<uint16_t>(250 + (static_cast<uint32_t>(level) - 1) * 50);
+                    return static_cast<uint16_t>(std::min<uint32_t>(1500 + (static_cast<uint32_t>(level) - 26) * 25, 5000));
+                }
+                if (level <= 20) return static_cast<uint16_t>(static_cast<uint32_t>(level) * 100);
+                return static_cast<uint16_t>(std::min<uint32_t>(2000 + (static_cast<uint32_t>(level) - 20) * 50, 10000));
+            };
+            const uint16_t currentValue = computeBonus(currentLevel, i);
             uint16_t nextValue = 0;
-            if (canUpgrade) {
-                const uint16_t increment = i == 3 ? 100 : 50;
-                nextValue = currentValue + increment;
+            const uint8_t maxLevel = (i == 3) ? 180 : 166;
+            if (currentLevel < maxLevel && upgradeCost > 0) {
+                nextValue = computeBonus(static_cast<uint8_t>(currentLevel + 1), i);
             }
 
             std::map<std::string, std::string> entry;
             entry["currentValue"] = stringify(currentValue);
             entry["nextValue"] = stringify(nextValue);
-            entry["canUpgrade"] = canUpgrade ? "1" : "0";
+            entry["canUpgrade"] = isActiveUpgrade != 0 ? "1" : "0";
             entry["upgradeCost"] = stringify(upgradeCost);
             talisman.emplace_back(std::move(entry));
         }
@@ -4691,15 +4705,16 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
     }
 
     if (mode == 1) {
+        // --- Weekly Task Data ---
         std::vector<std::map<std::string, std::string>> monsters;
         const uint16_t anyCreatureTotal = msg->getU16();
         const uint16_t anyCreatureCurrent = msg->getU16();
-        if (anyCreatureTotal > 0) {
+        if (anyCreatureTotal > 0 || anyCreatureCurrent > 0) {
             std::map<std::string, std::string> anyEntry;
             anyEntry["raceId"] = "0";
             anyEntry["total"] = stringify(anyCreatureTotal);
             anyEntry["current"] = stringify(anyCreatureCurrent);
-            anyEntry["state"] = anyCreatureCurrent >= anyCreatureTotal ? "1" : "0";
+            anyEntry["state"] = (anyCreatureTotal > 0 && anyCreatureCurrent >= anyCreatureTotal) ? "1" : "0";
             monsters.emplace_back(std::move(anyEntry));
         }
 
@@ -4713,52 +4728,67 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
             entry["raceId"] = stringify(raceId);
             entry["total"] = stringify(totalKills);
             entry["current"] = stringify(currentKills);
-            entry["state"] = currentKills >= totalKills ? "1" : "0";
+            entry["state"] = (totalKills > 0 && currentKills >= totalKills) ? "1" : "0";
             monsters.emplace_back(std::move(entry));
         }
 
         std::vector<std::map<std::string, std::string>> items;
         const uint8_t deliveryTaskCount = msg->getU8();
         for (uint8_t i = 0; i < deliveryTaskCount; ++i) {
-            msg->getU8();
+            const uint8_t slotIndex = msg->getU8();
             const uint16_t clientId = msg->getU16();
-            msg->getU8();
-            msg->getU8();
+            msg->getU8(); // unknown1
+            msg->getU8(); // unknown2
             const uint32_t totalItems = msg->getU32();
             const uint32_t currentItems = msg->getU32();
             const uint8_t completed = msg->getU8();
 
             std::map<std::string, std::string> entry;
+            entry["slotIndex"] = stringify(slotIndex);
             entry["itemId"] = stringify(clientId);
             entry["clientId"] = stringify(clientId);
             entry["total"] = stringify(totalItems);
             entry["current"] = stringify(currentItems);
             entry["claimed"] = completed != 0 ? "1" : "0";
-            entry["state"] = currentItems >= totalItems ? "1" : "0";
+            entry["state"] = (completed != 0 || (totalItems > 0 && currentItems >= totalItems)) ? "1" : "0";
             items.emplace_back(std::move(entry));
         }
 
-        msg->getU8();
+        const uint8_t difficultyMultiplier = msg->getU8();
         const uint32_t killTaskXp = msg->getU32();
         const uint32_t deliveryTaskXp = msg->getU32();
         const uint8_t completedKillTasks = msg->getU8();
         const uint8_t completedDeliveryTasks = msg->getU8();
-        const uint8_t showDifficultySelection = msg->getU8();
-        const uint8_t maxDifficulty = msg->getU8();
-        const uint8_t unlocked = msg->getU8();
+        const uint8_t weeklyProgressFinished = msg->getU8();
+        const uint8_t unlockedDifficulty = msg->getU8();
+        const uint32_t resetTimestamp = msg->getU32();
+        const uint8_t weeklyTaskExpansion = msg->getU8();
         const uint32_t taskPoints = msg->getU32();
         const uint32_t soulseals = msg->getU32();
 
+        // Compute remaining days from reset timestamp
+        auto getRemainingDays = [](uint32_t ts) -> uint8_t {
+            if (ts == 0) return 0;
+            const auto now = static_cast<uint32_t>(std::time(nullptr));
+            if (ts <= now) return 0;
+            const auto secs = ts - now;
+            const auto days = (secs + 86399) / 86400;
+            return static_cast<uint8_t>(std::min<uint32_t>(days, 255));
+        };
+
+        const bool hasGeneratedTasks = anyCreatureTotal > 0 || anyCreatureCurrent > 0
+            || killTaskCount > 0 || deliveryTaskCount > 0 || weeklyProgressFinished != 0;
+
         std::map<std::string, std::string> header;
-        header["difficulty"] = showDifficultySelection != 0 ? "0" : stringify(std::max<uint8_t>(1, maxDifficulty + 1));
-        header["remainingDays"] = "7";
-        header["totalTaskSlots"] = stringify(monsters.size() > 6 || items.size() > 6 ? 9 : 6);
+        header["difficulty"] = hasGeneratedTasks ? stringify(std::max<uint8_t>(1, difficultyMultiplier + 1)) : "0";
+        header["remainingDays"] = stringify(getRemainingDays(resetTimestamp));
+        header["totalTaskSlots"] = weeklyTaskExpansion != 0 ? "9" : "6";
         header["maxExperience"] = stringify(killTaskXp);
         header["maxDeliveryExperience"] = stringify(deliveryTaskXp);
         header["completedKillTasks"] = stringify(completedKillTasks);
         header["completedDeliveryTasks"] = stringify(completedDeliveryTasks);
 
-        const uint8_t difficultyId = std::max<uint8_t>(1, maxDifficulty + 1);
+        const uint8_t difficultyId = std::max<uint8_t>(1, difficultyMultiplier + 1);
         static const uint8_t killTaskPointsByDifficulty[4] = { 25, 50, 100, 110 };
         header["killTaskPoints"] = stringify(killTaskPointsByDifficulty[std::min<uint8_t>(3, difficultyId - 1)]);
         header["deliveryTaskPoints"] = "75";
@@ -4766,25 +4796,27 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
 
         const uint8_t totalCompleted = completedKillTasks + completedDeliveryTasks;
         uint8_t rewardMultiplier = 1;
-        if (totalCompleted >= 16)
+        if (totalCompleted >= 17)
             rewardMultiplier = 8;
-        else if (totalCompleted >= 12)
+        else if (totalCompleted >= 13)
             rewardMultiplier = 5;
-        else if (totalCompleted >= 8)
+        else if (totalCompleted >= 9)
             rewardMultiplier = 3;
-        else if (totalCompleted >= 4)
+        else if (totalCompleted >= 5)
             rewardMultiplier = 2;
 
         header["rewardMultiplier"] = stringify(rewardMultiplier);
         header["pointsEarned"] = stringify(taskPoints);
         header["soulsealsEarned"] = stringify(soulseals);
-        header["extraSlot"] = unlocked != 0 ? "1" : "0";
-        header["unlocked"] = unlocked != 0 ? "1" : "0";
+        header["extraSlot"] = weeklyTaskExpansion != 0 ? "1" : "0";
+        header["unlocked"] = weeklyTaskExpansion != 0 ? "1" : "0";
+        header["weeklyProgressFinished"] = stringify(weeklyProgressFinished);
+        header["unlockedDifficulty"] = stringify(std::clamp<uint8_t>(unlockedDifficulty + 1, 1, 4));
 
         std::vector<std::map<std::string, std::string>> difficulties;
         static const char* difficultyNames[4] = { "Beginner", "Adept", "Expert", "Master" };
         static const uint16_t difficultyMinLevels[4] = { 1, 150, 300, 500 };
-        for (uint8_t i = 0; i <= std::min<uint8_t>(3, maxDifficulty); ++i) {
+        for (uint8_t i = 0; i <= std::min<uint8_t>(3, unlockedDifficulty); ++i) {
             std::map<std::string, std::string> entry;
             entry["id"] = stringify(i + 1);
             entry["name"] = difficultyNames[i];
@@ -4797,60 +4829,78 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
     }
 
     if (mode == 2) {
+        // --- Hunt Shop Data ---
         std::vector<std::map<std::string, std::string>> items;
         const uint8_t itemCount = msg->getU8();
         items.reserve(itemCount);
         for (uint8_t i = 0; i < itemCount; ++i) {
             const uint8_t type = msg->getU8();
-            const std::string name = msg->getString();
-            const std::string desc = msg->getString();
-            const uint32_t clientId = msg->getU32();
 
             std::map<std::string, std::string> entry;
             entry["id"] = stringify(i + 1);
-            entry["title"] = name;
-            entry["description"] = desc;
+            entry["offerType"] = stringify(type);
 
-            if (type == 3)
-                entry["extraClientId"] = stringify(msg->getU32());
+            if (type == 4) {
+                // BONUS_PROMOTION: different layout
+                const uint16_t purchasedDisplay = msg->getU16();
+                const uint32_t nextCost = msg->getU32();
+                const uint8_t status = msg->getU8();
+                entry["title"] = "Bonus Promotion";
+                entry["description"] = "";
+                entry["price"] = stringify(nextCost);
+                entry["nextCost"] = stringify(nextCost);
+                entry["currentPurchases"] = stringify(purchasedDisplay > 0 ? purchasedDisplay - 1 : 0);
+                entry["bought"] = (status == 4 || nextCost == 0) ? "1" : "0";
+                entry["type"] = "Promotion";
+            } else {
+                const std::string name = msg->getString();
+                const std::string desc = msg->getString();
+                const uint32_t clientId = msg->getU32();
 
-            if (type == 2)
-                entry["addon"] = stringify(msg->getU8());
+                entry["title"] = name;
+                entry["description"] = desc;
 
-            const uint32_t price = msg->getU32();
-            const uint8_t buttonState = msg->getU8();
-            entry["price"] = stringify(price);
-            entry["bought"] = buttonState == 4 ? "1" : "0";
+                if (type == 2)
+                    entry["addon"] = stringify(msg->getU8());
 
-            switch (type) {
-            case 0:
-                entry["type"] = "Decoration";
-                entry["itemId"] = stringify(clientId);
-                entry["clientId"] = stringify(clientId);
-                break;
-            case 1:
-                entry["type"] = "Mount";
-                entry["lookType"] = stringify(clientId);
-                break;
-            case 2:
-                entry["type"] = "Outfit";
-                entry["lookType"] = stringify(clientId);
-                entry["lookHead"] = "0";
-                entry["lookBody"] = "0";
-                entry["lookLegs"] = "0";
-                entry["lookFeet"] = "0";
-                entry["lookAddons"] = entry["addon"];
-                break;
-            case 3:
-                entry["type"] = "Decoration";
-                entry["itemId"] = entry["extraClientId"];
-                entry["clientId"] = entry["extraClientId"];
-                break;
-            default:
-                entry["type"] = "Decoration";
-                entry["itemId"] = stringify(clientId);
-                entry["clientId"] = stringify(clientId);
-                break;
+                if (type == 3)
+                    entry["extraClientId"] = stringify(msg->getU32());
+
+                const uint32_t price = msg->getU32();
+                const uint8_t buttonState = msg->getU8();
+                entry["price"] = stringify(price);
+                entry["bought"] = buttonState == 4 ? "1" : "0";
+
+                switch (type) {
+                case 0:
+                    entry["type"] = "Decoration";
+                    entry["itemId"] = stringify(clientId);
+                    entry["clientId"] = stringify(clientId);
+                    break;
+                case 1:
+                    entry["type"] = "Mount";
+                    entry["lookType"] = stringify(clientId);
+                    break;
+                case 2:
+                    entry["type"] = "Outfit";
+                    entry["lookType"] = stringify(clientId);
+                    entry["lookHead"] = "0";
+                    entry["lookBody"] = "0";
+                    entry["lookLegs"] = "0";
+                    entry["lookFeet"] = "0";
+                    entry["lookAddons"] = entry["addon"];
+                    break;
+                case 3:
+                    entry["type"] = "Decoration";
+                    entry["itemId"] = entry["extraClientId"];
+                    entry["clientId"] = entry["extraClientId"];
+                    break;
+                default:
+                    entry["type"] = "Decoration";
+                    entry["itemId"] = stringify(clientId);
+                    entry["clientId"] = stringify(clientId);
+                    break;
+                }
             }
 
             items.emplace_back(std::move(entry));

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -1269,47 +1269,98 @@ void ProtocolGame::sendPreyHuntingAction(int slot, int actionType, bool upgrade,
     send(msg);
 }
 
-void ProtocolGame::sendTaskBoardCommand(const std::string& action, const std::string& data)
+void ProtocolGame::sendTaskBoardCommand(const std::string& /*action*/, const std::string& /*data*/)
 {
-    const std::string payload = "{\"action\":\"" + action + "\",\"data\":" + data + "}";
-    sendExtendedOpcode(205, payload);
+    // Deprecated: kept for ABI compatibility but does nothing.
+    // Use sendTaskBoardAction() for native byte protocol.
+}
+
+void ProtocolGame::sendTaskBoardAction(const uint8_t option, const uint16_t value, const uint16_t extraValue)
+{
+    const auto& msg = std::make_shared<OutputMessage>();
+    msg->addU8(Proto::ClientTaskBoardAction);
+    msg->addU8(option);
+    switch (option) {
+        case 2:  // CHANGE_DIFFICULTY
+        case 5:  // SELECT_TASK
+        case 7:  // TALISMAN_UPGRADE
+        case 8:  // WEEKLY_DELIVER
+        case 9:  // WEEKLY_SELECT_DIFFICULTY
+        case 11: // HUNTING_SHOP_BUY_OFFER
+            msg->addU8(static_cast<uint8_t>(std::clamp<uint16_t>(value, 0, 255)));
+            break;
+        case 12: // PREFERRED_UNLOCK
+        case 13: // PREFERRED_CLEAR
+        case 14: // UNWANTED_CLEAR
+            msg->addU16(value);
+            break;
+        case 15: // PREFERRED_ASSIGN
+        case 16: // UNWANTED_ASSIGN
+            msg->addU16(value);
+            msg->addU16(extraValue);
+            break;
+        case 0:  // OPEN_BOUNTY
+        case 1:  // OPEN_WEEKLY
+        case 3:  // BOUNTY_REROLL
+        case 4:  // BOUNTY_CLAIM_DAILY
+        case 6:  // BOUNTY_CLAIM_REWARD
+        case 10: // OPEN_HUNTING_SHOP
+            break;
+        default:
+            return;
+    }
+    send(msg);
 }
 
 void ProtocolGame::sendBountyTaskAction(int actionType, int param)
 {
-    sendTaskBoardCommand("bountyTaskAction",
-                         "{\"actionType\":" + std::to_string(actionType) +
-                         ",\"param\":" + std::to_string(param) + "}");
+    switch (actionType) {
+        case 0: sendTaskBoardAction(3); break;  // REROLL
+        case 1: sendTaskBoardAction(5, param); break;  // SELECT
+        case 2: sendTaskBoardAction(6); break;  // CLAIM_REWARD
+        case 3: sendTaskBoardAction(2, param); break;  // CHANGE_DIFFICULTY
+        case 4: sendTaskBoardAction(0); break;  // REQUEST (open bounty)
+        case 5: sendTaskBoardAction(4); break;  // CLAIM_DAILY
+        default: break;
+    }
 }
 
 void ProtocolGame::sendWeeklyTaskAction(int actionType, int param)
 {
-    sendTaskBoardCommand("weeklyTaskAction",
-                         "{\"actionType\":" + std::to_string(actionType) +
-                         ",\"param\":" + std::to_string(param) + "}");
+    switch (actionType) {
+        case 0: sendTaskBoardAction(9, param); break;  // SELECT_DIFFICULTY
+        case 1: sendTaskBoardAction(8, param); break;  // DELIVER_ITEM
+        case 2: sendTaskBoardAction(1); break;  // REFRESH_DATA (open weekly)
+        default: break;
+    }
 }
 
 void ProtocolGame::sendTaskHuntingShopRequest()
 {
-    sendTaskBoardCommand("taskShopRequest");
+    sendTaskBoardAction(10);
 }
 
 void ProtocolGame::sendTaskHuntingShopPurchase(int itemId)
 {
-    sendTaskBoardCommand("taskShopPurchase", "{\"itemId\":" + std::to_string(itemId) + "}");
+    sendTaskBoardAction(11, itemId);
 }
 
 void ProtocolGame::sendBountyPreferredAction(int actionType, int slot, int raceId)
 {
-    sendTaskBoardCommand("bountyPreferredAction",
-                         "{\"actionType\":" + std::to_string(actionType) +
-                         ",\"slot\":" + std::to_string(slot) +
-                         ",\"raceId\":" + std::to_string(raceId) + "}");
+    switch (actionType) {
+        case 0: sendTaskBoardAction(0); break;  // REQUEST
+        case 1: sendTaskBoardAction(12, slot); break;  // BUY_SLOT
+        case 2: sendTaskBoardAction(15, slot, raceId); break;  // SET_PREFERRED
+        case 3: sendTaskBoardAction(16, slot, raceId); break;  // SET_UNWANTED
+        case 4: sendTaskBoardAction(13, slot); break;  // REMOVE_PREFERRED
+        case 5: sendTaskBoardAction(14, slot); break;  // REMOVE_UNWANTED
+        default: break;
+    }
 }
 
 void ProtocolGame::sendBountyTalismanUpgrade(int statType)
 {
-    sendTaskBoardCommand("bountyTalismanUpgrade", "{\"statType\":" + std::to_string(statType) + "}");
+    sendTaskBoardAction(7, statType);
 }
 
 void ProtocolGame::sendPreyRequest()


### PR DESCRIPTION
## Summary

Substitui o protocolo JSON (extended opcode 205) por bytes nativos (opcode 0x5F) para todas as ações do Task Board. Corrige os parsers de bounty, weekly e shop para corresponder ao layout de bytes do Crystal Server. Remove dependência do extended opcode 205 do módulo game_task_hunt.

### Mudanças C++

**protocolcodes.h:**
- Adiciona ClientTaskBoardAction = 95 (0x5F)

**protocolgame.h / protocolgamesend.cpp:**
- Adiciona sendTaskBoardAction() genérico para 17 options
- Reescreve sendBountyTaskAction, sendWeeklyTaskAction, sendTaskHuntingShopRequest, sendTaskHuntingShopPurchase, sendBountyPreferredAction, sendBountyTalismanUpgrade para usar bytes nativos em 0x5F

**protocolgameparse.cpp:**
- Fix bounty parser: talisman usa U8 level + U8 multiplier2 + U8 isActiveUpgrade + U16 upgradeCost (5 bytes)
- Fix bounty parser: claimState (0=select, 1=active, 2=claimable) e grade (0=normal, 1=silver, 2=gold)
- Fix bounty parser: trailer + talismans + preferred slots após creatures
- Fix weekly parser: lê resetTimestamp (U32), calcula remainingDays
- Fix weekly parser: lê weeklyTaskExpansion (U8), corrige reward multiplier thresholds (5/9/13/17)
- Fix shop parser: trata BONUS_PROMOTION (type 4) com layout especial

### Mudanças Lua (modules/game_task_hunt/)

**tasks.lua:**
- Remove TASK_BOARD_AUX_OPCODE = 205 e egisterExtendedOpcode
- Remove onTaskBoardAuxOpcode JSON dispatcher
- Remove eventos onBountyKillUpdate, onWeeklyKillUpdate, onBountyPreferredData, onTaskHuntingShopResult

**bounty-tasks.lua:**
- Adiciona forward de preferred data para BountyPreferred module dentro de onServerData

**task-shop.lua:**
- onShopResult virou no-op stub (server envia full shop data refresh)

### Compatibilidade
- sendTaskBoardCommand() mantido como stub vazio para ABI
- sendSoulSealsAction() inalterado (já usa 0xBA nativo)
- Game methods (ountyTaskAction, etc.) inalterados
- game_trackers funciona sem mudanças (Tracker.Bounty/Weekly chamados de onServerData)

### Relacionado
- TFS 1.8 PR: https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/pull/82