### PR TITLE
Battlepass

### DIFF
--- a/modules/game_battlepass/battlepass.lua
+++ b/modules/game_battlepass/battlepass.lua
@@ -35,8 +35,19 @@ if not BattlePass then
 end
 
 -- Extended Opcode para comunicacao com Crystal Server
-local BATTLEPASS_OPCODE = 225
+BATTLEPASS_OPCODE_DEFAULT = BATTLEPASS_OPCODE_DEFAULT or 225
+BATTLEPASS_WIKI_URL = BATTLEPASS_WIKI_URL or "https://wiki.rubinot.com/pt-BR/passe-de-batalha/season-2"
+
+local BATTLEPASS_OPCODE = BATTLEPASS_OPCODE_DEFAULT
 BattlePass.opcode = BATTLEPASS_OPCODE
+
+local function getLoadedPlayerId()
+    if not LoadedPlayer or not LoadedPlayer.isLoaded or not LoadedPlayer.getId or not LoadedPlayer:isLoaded() then
+        return nil
+    end
+
+    return LoadedPlayer:getId()
+end
 
 local function safePercent(value, maxValue)
     value = tonumber(value) or 0
@@ -806,9 +817,12 @@ function BattlePass.calculateWeekNumber()
     local targetTime = os.time()
     local begindate = os.time{year=os.date("*t", BattlePass.beginTime).year, month=os.date("*t", BattlePass.beginTime).month, day=os.date("*t", BattlePass.beginTime).day, hour=10, min=0, sec=0}
     local diffSeconds = os.difftime(targetTime, begindate)
-    local diffDays = diffSeconds / 86400
-    local weekNumber = diffDays / 7
-    return math.ceil(weekNumber)
+    if diffSeconds <= 0 then
+        return 1
+    end
+
+    local weekNumber = math.ceil(diffSeconds / 604800)
+    return math.max(1, weekNumber)
 end
 
 function BattlePass.getNextResetWeek(currentIndex)
@@ -1101,9 +1115,10 @@ function BattlePass:doAnimatePlayerMove(targetMargin)
 end
 
 function BattlePass:loadConfigJson()
-    if not LoadedPlayer:isLoaded() then return end
+    local loadedPlayerId = getLoadedPlayerId()
+    if not loadedPlayerId then return end
 
-    local file = "/characterdata/" .. LoadedPlayer:getId() .. "/battlepass.json"
+    local file = "/characterdata/" .. loadedPlayerId .. "/battlepass.json"
     if g_resources.fileExists(file) then
         local status, result = pcall(function()
             return json.decode(g_resources.readFileContents(file))
@@ -1127,9 +1142,10 @@ end
 
 function BattlePass:saveConfigJson()
 	local config = { currentRewardStep = BattlePass.lastRewardStep, lastCameraPosition = BattlePass.lastCameraPosition }
-	if not LoadedPlayer:isLoaded() then return end
+	local loadedPlayerId = getLoadedPlayerId()
+	if not loadedPlayerId then return end
 
-	local file = "/characterdata/" .. LoadedPlayer:getId() .. "/battlepass.json"
+	local file = "/characterdata/" .. loadedPlayerId .. "/battlepass.json"
 	local status, result = pcall(function() return json.encode(config, 2) end)
 	if not status then
 		return g_logger.error("Error while saving profile Battlepass data. Data won't be saved. Details: " .. result)

--- a/modules/game_battlepass/battlepass.lua
+++ b/modules/game_battlepass/battlepass.lua
@@ -23,7 +23,7 @@ if not BattlePass then
     BattlePass.dailyMissionsBegin = 0
     BattlePass.dailyMissionsExpire = 0
     BattlePass.dailyMissions = {}
-    BattlePass.seassonMissions = {}
+    BattlePass.seasonMissions = {}
 
     BattlePass.isAnimatingWalk = false
     BattlePass.lastRewardStep = 0
@@ -161,12 +161,16 @@ local function aggresiveNumberToStr(n)
 end
 
 local function getOrdenedMissions(missions)
+    if type(missions) ~= "table" then
+        missions = {}
+    end
+
     local bronzeMissions = {}
     local silverMissions = {}
     local goldMissions = {}
     local orderedWithIndex = {}
 
-    for _, mission in ipairs(BattlePass.seassonMissions) do
+    for _, mission in ipairs(missions) do
         if mission.rewardPoints == 100 then
             table.insert(bronzeMissions, mission)
         elseif mission.rewardPoints == 200 then
@@ -736,7 +740,7 @@ function BattlePass.onBattlePassMissionsFromServer(data)
     BattlePass.dailyMissionsExpire = data.dailyEndTime or 0
 
     BattlePass.dailyMissions = data.dailyMissions or {}
-    BattlePass.seassonMissions = data.generalMissions or {}
+    BattlePass.seasonMissions = data.generalMissions or {}
 
     local getVipPassTicketButton = BattlePass.window:recursiveGetChildById('getVipPassTicket')
     local getVipPassTicketBorder = BattlePass.window:recursiveGetChildById('getVipPassTicketBorder')
@@ -896,7 +900,7 @@ function BattlePass:configureMissionPanel()
 
     -- General missions
     local missionsPanel = BattlePass.window:recursiveGetChildById('missionsBackground')
-    local orderedWithIndex = getOrdenedMissions(BattlePass.seassonMissions)
+    local orderedWithIndex = getOrdenedMissions(BattlePass.seasonMissions)
 
     for k, v in ipairs(orderedWithIndex) do
         local data = v.data

--- a/modules/game_battlepass/battlepass.lua
+++ b/modules/game_battlepass/battlepass.lua
@@ -106,8 +106,8 @@ local function updateGoldBalance()
         return
     end
 
-    local playerBank = player:getResourceBalance(ResourceTypes.BANK_BALANCE)
-    local playerInventory = player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED)
+    local playerBank = player:getResourceValue(ResourceBank)
+    local playerInventory = player:getResourceValue(ResourceInventary)
     local moneyTooltip = {}
 
     setStringColor(moneyTooltip, "Cash: " .. comma_value(playerInventory), "#3f3f3f")
@@ -1171,6 +1171,10 @@ function BattlePass:rerollDailyMission(data)
     }, okButton, cancelButton)
 end
 
-function onResourceBalance()
+function onResourceBalance(resourceType)
+    if resourceType and resourceType ~= ResourceBank and resourceType ~= ResourceInventary then
+        return
+    end
+
     updateGoldBalance()
 end

--- a/modules/game_battlepass/battlepass.lua
+++ b/modules/game_battlepass/battlepass.lua
@@ -1,6 +1,16 @@
 local battlePassBarWidget = nil
 local battlePassMainButton = nil
 
+local onBattlePassExtendedOpcode
+local online
+local offline
+local openBattlePass
+local createBattlePassBarWidget
+local destroyBattlePassBarWidget
+local onCreateRewardContainers
+local onResourceBalance
+local toggleNextWindow
+
 if not BattlePass then
     BattlePass = {}
     BattlePass.__index = BattlePass
@@ -171,7 +181,7 @@ local function aggresiveNumberToStr(n)
     return tostring(n)
 end
 
-local function getOrdenedMissions(missions)
+local function getOrderedMissions(missions)
     if type(missions) ~= "table" then
         missions = {}
     end
@@ -263,25 +273,24 @@ local function getTimeUntil(timestamp)
 end
 
 local function timerEvent(widget, endTime)
-	if not widget or not widget:isVisible() or os.time() > endTime then
+    if not widget or not widget:isVisible() or os.time() > endTime then
         BattlePass.unlockTimerEvent = nil
-		return
-	end
+        return
+    end
 
-	widget:setText(BattlePass:running() and (string.format("New missions available in: %s", getTimeUntil(endTime))) or "                              Expired")
-	BattlePass.unlockTimerEvent = scheduleEvent(function()
-		timerEvent(widget, endTime)
-	end, 1000)
+    widget:setText(BattlePass:running() and (string.format("New missions available in: %s", getTimeUntil(endTime))) or "                              Expired")
+    BattlePass.unlockTimerEvent = scheduleEvent(function()
+        timerEvent(widget, endTime)
+    end, 1000)
 end
 
-function redirectToStore()
+function BattlePass.redirectToStore()
     BattlePass.window:hide()
-    -- g_client.setInputLockWidget(nil)
-	g_game.openStore()
-	g_game.requestStoreOffers(3, "", 20)
+    g_game.openStore()
+    g_game.requestStoreOffers(3, "", 20)
 end
 
-function init()
+function BattlePass.init()
     g_ui.importStyle('styles/battlepass_button')
 
     BattlePass.window = g_ui.displayUI('battlepass')
@@ -325,7 +334,7 @@ function init()
 
     g_keyboard.bindKeyPress('Tab', toggleNextWindow, BattlePass.window)
 
-    loadMenu('challengesMenu')
+    BattlePass.loadMenu('challengesMenu')
     onCreateRewardContainers()
 
     if modules.game_mainpanel and modules.game_mainpanel.addToggleButton then
@@ -351,10 +360,10 @@ function init()
         scheduleEvent(online, 50)
     end
 
-    consoleln("Battle Pass loaded.")
+    g_logger.info("Battle Pass loaded.")
 end
 
-function terminate()
+function BattlePass.terminate()
     destroyBattlePassBarWidget()
 
     if battlePassMainButton and not battlePassMainButton:isDestroyed() then
@@ -400,7 +409,7 @@ end
 -- ============================================================
 -- Extended Opcode Handler: recebe dados do Crystal Server
 -- ============================================================
-function onBattlePassExtendedOpcode(protocol, opcode, buffer)
+onBattlePassExtendedOpcode = function(protocol, opcode, buffer)
     local status, jsonData = pcall(json.decode, buffer)
     if not status or not jsonData then
         return
@@ -413,7 +422,7 @@ function onBattlePassExtendedOpcode(protocol, opcode, buffer)
         if data then
             if BattlePass.pendingOpen then
                 BattlePass.pendingOpen = false
-                loadMenu('challengesMenu')
+                BattlePass.loadMenu('challengesMenu')
             end
             BattlePass.onBattlePassMissionsFromServer(data)
         end
@@ -424,7 +433,7 @@ function onBattlePassExtendedOpcode(protocol, opcode, buffer)
     end
 end
 
-function online()
+online = function()
     -- Load battlepass config
     BattlePass:loadConfigJson()
     BattlePass:loadPlayerPosition()
@@ -459,9 +468,9 @@ function online()
     end, 200)
 end
 
-function openBattlePass()
+openBattlePass = function()
     if BattlePass.window:isVisible() then
-        hide()
+        BattlePass.hide()
     elseif not g_game.isOnline() then
         return
     else
@@ -471,7 +480,7 @@ function openBattlePass()
     end
 end
 
-function onBattlePassBarClick()
+function BattlePass.onBattlePassBarClick()
     openBattlePass()
 end
 
@@ -502,7 +511,7 @@ local function getBattlePassBarInsertIndex(mainRightPanel)
     return insertIndex
 end
 
-function createBattlePassBarWidget()
+createBattlePassBarWidget = function()
     if battlePassBarWidget then
         return
     end
@@ -522,7 +531,7 @@ function createBattlePassBarWidget()
     fitBattlePassSidePanel(mainRightPanel)
 end
 
-function destroyBattlePassBarWidget()
+destroyBattlePassBarWidget = function()
     if battlePassBarWidget then
         local mainRightPanel = battlePassBarWidget:getParent() or getBattlePassSidePanel()
         battlePassBarWidget:destroy()
@@ -531,24 +540,8 @@ function destroyBattlePassBarWidget()
     end
 end
 
-function repositionBattlePassBarBelowMinimap()
-    if not battlePassBarWidget then
-        return
-    end
-
-    local mainRightPanel = getBattlePassSidePanel()
-    if not mainRightPanel then
-        return
-    end
-
-    mainRightPanel:removeChild(battlePassBarWidget)
-    mainRightPanel:insertChild(getBattlePassBarInsertIndex(mainRightPanel), battlePassBarWidget)
-
-    fitBattlePassSidePanel(mainRightPanel)
-end
-
-function offline()
-    hide()
+offline = function()
+    BattlePass.hide()
     BattlePass.lastRewardStep = BattlePass.currentRewardStep
     BattlePass.lastCameraPosition = getRewardPosition(BattlePass.currentRewardStep).scrollPosition
     BattlePass.outfitWidget:setMarginLeft(165)
@@ -578,36 +571,33 @@ function BattlePass:showBattlePass()
     BattlePass.window:show(true)
     BattlePass.window:raise()
     BattlePass.window:focus()
-    -- g_client.setInputLockWidget(BattlePass.window)
 
     updateGoldBalance()
     setBattlePassMainButtonOn(true)
 end
 
-function show()
+function BattlePass.show()
     BattlePass.window:show(true)
     BattlePass.window:raise()
     BattlePass.window:focus()
 
     g_keyboard.bindKeyPress('Tab', toggleNextWindow, BattlePass.window)
-    -- g_client.setInputLockWidget(BattlePass.window)
     updateGoldBalance()
     setBattlePassMainButtonOn(true)
 end
 
-function hide()
+function BattlePass.hide()
     if not BattlePass.window then
         return
     end
 
     BattlePass.window:hide()
-    -- g_client.setInputLockWidget(nil)
     g_keyboard.unbindKeyPress('Tab', toggleNextWindow, BattlePass.window)
     stopUnlockTimer()
     setBattlePassMainButtonOn(false)
 end
 
-function onCreateRewardContainers()
+onCreateRewardContainers = function()
     local progressPanelContent = BattlePass.window:recursiveGetChildById('progressPanelContent')
     if not progressPanelContent then return end
 
@@ -652,7 +642,7 @@ function onCreateRewardContainers()
     end
 end
 
-function loadMenu(menuId)
+function BattlePass.loadMenu(menuId)
     BattlePass.currentMenuId = menuId
 
     local buttons = {
@@ -700,21 +690,20 @@ function loadMenu(menuId)
         end, 50)
     end
 
-    -- g_client.setInputLockWidget(BattlePass.window)
 end
 
-function toggleNextWindow()
+toggleNextWindow = function()
     local widgetList = {
-      "challengesMenu",
-      "rewardsMenu"
+        "challengesMenu",
+        "rewardsMenu"
     }
 
     local selectedIndex = nil
     for i, widget in ipairs(widgetList) do
-      if widget == BattlePass.currentMenuId then
-        selectedIndex = i
-        break
-      end
+        if widget == BattlePass.currentMenuId then
+            selectedIndex = i
+            break
+        end
     end
 
     if not selectedIndex then
@@ -723,7 +712,7 @@ function toggleNextWindow()
 
     local nextWidgetId = (selectedIndex == #widgetList and 1 or selectedIndex + 1)
     BattlePass.currentMenuId = widgetList[nextWidgetId]
-    loadMenu(BattlePass.currentMenuId)
+    BattlePass.loadMenu(BattlePass.currentMenuId)
 end
 
 function BattlePass.onBattlePassMissionsFromServer(data)
@@ -914,7 +903,7 @@ function BattlePass:configureMissionPanel()
 
     -- General missions
     local missionsPanel = BattlePass.window:recursiveGetChildById('missionsBackground')
-    local orderedWithIndex = getOrdenedMissions(BattlePass.seasonMissions)
+    local orderedWithIndex = getOrderedMissions(BattlePass.seasonMissions)
 
     for k, v in ipairs(orderedWithIndex) do
         local data = v.data
@@ -1040,8 +1029,8 @@ end
 
 function BattlePass:updatePlayerPosition()
     local stepsToReward = BattlePass:getStepsToReward(BattlePass.currentRewardStep)
-	local newProgress = BattlePass.rewardMinMargin + stepsToReward * 32
-	local playerProgress = math.max(BattlePass.rewardMinMargin, math.min(newProgress, BattlePass.rewardMaxMargin))
+    local newProgress = BattlePass.rewardMinMargin + stepsToReward * 32
+    local playerProgress = math.max(BattlePass.rewardMinMargin, math.min(newProgress, BattlePass.rewardMaxMargin))
 
     if playerProgress > 195 then
         BattlePass.lastCameraPosition = getRewardPosition(BattlePass.lastRewardStep).scrollPosition
@@ -1066,7 +1055,6 @@ function BattlePass:doAnimatePlayerMove(targetMargin)
         return
     end
 
-    local player = g_game.getLocalPlayer()
     BattlePass.outfitWidget:setDirection(East)
     setOutfitStaticWalking(true)
 
@@ -1141,20 +1129,20 @@ function BattlePass:loadConfigJson()
 end
 
 function BattlePass:saveConfigJson()
-	local config = { currentRewardStep = BattlePass.lastRewardStep, lastCameraPosition = BattlePass.lastCameraPosition }
-	local loadedPlayerId = getLoadedPlayerId()
-	if not loadedPlayerId then return end
+    local config = { currentRewardStep = BattlePass.lastRewardStep, lastCameraPosition = BattlePass.lastCameraPosition }
+    local loadedPlayerId = getLoadedPlayerId()
+    if not loadedPlayerId then return end
 
-	local file = "/characterdata/" .. loadedPlayerId .. "/battlepass.json"
-	local status, result = pcall(function() return json.encode(config, 2) end)
-	if not status then
-		return g_logger.error("Error while saving profile Battlepass data. Data won't be saved. Details: " .. result)
-	end
+    local file = "/characterdata/" .. loadedPlayerId .. "/battlepass.json"
+    local status, result = pcall(function() return json.encode(config, 2) end)
+    if not status then
+        return g_logger.error("Error while saving profile Battlepass data. Data won't be saved. Details: " .. result)
+    end
 
-	if result:len() > 100 * 1024 * 1024 then
-		return g_logger.error("Something went wrong, file is above 100MB, won't be saved")
-	end
-	g_resources.writeFileContents(file, result)
+    if result:len() > 100 * 1024 * 1024 then
+        return g_logger.error("Something went wrong, file is above 100MB, won't be saved")
+    end
+    g_resources.writeFileContents(file, result)
 end
 
 function BattlePass:rerollDailyMission(data)
@@ -1172,7 +1160,6 @@ function BattlePass:rerollDailyMission(data)
     local okButton = function()
         BattlePass.dailyRerollWindow:destroy()
         BattlePass.dailyRerollWindow = nil
-        -- g_client.setInputLockWidget(nil)
         sendToServer("reroll", { missionId = data.missionId })
     end
 
@@ -1180,7 +1167,6 @@ function BattlePass:rerollDailyMission(data)
         BattlePass.dailyRerollWindow:destroy()
         BattlePass.dailyRerollWindow = nil
         BattlePass:showBattlePass()
-        -- g_client.setInputLockWidget(BattlePass.window)
     end
 
     local message = string.format("Are you sure you want to reroll the mission %s for %s gold?", data.missionName, comma_value(BattlePass.dailyRerollPrice * player:getLevel()))
@@ -1191,7 +1177,7 @@ function BattlePass:rerollDailyMission(data)
     }, okButton, cancelButton)
 end
 
-function onResourceBalance(resourceType)
+onResourceBalance = function(resourceType)
     if resourceType and resourceType ~= ResourceBank and resourceType ~= ResourceInventary then
         return
     end

--- a/modules/game_battlepass/battlepass.lua
+++ b/modules/game_battlepass/battlepass.lua
@@ -36,6 +36,7 @@ if not BattlePass then
     BattlePass.seasonMissions = {}
 
     BattlePass.isAnimatingWalk = false
+    BattlePass.pendingRewardsSchedule = nil
     BattlePass.lastRewardStep = 0
     BattlePass.lastCameraPosition = 0
 
@@ -46,7 +47,6 @@ end
 
 -- Extended Opcode para comunicacao com Crystal Server
 BATTLEPASS_OPCODE_DEFAULT = BATTLEPASS_OPCODE_DEFAULT or 225
-BATTLEPASS_WIKI_URL = BATTLEPASS_WIKI_URL or "https://wiki.rubinot.com/pt-BR/passe-de-batalha/season-2"
 
 local BATTLEPASS_OPCODE = BATTLEPASS_OPCODE_DEFAULT
 BattlePass.opcode = BATTLEPASS_OPCODE
@@ -113,6 +113,13 @@ local function stopUnlockTimer()
     if BattlePass.unlockTimerEvent then
         removeEvent(BattlePass.unlockTimerEvent)
         BattlePass.unlockTimerEvent = nil
+    end
+end
+
+local function stopPendingRewardsSchedule()
+    if BattlePass.pendingRewardsSchedule then
+        removeEvent(BattlePass.pendingRewardsSchedule)
+        BattlePass.pendingRewardsSchedule = nil
     end
 end
 
@@ -285,7 +292,7 @@ local function timerEvent(widget, endTime)
 end
 
 function BattlePass.redirectToStore()
-    BattlePass.window:hide()
+    BattlePass.hide()
     g_game.openStore()
     g_game.requestStoreOffers(3, "", 20)
 end
@@ -294,7 +301,7 @@ function BattlePass.init()
     g_ui.importStyle('styles/battlepass_button')
 
     BattlePass.window = g_ui.displayUI('battlepass')
-    BattlePass.window:hide()
+    BattlePass.hide()
 
     BattlePass.missionPanel = BattlePass.window:recursiveGetChildById('missionPanel')
     BattlePass.progressPanel = BattlePass.window:recursiveGetChildById('progressPanel')
@@ -331,8 +338,6 @@ function BattlePass.init()
             end
         end
     end
-
-    g_keyboard.bindKeyPress('Tab', toggleNextWindow, BattlePass.window)
 
     BattlePass.loadMenu('challengesMenu')
     onCreateRewardContainers()
@@ -568,12 +573,7 @@ offline = function()
 end
 
 function BattlePass:showBattlePass()
-    BattlePass.window:show(true)
-    BattlePass.window:raise()
-    BattlePass.window:focus()
-
-    updateGoldBalance()
-    setBattlePassMainButtonOn(true)
+    BattlePass.show()
 end
 
 function BattlePass.show()
@@ -581,6 +581,7 @@ function BattlePass.show()
     BattlePass.window:raise()
     BattlePass.window:focus()
 
+    g_keyboard.unbindKeyPress('Tab', toggleNextWindow, BattlePass.window)
     g_keyboard.bindKeyPress('Tab', toggleNextWindow, BattlePass.window)
     updateGoldBalance()
     setBattlePassMainButtonOn(true)
@@ -594,6 +595,7 @@ function BattlePass.hide()
     BattlePass.window:hide()
     g_keyboard.unbindKeyPress('Tab', toggleNextWindow, BattlePass.window)
     stopUnlockTimer()
+    stopPendingRewardsSchedule()
     setBattlePassMainButtonOn(false)
 end
 
@@ -643,6 +645,7 @@ onCreateRewardContainers = function()
 end
 
 function BattlePass.loadMenu(menuId)
+    stopPendingRewardsSchedule()
     BattlePass.currentMenuId = menuId
 
     local buttons = {
@@ -682,7 +685,12 @@ function BattlePass.loadMenu(menuId)
         BattlePass.outfitWidget:setDirection(BattlePass.currentRewardStep == 0 and East or North)
         sendToServer("getRewards")
 
-        scheduleEvent(function()
+        BattlePass.pendingRewardsSchedule = scheduleEvent(function()
+            BattlePass.pendingRewardsSchedule = nil
+            if BattlePass.currentMenuId ~= 'rewardsMenu' or not BattlePass.window or not BattlePass.window:isVisible() then
+                return
+            end
+
             BattlePass.missionPanel:hide()
             BattlePass.progressPanel:show(true)
             BattlePass.window:setHeight(515)
@@ -1155,7 +1163,7 @@ function BattlePass:rerollDailyMission(data)
         return
     end
 
-    BattlePass.window:hide()
+    BattlePass.hide()
 
     local okButton = function()
         BattlePass.dailyRerollWindow:destroy()

--- a/modules/game_battlepass/battlepass.lua
+++ b/modules/game_battlepass/battlepass.lua
@@ -1,0 +1,1176 @@
+local battlePassBarWidget = nil
+local battlePassMainButton = nil
+
+if not BattlePass then
+    BattlePass = {}
+    BattlePass.__index = BattlePass
+
+    BattlePass.window = nil
+    BattlePass.missionPanel = nil
+    BattlePass.progressPanel = nil
+    BattlePass.outfitWidget = nil
+    BattlePass.scrollBarWidget = nil
+    BattlePass.dailyRerollWindow = nil
+
+    BattlePass.beginTime = 0
+    BattlePass.endTime = 0
+    BattlePass.progressPoints = 0
+    BattlePass.dailyRerollPrice = 0
+    BattlePass.premiumBattlepass = false
+    BattlePass.currentRewardStep = 0
+    BattlePass.nextStepPoints = 0
+    BattlePass.currentReward = 0
+    BattlePass.dailyMissionsBegin = 0
+    BattlePass.dailyMissionsExpire = 0
+    BattlePass.dailyMissions = {}
+    BattlePass.seassonMissions = {}
+
+    BattlePass.isAnimatingWalk = false
+    BattlePass.lastRewardStep = 0
+    BattlePass.lastCameraPosition = 0
+
+    -- Common variables
+    BattlePass.rewardMinMargin = 195
+    BattlePass.rewardMaxMargin = 18045
+end
+
+-- Extended Opcode para comunicacao com Crystal Server
+local BATTLEPASS_OPCODE = 225
+BattlePass.opcode = BATTLEPASS_OPCODE
+
+local function safePercent(value, maxValue)
+    value = tonumber(value) or 0
+    maxValue = tonumber(maxValue) or 0
+    if maxValue <= 0 then
+        return 0
+    end
+    return math.max(0, math.min(100, value / maxValue * 100))
+end
+
+local function getRewardPosition(step)
+    return RewardPositions[step] or RewardPositions[0]
+end
+
+local function getBattlePassSidePanel()
+    if not modules.game_interface then
+        return nil
+    end
+
+    if modules.game_interface.getMainRightPanel then
+        local panel = modules.game_interface.getMainRightPanel()
+        if panel then
+            return panel
+        end
+    end
+
+    if modules.game_interface.getRightPanel then
+        return modules.game_interface.getRightPanel()
+    end
+
+    return nil
+end
+
+local function fitBattlePassSidePanel(panel)
+    if not panel then
+        return
+    end
+
+    if panel.fitAllChildren then
+        panel:fitAllChildren()
+    elseif panel.fitAll then
+        panel:fitAll()
+    end
+end
+
+local function setBattlePassMainButtonOn(state)
+    if battlePassMainButton and battlePassMainButton.setOn then
+        battlePassMainButton:setOn(state)
+    end
+end
+
+local function stopUnlockTimer()
+    if BattlePass.unlockTimerEvent then
+        removeEvent(BattlePass.unlockTimerEvent)
+        BattlePass.unlockTimerEvent = nil
+    end
+end
+
+local function updateGoldBalance()
+    if not BattlePass.window or not BattlePass.window:isVisible() then
+        return
+    end
+
+    local player = g_game.getLocalPlayer()
+    local goldCoinsLabel = BattlePass.window:recursiveGetChildById('rCoins')
+    if not player or not goldCoinsLabel then
+        return
+    end
+
+    local playerBank = player:getResourceBalance(ResourceTypes.BANK_BALANCE)
+    local playerInventory = player:getResourceBalance(ResourceTypes.GOLD_EQUIPPED)
+    local moneyTooltip = {}
+
+    setStringColor(moneyTooltip, "Cash: " .. comma_value(playerInventory), "#3f3f3f")
+    setStringColor(moneyTooltip, " $", "#f7e6fe")
+    setStringColor(moneyTooltip, "\nBank: " .. comma_value(playerBank), "#3f3f3f")
+    setStringColor(moneyTooltip, " $", "#f7e6fe")
+
+    goldCoinsLabel:setText(comma_value(playerBank + playerInventory))
+    goldCoinsLabel:setTooltip(moneyTooltip)
+end
+
+local function sendToServer(action, data)
+    local protocol = g_game.getProtocolGame()
+    if protocol then
+        protocol:sendExtendedOpcode(BATTLEPASS_OPCODE, json.encode({
+            action = action,
+            data = data or {},
+        }))
+    end
+end
+
+local function setOutfitStaticWalking(enabled)
+    local widget = BattlePass.outfitWidget
+    if not widget then
+        return
+    end
+
+    if widget.setStaticWalking then
+        widget:setStaticWalking(enabled)
+        return
+    end
+
+    local creature = widget.getCreature and widget:getCreature()
+    if creature and creature.setStaticWalking then
+        creature:setStaticWalking(enabled)
+    end
+end
+
+local function getMissionIndex(index)
+    return MissionsDisplacement[index]
+end
+
+local function aggresiveNumberToStr(n)
+    n = tonumber(n) or 0
+    if n >= 1000000 then
+        return string.format("%.1fM", n / 1000000)
+    elseif n >= 1000 then
+        return string.format("%.1fK", n / 1000)
+    end
+    return tostring(n)
+end
+
+local function getOrdenedMissions(missions)
+    local bronzeMissions = {}
+    local silverMissions = {}
+    local goldMissions = {}
+    local orderedWithIndex = {}
+
+    for _, mission in ipairs(BattlePass.seassonMissions) do
+        if mission.rewardPoints == 100 then
+            table.insert(bronzeMissions, mission)
+        elseif mission.rewardPoints == 200 then
+            table.insert(silverMissions, mission)
+        elseif mission.rewardPoints == 300 then
+            table.insert(goldMissions, mission)
+        end
+    end
+
+    local bronzeIndex = 1
+    local silverIndex = 1
+    local goldIndex = 1
+
+    for i, missionType in ipairs(MissionTypesOrder) do
+        local indexDestino = MissionsDisplacement[i]
+        local mission = nil
+
+        if missionType == "bronze" and bronzeMissions[bronzeIndex] then
+            mission = bronzeMissions[bronzeIndex]
+            bronzeIndex = bronzeIndex + 1
+        elseif missionType == "silver" and silverMissions[silverIndex] then
+            mission = silverMissions[silverIndex]
+            silverIndex = silverIndex + 1
+        elseif missionType == "gold" and goldMissions[goldIndex] then
+            mission = goldMissions[goldIndex]
+            goldIndex = goldIndex + 1
+        end
+
+        if mission then
+            table.insert(orderedWithIndex, { data = mission, index = indexDestino })
+        end
+    end
+    return orderedWithIndex
+end
+
+local function getFormatedTime(dailyEndTime)
+    local timeLeft = dailyEndTime - os.time()
+    if timeLeft <= 0 then
+        return "Expired", "Expired"
+    end
+
+    local days = math.floor(timeLeft / 86400)
+    local hours = math.floor((timeLeft % 86400) / 3600)
+    local minutes = math.floor((timeLeft % 3600) / 60)
+    local seconds = timeLeft % 60
+
+    local function formatUnit(value, singular, plural)
+        return value == 1 and string.format("%d %s", value, singular) or string.format("%02d %s", value, plural)
+    end
+
+    local shortFormat, longFormat
+    if days > 0 then
+        shortFormat = formatUnit(days, "Day left", "Days left")
+        longFormat = formatUnit(days, "Day", "Days") .. string.format(" and %02d hours left", hours)
+    elseif hours > 0 then
+        shortFormat = formatUnit(hours, "Hour left", "Hours left")
+        longFormat = formatUnit(hours, "Hour", "Hours") .. string.format(" and %02d minutes left", minutes)
+    elseif minutes > 0 then
+        shortFormat = formatUnit(minutes, "Minute left", "Minutes left")
+        longFormat = formatUnit(minutes, "Minute", "Minutes") .. string.format(" and %02d seconds left", seconds)
+    else
+        shortFormat = string.format("%02d Seconds left", seconds)
+        longFormat = shortFormat
+    end
+    return shortFormat, longFormat
+end
+
+local function getTimeUntil(timestamp)
+    local timeLeft = timestamp - os.time()
+    if timeLeft <= 0 then
+        return "00:00:00:00"
+    end
+
+    local days = math.floor(timeLeft / 86400)
+    local hours = math.floor((timeLeft % 86400) / 3600)
+    local minutes = math.floor((timeLeft % 3600) / 60)
+    local seconds = timeLeft % 60
+    return string.format("%02d:%02d:%02d:%02d", days, hours, minutes, seconds)
+end
+
+local function timerEvent(widget, endTime)
+	if not widget or not widget:isVisible() or os.time() > endTime then
+        BattlePass.unlockTimerEvent = nil
+		return
+	end
+
+	widget:setText(BattlePass:running() and (string.format("New missions available in: %s", getTimeUntil(endTime))) or "                              Expired")
+	BattlePass.unlockTimerEvent = scheduleEvent(function()
+		timerEvent(widget, endTime)
+	end, 1000)
+end
+
+function redirectToStore()
+    BattlePass.window:hide()
+    -- g_client.setInputLockWidget(nil)
+	g_game.openStore()
+	g_game.requestStoreOffers(3, "", 20)
+end
+
+function init()
+    g_ui.importStyle('styles/battlepass_button')
+
+    BattlePass.window = g_ui.displayUI('battlepass')
+    BattlePass.window:hide()
+
+    BattlePass.missionPanel = BattlePass.window:recursiveGetChildById('missionPanel')
+    BattlePass.progressPanel = BattlePass.window:recursiveGetChildById('progressPanel')
+    BattlePass.outfitWidget = BattlePass.window:recursiveGetChildById('playerOutfit')
+    BattlePass.scrollBarWidget = BattlePass.window:recursiveGetChildById('progressPanelScrollBar')
+
+    BattlePass.scrollBarWidget.canChangeValue = function()
+        return not BattlePass.isAnimatingWalk
+    end
+
+    local progressPanelContent = BattlePass.window:recursiveGetChildById('progressPanelContent')
+    if progressPanelContent then
+        progressPanelContent.onMousePress = function(widget, mousePos, button)
+            if button == MouseLeftButton and not BattlePass.isAnimatingWalk then
+                BattlePass.isDragging = true
+                BattlePass.dragStartX = mousePos.x
+                BattlePass.dragStartScrollValue = BattlePass.scrollBarWidget:getValue()
+            end
+        end
+
+        progressPanelContent.onMouseMove = function(widget, mousePos)
+            if BattlePass.isDragging and not BattlePass.isAnimatingWalk then
+                local deltaX = mousePos.x - BattlePass.dragStartX
+                local scrollChange = -deltaX * 1.5 -- Adjust the multiplier for sensitivity
+                local newScrollValue = BattlePass.dragStartScrollValue + scrollChange
+                newScrollValue = math.max(BattlePass.scrollBarWidget:getMinimum(), math.min(newScrollValue, BattlePass.scrollBarWidget:getMaximum()))
+                BattlePass.scrollBarWidget:setValue(newScrollValue)
+            end
+        end
+
+        progressPanelContent.onMouseRelease = function(widget, mousePos, button)
+            if button == MouseLeftButton then
+                BattlePass.isDragging = false
+            end
+        end
+    end
+
+    g_keyboard.bindKeyPress('Tab', toggleNextWindow, BattlePass.window)
+
+    loadMenu('challengesMenu')
+    onCreateRewardContainers()
+
+    if modules.game_mainpanel and modules.game_mainpanel.addToggleButton then
+        battlePassMainButton = modules.game_mainpanel.addToggleButton(
+            'battlePassButton',
+            tr('Battle Pass'),
+            '/images/game/battlepass/mainIcon1',
+            openBattlePass,
+            false,
+            1007
+        )
+    end
+
+    ProtocolGame.registerExtendedOpcode(BATTLEPASS_OPCODE, onBattlePassExtendedOpcode)
+
+    connect(g_game, {
+        onGameStart = online,
+        onGameEnd = offline,
+        onResourceBalance = onResourceBalance,
+    })
+
+    if g_game.isOnline() then
+        scheduleEvent(online, 50)
+    end
+
+    consoleln("Battle Pass loaded.")
+end
+
+function terminate()
+    destroyBattlePassBarWidget()
+
+    if battlePassMainButton and not battlePassMainButton:isDestroyed() then
+        battlePassMainButton:destroy()
+    end
+    battlePassMainButton = nil
+
+    stopUnlockTimer()
+
+    g_keyboard.unbindKeyPress('Tab', toggleNextWindow, BattlePass.window)
+
+    pcall(function()
+        ProtocolGame.unregisterExtendedOpcode(BATTLEPASS_OPCODE)
+    end)
+
+    disconnect(g_game, {
+        onGameStart = online,
+        onGameEnd = offline,
+        onResourceBalance = onResourceBalance,
+    })
+
+    if BattlePass.dailyRerollWindow then
+        BattlePass.dailyRerollWindow:destroy()
+        BattlePass.dailyRerollWindow = nil
+    end
+
+    if BattlePassRewards and BattlePassRewards.claimRewardWindow then
+        BattlePassRewards.claimRewardWindow:destroy()
+        BattlePassRewards.claimRewardWindow = nil
+    end
+
+    if BattlePassRewards and BattlePassRewards.confirmRewardWindow then
+        BattlePassRewards.confirmRewardWindow:destroy()
+        BattlePassRewards.confirmRewardWindow = nil
+    end
+
+    if BattlePass.window then
+        BattlePass.window:destroy()
+        BattlePass.window = nil
+    end
+end
+
+-- ============================================================
+-- Extended Opcode Handler: recebe dados do Crystal Server
+-- ============================================================
+function onBattlePassExtendedOpcode(protocol, opcode, buffer)
+    local status, jsonData = pcall(json.decode, buffer)
+    if not status or not jsonData then
+        return
+    end
+
+    local action = jsonData.action
+    local data = jsonData.data
+
+    if action == "missions" then
+        if data then
+            if BattlePass.pendingOpen then
+                BattlePass.pendingOpen = false
+                loadMenu('challengesMenu')
+            end
+            BattlePass.onBattlePassMissionsFromServer(data)
+        end
+    elseif action == "rewards" then
+        if data then
+            BattlePass.onBattlePassRewards(data)
+        end
+    end
+end
+
+function online()
+    -- Load battlepass config
+    BattlePass:loadConfigJson()
+    BattlePass:loadPlayerPosition()
+
+    -- Reset daily mission panel
+    local dailyMissionsPanel = BattlePass.window:recursiveGetChildById('dailyMissionsBg')
+    dailyMissionsPanel:destroyChildren()
+    for i = 1, 2 do
+        local widget = g_ui.createWidget('DailyMissionWidget', dailyMissionsPanel)
+        local imageBackground = widget:recursiveGetChildById('dailyMissionIconImage')
+        local image = i == 1 and 'daily-free-icon' or 'daily-vip-icon'
+        imageBackground:setImageSource('/images/game/battlepass/' .. image)
+    end
+
+    -- Reset mission panel
+    local missionsPanel = BattlePass.window:recursiveGetChildById('missionsBackground')
+    missionsPanel:destroyChildren()
+    for i = 1, 26 do
+        g_ui.createWidget('MissionWidget', missionsPanel)
+    end
+
+    if BattlePassRewards.claimRewardWindow then
+        BattlePassRewards.claimRewardWindow:destroy()
+        BattlePassRewards.claimRewardWindow = nil
+    end
+
+    -- Bot estilo "Bot Helper" no painel direito (abaixo do minimapa / Bot Helper)
+    scheduleEvent(function()
+        if g_game.isOnline() then
+            createBattlePassBarWidget()
+        end
+    end, 200)
+end
+
+function openBattlePass()
+    if BattlePass.window:isVisible() then
+        hide()
+    elseif not g_game.isOnline() then
+        return
+    else
+        BattlePass.pendingOpen = true
+        BattlePass.shouldShow = true
+        sendToServer("getMissions")
+    end
+end
+
+function onBattlePassBarClick()
+    openBattlePass()
+end
+
+local function getBattlePassBarInsertIndex(mainRightPanel)
+    local children = mainRightPanel:getChildren()
+    local insertIndex = 1
+    local afterMinimap = nil
+    for i, child in ipairs(children) do
+        if child:getId() == 'minimapWindow' then
+            afterMinimap = i
+            break
+        end
+    end
+    if afterMinimap then
+        insertIndex = afterMinimap + 1
+        if modules.game_helper and modules.game_helper.getBTCHelperWidget then
+            local btc = modules.game_helper.getBTCHelperWidget()
+            if btc and btc:getParent() == mainRightPanel then
+                for i = insertIndex, #children do
+                    if children[i] == btc then
+                        insertIndex = i + 1
+                        break
+                    end
+                end
+            end
+        end
+    end
+    return insertIndex
+end
+
+function createBattlePassBarWidget()
+    if battlePassBarWidget then
+        return
+    end
+
+    local mainRightPanel = getBattlePassSidePanel()
+    if not mainRightPanel then
+        return
+    end
+
+    battlePassBarWidget = g_ui.createWidget('BattlePassBarWidget')
+    if not battlePassBarWidget then
+        return
+    end
+
+    mainRightPanel:insertChild(getBattlePassBarInsertIndex(mainRightPanel), battlePassBarWidget)
+
+    fitBattlePassSidePanel(mainRightPanel)
+end
+
+function destroyBattlePassBarWidget()
+    if battlePassBarWidget then
+        local mainRightPanel = battlePassBarWidget:getParent() or getBattlePassSidePanel()
+        battlePassBarWidget:destroy()
+        battlePassBarWidget = nil
+        fitBattlePassSidePanel(mainRightPanel)
+    end
+end
+
+function repositionBattlePassBarBelowMinimap()
+    if not battlePassBarWidget then
+        return
+    end
+
+    local mainRightPanel = getBattlePassSidePanel()
+    if not mainRightPanel then
+        return
+    end
+
+    mainRightPanel:removeChild(battlePassBarWidget)
+    mainRightPanel:insertChild(getBattlePassBarInsertIndex(mainRightPanel), battlePassBarWidget)
+
+    fitBattlePassSidePanel(mainRightPanel)
+end
+
+function offline()
+    hide()
+    BattlePass.lastRewardStep = BattlePass.currentRewardStep
+    BattlePass.lastCameraPosition = getRewardPosition(BattlePass.currentRewardStep).scrollPosition
+    BattlePass.outfitWidget:setMarginLeft(165)
+    BattlePass:saveConfigJson()
+    stopUnlockTimer()
+
+    if BattlePassRewards.claimRewardWindow then
+        BattlePassRewards.claimRewardWindow:destroy()
+        BattlePassRewards.claimRewardWindow = nil
+    end
+
+    if BattlePassRewards.confirmRewardWindow then
+        BattlePassRewards.confirmRewardWindow:destroy()
+        BattlePassRewards.confirmRewardWindow = nil
+    end
+
+    if BattlePass.dailyRerollWindow then
+        BattlePass.dailyRerollWindow:destroy()
+        BattlePass.dailyRerollWindow = nil
+    end
+
+    destroyBattlePassBarWidget()
+    setBattlePassMainButtonOn(false)
+end
+
+function BattlePass:showBattlePass()
+    BattlePass.window:show(true)
+    BattlePass.window:raise()
+    BattlePass.window:focus()
+    -- g_client.setInputLockWidget(BattlePass.window)
+
+    updateGoldBalance()
+    setBattlePassMainButtonOn(true)
+end
+
+function show()
+    BattlePass.window:show(true)
+    BattlePass.window:raise()
+    BattlePass.window:focus()
+
+    g_keyboard.bindKeyPress('Tab', toggleNextWindow, BattlePass.window)
+    -- g_client.setInputLockWidget(BattlePass.window)
+    updateGoldBalance()
+    setBattlePassMainButtonOn(true)
+end
+
+function hide()
+    if not BattlePass.window then
+        return
+    end
+
+    BattlePass.window:hide()
+    -- g_client.setInputLockWidget(nil)
+    g_keyboard.unbindKeyPress('Tab', toggleNextWindow, BattlePass.window)
+    stopUnlockTimer()
+    setBattlePassMainButtonOn(false)
+end
+
+function onCreateRewardContainers()
+    local progressPanelContent = BattlePass.window:recursiveGetChildById('progressPanelContent')
+    if not progressPanelContent then return end
+
+    for i, data in ipairs(RewardPositions) do
+        for rewardType, position in pairs(data.positions) do
+            local rewardWidgetId = rewardType .. "RewardWidget" .. i
+            local rewardWidget = g_ui.createWidget('RewardWidget', progressPanelContent)
+            rewardWidget:setId(rewardWidgetId)
+            rewardWidget:setMarginLeft(position.marginLeft)
+            rewardWidget:setMarginTop(position.marginTop)
+            rewardWidget:setVisible(false)
+
+            local rewardBoxImage = rewardWidget:recursiveGetChildById("rewardBoxImage")
+            if rewardType == "free" then
+                rewardBoxImage:setImageSource("/images/game/battlepass/free-reward-chest")
+                rewardBoxImage:setImageClip("30 32 29 31")
+            else
+                rewardBoxImage:setImageSource("/images/game/battlepass/vip-reward-chest")
+                rewardBoxImage:setImageClip("30 32 29 31")
+            end
+            rewardBoxImage:setTooltip(string.format("Battle Pass %s Reward\nUnlocked at level %d", string.capitalize(rewardType), i))
+
+            rewardWidget.rewardBox.onClick = function()
+                BattlePass.scrollBarWidget:setValue(RewardPositions[i].scrollPosition)
+                BattlePassRewards:onConfirmClaimReward(i, rewardType)
+            end
+
+            local blockedRewardId = rewardType .. "BlockedRewardWidget" .. i
+            local blockedReward = g_ui.createWidget('BlockedRewardWidget', progressPanelContent)
+            blockedReward:setId(blockedRewardId)
+            blockedReward:setMarginLeft(position.marginLeft)
+            blockedReward:setMarginTop(position.marginTop)
+            blockedReward:setVisible(true)
+            local lockedBoxImage = blockedReward:recursiveGetChildById("lockedBoxImage")
+            if rewardType == "free" then
+                lockedBoxImage:setImageSource("/images/game/battlepass/free-reward-chest")
+            else
+                lockedBoxImage:setImageSource("/images/game/battlepass/vip-reward-chest")
+            end
+            lockedBoxImage:setTooltip(string.format("Battle Pass %s Reward\nUnlock at level %d", string.capitalize(rewardType), i))
+        end
+    end
+end
+
+function loadMenu(menuId)
+    BattlePass.currentMenuId = menuId
+
+    local buttons = {
+        challengesMenuButton = 'challengesMenu',
+        rewardsMenuButton = 'rewardsMenu'
+    }
+
+    -- if menuId == 'challengesMenu' and not BattlePass:running() then
+    --     menuId = 'rewardsMenu'
+    -- end
+
+    for buttonName, buttonId in pairs(buttons) do
+        local button = BattlePass.window.mainPanel.optionsTabBar:getChildById(buttonId)
+        if button then
+            button:setChecked(false)
+        end
+    end
+
+    local selectedButton = BattlePass.window.mainPanel.optionsTabBar:getChildById(menuId)
+    if selectedButton then
+        selectedButton:setChecked(true)
+    end
+
+    if menuId == 'challengesMenu' then
+        BattlePass.missionPanel:show(true)
+        if g_game.isOnline() and BattlePass.progressPanel:isVisible() then
+            local nextUnlock = BattlePass.getNextResetWeek(BattlePass.calculateWeekNumber())
+            local unlockInfo = BattlePass.window:recursiveGetChildById("unlockInfo")
+            stopUnlockTimer()
+            timerEvent(unlockInfo, nextUnlock)
+        end
+
+        BattlePass.progressPanel:hide()
+        BattlePass.window:setHeight(595)
+    elseif menuId == 'rewardsMenu' then
+        BattlePass.scrollBarWidget:setValue(BattlePass.lastCameraPosition)
+        BattlePass.outfitWidget:setDirection(BattlePass.currentRewardStep == 0 and East or North)
+        sendToServer("getRewards")
+
+        scheduleEvent(function()
+            BattlePass.missionPanel:hide()
+            BattlePass.progressPanel:show(true)
+            BattlePass.window:setHeight(515)
+            BattlePass:updatePlayerPosition()
+        end, 50)
+    end
+
+    -- g_client.setInputLockWidget(BattlePass.window)
+end
+
+function toggleNextWindow()
+    local widgetList = {
+      "challengesMenu",
+      "rewardsMenu"
+    }
+
+    local selectedIndex = nil
+    for i, widget in ipairs(widgetList) do
+      if widget == BattlePass.currentMenuId then
+        selectedIndex = i
+        break
+      end
+    end
+
+    if not selectedIndex then
+        selectedIndex = 1
+    end
+
+    local nextWidgetId = (selectedIndex == #widgetList and 1 or selectedIndex + 1)
+    BattlePass.currentMenuId = widgetList[nextWidgetId]
+    loadMenu(BattlePass.currentMenuId)
+end
+
+function BattlePass.onBattlePassMissionsFromServer(data)
+    -- Converter outfit JSON para formato do client
+    if data.playerOutfit then
+        local o = data.playerOutfit
+        BattlePass.outfitWidget:setOutfit({
+            type = o.type or 0,
+            head = o.head or 0,
+            body = o.body or 0,
+            legs = o.legs or 0,
+            feet = o.feet or 0,
+            addons = o.addons or 0,
+        })
+    end
+
+    BattlePass.beginTime = data.beginTime or 0
+    BattlePass.endTime = data.endTime or 0
+    BattlePass.progressPoints = data.points or 0
+    BattlePass.dailyRerollPrice = data.rerollPrice or 0
+    BattlePass.premiumBattlepass = data.battlePassActive or false
+    BattlePass.currentRewardStep = data.currentRewardStep or 0
+    BattlePass.nextStepPoints = data.nextStepPoints or 0
+    BattlePass.dailyMissionsBegin = data.dailyBeginTime or 0
+    BattlePass.dailyMissionsExpire = data.dailyEndTime or 0
+
+    BattlePass.dailyMissions = data.dailyMissions or {}
+    BattlePass.seassonMissions = data.generalMissions or {}
+
+    local getVipPassTicketButton = BattlePass.window:recursiveGetChildById('getVipPassTicket')
+    local getVipPassTicketBorder = BattlePass.window:recursiveGetChildById('getVipPassTicketBorder')
+    if getVipPassTicketButton then
+        getVipPassTicketButton:setVisible(not BattlePass.premiumBattlepass)
+        getVipPassTicketBorder:setVisible(not BattlePass.premiumBattlepass)
+    end
+
+    BattlePass:configureMissionPanel()
+
+    -- Reset player data in case of season ends
+    if BattlePass.currentRewardStep == 0 then
+        BattlePass.lastCameraPosition = 0
+        BattlePass.lastRewardStep = 0
+        BattlePass.outfitWidget:setMarginLeft(165)
+        BattlePass.scrollBarWidget:setValue(0)
+    end
+end
+
+function BattlePass.onBattlePassRewards(rewardSteps)
+    if type(rewardSteps) == "table" and rewardSteps.chunk then
+        local total = tonumber(rewardSteps.total) or 0
+        local first = tonumber(rewardSteps.first) or 1
+        local steps = rewardSteps.steps or {}
+
+        if first <= 1 or not BattlePass.rewardChunkBuffer then
+            BattlePass.rewardChunkBuffer = {}
+        end
+
+        for _, step in ipairs(steps) do
+            local stepId = tonumber(step.stepId)
+            if stepId then
+                BattlePass.rewardChunkBuffer[stepId] = step
+            end
+        end
+
+        if total > 0 then
+            for stepId = 1, total do
+                if not BattlePass.rewardChunkBuffer[stepId] then
+                    return
+                end
+            end
+
+            local assembledRewards = {}
+            for stepId = 1, total do
+                table.insert(assembledRewards, BattlePass.rewardChunkBuffer[stepId])
+            end
+
+            BattlePass.rewardChunkBuffer = nil
+            rewardSteps = assembledRewards
+        end
+    end
+
+    BattlePass.rewardSteps = rewardSteps or {}
+    BattlePass:configureRewardPanel()
+end
+
+function BattlePass.calculateWeekNumber()
+    if (tonumber(BattlePass.beginTime) or 0) <= 0 then
+        return 1
+    end
+
+    local targetTime = os.time()
+    local begindate = os.time{year=os.date("*t", BattlePass.beginTime).year, month=os.date("*t", BattlePass.beginTime).month, day=os.date("*t", BattlePass.beginTime).day, hour=10, min=0, sec=0}
+    local diffSeconds = os.difftime(targetTime, begindate)
+    local diffDays = diffSeconds / 86400
+    local weekNumber = diffDays / 7
+    return math.ceil(weekNumber)
+end
+
+function BattlePass.getNextResetWeek(currentIndex)
+    if (tonumber(BattlePass.beginTime) or 0) <= 0 then
+        return os.time()
+    end
+
+    local nextDays = 7 * currentIndex
+    local begindate = os.time{year=os.date("*t", BattlePass.beginTime).year, month=os.date("*t", BattlePass.beginTime).month, day=os.date("*t", BattlePass.beginTime).day, hour=10, min=0, sec=0}
+    local nextResetTime = begindate + (nextDays * 86400)
+    local tableDate = os.date("*t", nextResetTime)
+    return os.time{year=tableDate.year, month=tableDate.month, day=tableDate.day, hour=10, min=0, sec=0}
+end
+
+function BattlePass:configureMissionPanel()
+    if not BattlePass.window:isVisible() and BattlePass.shouldShow then
+        BattlePass.shouldShow = false
+        BattlePass:showBattlePass(true)
+    end
+
+    -- Current reward points
+    BattlePass.window:recursiveGetChildById("playerLevel"):setText(BattlePass.currentRewardStep)
+    BattlePass.window:recursiveGetChildById("currentlyLevelText"):setText(string.format("%s/%s", BattlePass.progressPoints, BattlePass.nextStepPoints))
+    BattlePass.window:recursiveGetChildById("levelProgress"):setPercent(safePercent(BattlePass.progressPoints, BattlePass.nextStepPoints))
+
+    -- BattlePass end time
+    local seasonTotalTime = BattlePass.endTime - BattlePass.beginTime
+    local timeRemaining = BattlePass.endTime - os.time()
+    local seasonPercent = safePercent(timeRemaining, seasonTotalTime)
+    local seasonTimeText, seasonTimeTooltip = getFormatedTime(BattlePass.endTime)
+    BattlePass.window:recursiveGetChildById("seasonTimeText"):setText(seasonTimeText)
+    BattlePass.window:recursiveGetChildById("seasonHourglassIcon"):setTooltip(seasonTimeTooltip)
+    BattlePass.window:recursiveGetChildById("seasonTimeProgress"):setPercent(seasonPercent)
+
+    -- Next unlocked missions
+    local nextUnlock = BattlePass.getNextResetWeek(BattlePass.calculateWeekNumber())
+    local unlockInfo = BattlePass.window:recursiveGetChildById("unlockInfo")
+    unlockInfo:setText(string.format("New missions available in: %s", getTimeUntil(nextUnlock)))
+    stopUnlockTimer()
+    timerEvent(unlockInfo, nextUnlock)
+
+    -- Daily end time
+    local dailyTotalTime = BattlePass.dailyMissionsExpire - BattlePass.dailyMissionsBegin
+    local dailyTimeRemaining = BattlePass.dailyMissionsExpire - os.time()
+    local dailyPercent = safePercent(dailyTimeRemaining, dailyTotalTime)
+    local dailyTimeText, dailyTimeTooltip = getFormatedTime(BattlePass.dailyMissionsExpire)
+    BattlePass.window:recursiveGetChildById("dailyTimeText"):setText(dailyTimeText)
+    BattlePass.window:recursiveGetChildById("hourglassIcon"):setTooltip(dailyTimeTooltip)
+    BattlePass.window:recursiveGetChildById("dailyTimeProgress"):setPercent(dailyPercent)
+
+    -- Daily Missions
+    local dailyMissionsPanel = BattlePass.window:recursiveGetChildById('dailyMissionsBg')
+
+    for k, v in ipairs(BattlePass.dailyMissions) do
+        if k > 2 then
+            print(string.format("[WARNING] Daily mission count is higher than 2 missions. (%s)", #BattlePass.dailyMissions))
+            break
+        end
+
+        local widget = dailyMissionsPanel:getChildByIndex(getMissionIndex(k))
+        local currentProgress = tonumber(v.currentProgress) or 0
+        local maxProgress = tonumber(v.maxProgress) or 0
+        local completed = maxProgress > 0 and currentProgress >= maxProgress
+
+        widget:recursiveGetChildById("dailyMissionName"):setText(v.missionName or "")
+        widget:recursiveGetChildById("dailyMissionPoints"):setText(v.rewardPoints or 0)
+        widget:recursiveGetChildById("dailyMissionProgress"):setPercent(safePercent(currentProgress, maxProgress))
+        widget:recursiveGetChildById("dailyMissionProgressText"):setText(string.format("%s/%s", aggresiveNumberToStr(currentProgress), aggresiveNumberToStr(maxProgress)))
+        widget:recursiveGetChildById("dailyMissionInformation"):setTooltip(v.missionDescription or "")
+        widget:recursiveGetChildById("dailyBlockedMissionIcon"):setVisible(false)
+        widget:recursiveGetChildById("dailyFreeIcon"):setVisible(false)
+        widget:recursiveGetChildById("dailyRerollButton"):setVisible(not completed)
+        widget:recursiveGetChildById("dailyRerollButton").onClick = function() if not BattlePass:running() then return true end BattlePass:rerollDailyMission(v) end
+
+        local icon = (k == 1 and "daily-free-icon" or "daily-vip-icon")
+        if completed then
+            icon = "daily-icon-complete"
+        end
+
+        widget:recursiveGetChildById("dailyMissionIconImage"):setImageSource("/images/game/battlepass/" .. icon)
+        widget:recursiveGetChildById("dailyProgressPanel"):setVisible(not completed)
+        widget:recursiveGetChildById("dailyCompletedIcon"):setVisible(completed)
+
+        if not BattlePass:running() then
+            widget:setEnabled(false)
+            widget:setVisible(false)
+        end
+    end
+
+    -- General missions
+    local missionsPanel = BattlePass.window:recursiveGetChildById('missionsBackground')
+    local orderedWithIndex = getOrdenedMissions(BattlePass.seassonMissions)
+
+    for k, v in ipairs(orderedWithIndex) do
+        local data = v.data
+        local widget = missionsPanel:getChildByIndex(v.index)
+        if not widget then
+            break
+        end
+
+        local currentProgress = tonumber(data.currentProgress) or 0
+        local maxProgress = tonumber(data.maxProgress) or 0
+
+        widget:recursiveGetChildById("missionName"):setText(data.missionName or "")
+        widget:recursiveGetChildById("missionPoints"):setText(data.rewardPoints or 0)
+        widget:recursiveGetChildById("missionProgress"):setPercent(safePercent(currentProgress, maxProgress))
+        widget:recursiveGetChildById("missionProgressText"):setText(string.format("%s/%s", aggresiveNumberToStr(currentProgress), aggresiveNumberToStr(maxProgress)))
+        widget:recursiveGetChildById("missionInformation"):setTooltip(data.missionDescription or "")
+        widget:recursiveGetChildById("blockedMissionIcon"):setVisible(false)
+
+        local completed = maxProgress > 0 and currentProgress >= maxProgress
+        local missionIconBase = MissionRankIcons[data.rewardPoints] or "mission-locked-icon"
+        local missionIcon = completed and MissionRankIcons[data.rewardPoints] and missionIconBase .. "-complete" or missionIconBase
+        widget:recursiveGetChildById("missionIconImage"):setImageSource("/images/game/battlepass/" .. missionIcon)
+        widget:recursiveGetChildById("progressPanel"):setVisible(not completed)
+        widget:recursiveGetChildById("completedIcon"):setVisible(completed)
+        if not BattlePass:running() then
+            widget:setEnabled(false)
+            widget:setVisible(false)
+        end
+    end
+end
+
+function BattlePass:configureRewardPanel()
+    local rewardPanel = BattlePass.window:recursiveGetChildById('progressPanelContent')
+    if not rewardPanel then
+        return
+    end
+
+    for k, v in ipairs(BattlePass.rewardSteps) do
+        for i, reward in ipairs(v.rewards) do
+            local rewardType = reward.freeReward and "free" or "premium"
+            local rewardWidget = rewardPanel:getChildById(rewardType .. "RewardWidget" .. v.stepId)
+            local blockedReward = rewardPanel:getChildById(rewardType .. "BlockedRewardWidget" .. v.stepId)
+            if rewardWidget and blockedReward then
+                local availableReward = v.stepId <= BattlePass.currentRewardStep
+                blockedReward:setVisible(not availableReward)
+                rewardWidget:setVisible(availableReward)
+
+                local enabled = not reward.hasClamedReward
+                local text = reward.hasClamedReward and "Claimed" or "Claim Reward"
+                if not availableReward then
+                    text = "Locked"
+                    enabled = false
+                elseif not reward.freeReward and not BattlePass.premiumBattlepass and availableReward then
+                    text = "Deluxe"
+                    enabled = false
+                end
+
+                rewardWidget:recursiveGetChildById("collectRewardLabel"):setText(text)
+                rewardWidget:recursiveGetChildById("rewardBox"):setEnabled(enabled)
+                local rewardBoxImage = rewardWidget:recursiveGetChildById("rewardBoxImage")
+                if reward.hasClamedReward then
+                    if rewardType == "free" then
+                        rewardBoxImage:setImageSource("/images/game/battlepass/free-reward-chest-open")
+                        rewardBoxImage:setImageClip("26 22 38 42")
+                        rewardBoxImage:setSize("38 42")
+                        rewardBoxImage:setMarginTop(-10)
+                    else
+                        rewardBoxImage:setImageSource("/images/game/battlepass/vip-reward-chest-open")
+                        rewardBoxImage:setImageClip("24 20 40 44")
+                        rewardBoxImage:setSize("40 44")
+                        rewardBoxImage:setMarginTop(-12)
+                    end
+                else
+                    if rewardType == "free" then
+                        rewardBoxImage:setImageSource("/images/game/battlepass/free-reward-chest")
+                        rewardBoxImage:setImageClip("30 32 29 31")
+
+                    else
+                        rewardBoxImage:setImageSource("/images/game/battlepass/vip-reward-chest")
+                        rewardBoxImage:setImageClip("30 32 29 31")
+                    end
+                end
+                local rewardTypeText = reward.freeReward and "Free" or "Deluxe"
+                rewardBoxImage:setTooltip(string.format("Battle Pass %s Reward\n%s at level %d", string.capitalize(rewardTypeText), (reward.hasClamedReward and "Claimed" or "Unlocked"), v.stepId))
+
+                -- Set lockedBoxImage for blocked rewards (always closed chest)
+                local lockedBoxImage = blockedReward:recursiveGetChildById("lockedBoxImage")
+                if rewardType == "free" then
+                    lockedBoxImage:setImageSource("/images/game/battlepass/free-reward-chest")
+                else
+                    lockedBoxImage:setImageSource("/images/game/battlepass/vip-reward-chest")
+                end
+                lockedBoxImage:setTooltip(string.format("Battle Pass %s Reward\nUnlock at level %d", string.capitalize(rewardTypeText), v.stepId))
+            end
+        end
+    end
+end
+
+function BattlePass:getStepsToReward(rewardStep)
+    rewardStep = tonumber(rewardStep) or 0
+    local stepsToReward = 0
+    for i, data in ipairs(RewardPositions) do
+        if i <= rewardStep then
+            stepsToReward = stepsToReward + data.stepsTo
+        end
+    end
+    return stepsToReward
+end
+
+function BattlePass:loadPlayerPosition()
+    -- First execution
+    local stepsToReward = BattlePass:getStepsToReward(BattlePass.lastRewardStep)
+    if stepsToReward == 0 then
+        return
+    end
+
+    local newProgress = BattlePass.rewardMinMargin + stepsToReward * 32
+    local playerProgress = math.max(BattlePass.rewardMinMargin, math.min(newProgress, BattlePass.rewardMaxMargin))
+
+    BattlePass.outfitWidget:setMarginLeft(playerProgress)
+    BattlePass.scrollBarWidget:setValue(BattlePass.lastCameraPosition)
+end
+
+function BattlePass:updatePlayerPosition()
+    local stepsToReward = BattlePass:getStepsToReward(BattlePass.currentRewardStep)
+	local newProgress = BattlePass.rewardMinMargin + stepsToReward * 32
+	local playerProgress = math.max(BattlePass.rewardMinMargin, math.min(newProgress, BattlePass.rewardMaxMargin))
+
+    if playerProgress > 195 then
+        BattlePass.lastCameraPosition = getRewardPosition(BattlePass.lastRewardStep).scrollPosition
+        BattlePass:doAnimatePlayerMove(playerProgress)
+    end
+
+    -- Force save data
+    BattlePass:saveConfigJson()
+end
+
+function BattlePass:running()
+    local timeLeft = BattlePass.endTime - os.time()
+    if timeLeft <= 0 then
+        return false
+    end
+
+    return true
+end
+
+function BattlePass:doAnimatePlayerMove(targetMargin)
+    if targetMargin == BattlePass.outfitWidget:getMarginLeft() then
+        return
+    end
+
+    local player = g_game.getLocalPlayer()
+    BattlePass.outfitWidget:setDirection(East)
+    setOutfitStaticWalking(true)
+
+    BattlePass.isAnimatingWalk = true
+    local currentMargin = BattlePass.outfitWidget:getMarginLeft()
+    local scrollBar = BattlePass.scrollBarWidget
+
+    local function finishAnimation()
+        BattlePass.outfitWidget:setMarginLeft(targetMargin)
+        setOutfitStaticWalking(false)
+        BattlePass.isAnimatingWalk = false
+        BattlePass.lastRewardStep = BattlePass.currentRewardStep
+        BattlePass.lastCameraPosition = getRewardPosition(BattlePass.currentRewardStep).scrollPosition
+
+        -- Force save data
+        BattlePass:saveConfigJson()
+
+        scheduleEvent(function()
+            BattlePass.outfitWidget:setDirection(North)
+        end, 150)
+    end
+
+    local function animateStep()
+        if not BattlePass.outfitWidget:isVisible() then
+            finishAnimation()
+            return true
+        end
+
+        if currentMargin < targetMargin then
+            currentMargin = math.min(currentMargin + 3, targetMargin)
+            BattlePass.outfitWidget:setMarginLeft(currentMargin)
+            if currentMargin < targetMargin then
+                scheduleEvent(animateStep, 25)
+                if currentMargin >= 350 then
+                    scrollBar:setValue(scrollBar:getValue() + 3)
+                end
+            else
+                finishAnimation()
+            end
+        else
+            finishAnimation()
+        end
+    end
+
+    animateStep()
+end
+
+function BattlePass:loadConfigJson()
+    if not LoadedPlayer:isLoaded() then return end
+
+    local file = "/characterdata/" .. LoadedPlayer:getId() .. "/battlepass.json"
+    if g_resources.fileExists(file) then
+        local status, result = pcall(function()
+            return json.decode(g_resources.readFileContents(file))
+        end)
+
+        if not status then
+            return g_logger.error("Error while reading characterdata file. Details: " .. result)
+        end
+
+        if type(result) ~= "table" then
+            result = {}
+        end
+
+        BattlePass.lastRewardStep = result.currentRewardStep or 0
+        BattlePass.lastCameraPosition = result.lastCameraPosition or 0
+    else
+        BattlePass.lastRewardStep = 0
+        BattlePass.lastCameraPosition = 0
+    end
+end
+
+function BattlePass:saveConfigJson()
+	local config = { currentRewardStep = BattlePass.lastRewardStep, lastCameraPosition = BattlePass.lastCameraPosition }
+	if not LoadedPlayer:isLoaded() then return end
+
+	local file = "/characterdata/" .. LoadedPlayer:getId() .. "/battlepass.json"
+	local status, result = pcall(function() return json.encode(config, 2) end)
+	if not status then
+		return g_logger.error("Error while saving profile Battlepass data. Data won't be saved. Details: " .. result)
+	end
+
+	if result:len() > 100 * 1024 * 1024 then
+		return g_logger.error("Something went wrong, file is above 100MB, won't be saved")
+	end
+	g_resources.writeFileContents(file, result)
+end
+
+function BattlePass:rerollDailyMission(data)
+    if BattlePass.dailyRerollWindow then
+        BattlePass.dailyRerollWindow:destroy()
+    end
+
+    local player = g_game.getLocalPlayer()
+    if not player then
+        return
+    end
+
+    BattlePass.window:hide()
+
+    local okButton = function()
+        BattlePass.dailyRerollWindow:destroy()
+        BattlePass.dailyRerollWindow = nil
+        -- g_client.setInputLockWidget(nil)
+        sendToServer("reroll", { missionId = data.missionId })
+    end
+
+    local cancelButton = function()
+        BattlePass.dailyRerollWindow:destroy()
+        BattlePass.dailyRerollWindow = nil
+        BattlePass:showBattlePass()
+        -- g_client.setInputLockWidget(BattlePass.window)
+    end
+
+    local message = string.format("Are you sure you want to reroll the mission %s for %s gold?", data.missionName, comma_value(BattlePass.dailyRerollPrice * player:getLevel()))
+
+    BattlePass.dailyRerollWindow = displayGeneralBox(tr('Confirm mission reroll'), message, {
+        { text=tr('Ok'), callback = okButton },
+        { text=tr('Cancel'), callback = cancelButton },
+    }, okButton, cancelButton)
+end
+
+function onResourceBalance()
+    updateGoldBalance()
+end

--- a/modules/game_battlepass/battlepass.otmod
+++ b/modules/game_battlepass/battlepass.otmod
@@ -1,0 +1,9 @@
+Module
+  name: game_battlepass
+  description: Battle Pass
+  author: R!ck && ZLukSrT#8740 && Christianlb
+  sandboxed: true
+  autoload: true
+  scripts: [ battlepass, const, classes/rewards ]
+  @onLoad: init()
+  @onUnload: terminate()

--- a/modules/game_battlepass/battlepass.otmod
+++ b/modules/game_battlepass/battlepass.otmod
@@ -4,6 +4,6 @@ Module
   author: R!ck && ZLukSrT#8740 && Christianlb
   sandboxed: true
   autoload: false
-  scripts: [ battlepass, const, classes/rewards ]
+  scripts: [ const, battlepass, classes/rewards ]
   @onLoad: BattlePass.init()
   @onUnload: BattlePass.terminate()

--- a/modules/game_battlepass/battlepass.otmod
+++ b/modules/game_battlepass/battlepass.otmod
@@ -3,7 +3,7 @@ Module
   description: Battle Pass
   author: R!ck && ZLukSrT#8740 && Christianlb
   sandboxed: true
-  autoload: true
+  autoload: false
   scripts: [ battlepass, const, classes/rewards ]
   @onLoad: init()
   @onUnload: terminate()

--- a/modules/game_battlepass/battlepass.otmod
+++ b/modules/game_battlepass/battlepass.otmod
@@ -5,5 +5,5 @@ Module
   sandboxed: true
   autoload: false
   scripts: [ battlepass, const, classes/rewards ]
-  @onLoad: init()
-  @onUnload: terminate()
+  @onLoad: BattlePass.init()
+  @onUnload: BattlePass.terminate()

--- a/modules/game_battlepass/battlepass.otui
+++ b/modules/game_battlepass/battlepass.otui
@@ -967,7 +967,7 @@ NewHeadlessWindow
   id: battlePassWindow
   anchors.horizontalCenter: parent.horizontalCenter
   size: 795 595
-  @onEscape: modules.game_battlepass.hide()
+  @onEscape: modules.game_battlepass.BattlePass.hide()
   UIWidget
     size: 145 56
     anchors.top: parent.top
@@ -1003,7 +1003,7 @@ NewHeadlessWindow
           image-clip: 0 34 384 34
         $checked:
           image-clip: 0 34 384 34
-        @onClick: loadMenu('challengesMenu')
+        @onClick: modules.game_battlepass.BattlePass.loadMenu('challengesMenu')
       Button
         id: rewardsMenu
         anchors.top: parent.top
@@ -1019,7 +1019,7 @@ NewHeadlessWindow
           image-clip: 0 102 383 34
         $checked:
           image-clip: 0 102 383 34
-        @onClick: loadMenu('rewardsMenu')
+        @onClick: modules.game_battlepass.BattlePass.loadMenu('rewardsMenu')
 
     Panel
       id: contentPanel
@@ -1048,7 +1048,7 @@ NewHeadlessWindow
       anchors.right: parent.right
       !text: tr('Close')
       size: 43 20
-      @onClick: modules.game_battlepass.hide()
+      @onClick: modules.game_battlepass.BattlePass.hide()
 
     Button
       id: bPassWiki
@@ -1070,7 +1070,7 @@ NewHeadlessWindow
       anchors.right: prev.left
       margin-right: 9
       !text: tr('Get Deluxe Battle Pass')
-      @onClick: modules.game_battlepass.redirectToStore()
+      @onClick: modules.game_battlepass.BattlePass.redirectToStore()
       UIWidget
         id: getVipIcon
         size: 16 16

--- a/modules/game_battlepass/battlepass.otui
+++ b/modules/game_battlepass/battlepass.otui
@@ -193,12 +193,6 @@ SelectRewardWindow < NewHeadlessWindow
         cell-spacing: 10
         num-lines: 1
         num-columns: 50
-      @onSetup: |
-        for i = 1, 30 do
-          local slot = g_ui.createWidget('RewardInfoSlot', self)
-          slot:setId('rewardSlot' .. (i - 1))
-          slot:setVisible(false)
-        end
     UIButton
       id: rotateNextButton
       size: 20 20
@@ -314,19 +308,6 @@ SelectRewardWindow < NewHeadlessWindow
       margin-top: -1
       phantom: true
       image-source: /images/store/rectangle-highlight
-
-PlaceHolder < UIWidget
-  size: 16380 384
-  phantom: true
-
-  UICreature
-    id: playerOutfit
-    phantom: true
-    size: 64 64
-    anchors.top: parent.top
-    anchors.left: parent.left
-    margin-left: 165
-    margin-top: 175
 
 MapFragment < UIWidget
   size: 384 384
@@ -1078,7 +1059,7 @@ NewHeadlessWindow
       anchors.right: prev.left
       margin-right: 9
       !text: tr('Battle Pass Wiki')
-      @onClick: g_platform.openUrl("https://wiki.rubinot.com/pt-BR/passe-de-batalha/season-2")
+      @onClick: g_platform.openUrl(BATTLEPASS_WIKI_URL)
 
     Button
       id: getVipPassTicket

--- a/modules/game_battlepass/battlepass.otui
+++ b/modules/game_battlepass/battlepass.otui
@@ -1,0 +1,1135 @@
+ConfirmReward < NewHeadlessWindow
+  anchors.centerIn: parent
+  size: 455 245
+  UIWidget
+    size: 145 56
+    anchors.top: parent.top
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin-top: -33
+    image-source: /images/game/tutorial/backdrop_crestr
+    phantom: true
+  Panel
+    id: contentPanel
+    anchors.fill: parent
+    margin: 15 13 17 13
+    TextEdit
+      id: textContent
+      anchors.top: parent.top
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: separator.top
+      vertical-scrollbar: textContentScrollBar
+      margin-top: 10
+      margin-bottom: 10
+      text-align: center
+      padding: 5
+      focusable: false
+      multi-line: true
+      background-color: #484848
+      text-wrap: true
+
+    VerticalScrollBar
+      id: textContentScrollBar
+      anchors.top: prev.top
+      anchors.bottom: prev.bottom
+      anchors.right: prev.right
+      margin: 1 1 1 0
+      step: 20
+      pixels-scroll: true
+
+    HorizontalSeparator
+      id: separator
+      anchors.bottom: next.top
+      anchors.left: parent.left
+      anchors.right: parent.right
+      margin-bottom: 10
+    Button
+      id: cancel
+      anchors.bottom: parent.bottom
+      anchors.right: parent.right
+      !text: tr('Cancel')
+      size: 43 20
+      enabled: true
+    Button
+      id: confirm
+      anchors.bottom: parent.bottom
+      anchors.right: prev.left
+      margin-right: 5
+      !text: tr('Confirm')
+      size: 43 20
+
+RewardInfoSlot < UIWidget
+  size: 66 66
+  image-source: /images/ui/item66
+  border-width: 1
+  border-color-top: #161616
+  border-color-left: #161616
+  border-color-bottom: #787878
+  border-color-right: #787878
+  focusable: false
+
+  $focus:
+    border-width: 1
+    border-color: white
+
+  $!focus:
+    border-width: 1
+    border-color-top: #161616
+    border-color-left: #161616
+    border-color-bottom: #787878
+    border-color-right: #787878
+
+  UIItem
+    id: rewardItem
+    size: 64 64
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.verticalCenter: parent.verticalCenter
+    image-source:
+    visible: false
+    draggable: false
+    tooltip-delayed: true
+    virtual-count: false
+    virtual: true
+    fixed-size: true
+
+    Label
+      id: rewardItemCount
+      anchors.bottom: parent.bottom
+      anchors.right: parent.right
+      margin-bottom: 2
+      margin-right: 2
+      !text: ''
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-auto-resize: true
+  UICreature
+    id: rewardOutfit
+    size: 64 64
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.verticalCenter: parent.verticalCenter
+    idle-animate: true
+    visible: false
+    tooltip-delayed: true
+    outfit-center: true
+  UIWidget
+    id: rewardSpecial
+    size: 64 64
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.verticalCenter: parent.verticalCenter
+    phantom: false
+    visible: false
+    tooltip-delayed: true
+
+
+SelectRewardWindow < NewHeadlessWindow
+  id: battlePassRewardWindow
+  anchors.horizontalCenter: parent.horizontalCenter
+  size: 500 255
+  @onEscape: self:hide()
+  UIWidget
+    size: 145 56
+    anchors.top: parent.top
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin-top: -33
+    image-source: /images/game/tutorial/backdrop_crestr
+    phantom: true
+  Panel
+    id: mainPanel
+    anchors.fill: parent
+    margin: 15 13 17 13
+    Label
+      id: rewardLabel
+      anchors.top: parent.top
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-top: 15
+      !text: 'Battlepass Reward - Step %d\n Click on the collect button to receive your reward.'
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-align: center
+      wrap: true
+      text-auto-resize: true
+    Label
+      id: infoLabel
+      anchors.top: rewardLabel.bottom
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-top: 10
+      !text: tr('This reward does not have a visual representation yet.')
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-align: center
+      wrap: true
+      text-auto-resize: true
+
+    UIButton
+      id: rotatePrevButton
+      size: 20 20
+      anchors.top: next.top
+      anchors.right: next.left
+      margin-top: 30
+      margin-right: 10
+      image-source: /images/ui/rotate_button
+      image-clip: 0 0 20 20
+      visible: false
+      $pressed:
+        image-clip: 0 20 20 20
+      padding: 1
+      @onClick:
+
+    TextList
+      id: rewardsInfoPanel
+      anchors.top: infoLabel.bottom
+      anchors.horizontalCenter: parent.horizontalCenter
+      height: 95
+      width: 465
+      margin-top: 10
+      margin-bottom: 10
+      horizontal-scrollbar: rewardsInfoScrollBar
+      padding-top: 9
+      padding-left: 9
+      padding-right: 9
+      layout:
+        type: grid
+        cell-size: 66 66
+        cell-spacing: 10
+        num-lines: 1
+        num-columns: 50
+      @onSetup: |
+        for i = 1, 30 do
+          local slot = g_ui.createWidget('RewardInfoSlot', self)
+          slot:setId('rewardSlot' .. (i - 1))
+          slot:setVisible(false)
+        end
+    UIButton
+      id: rotateNextButton
+      size: 20 20
+      anchors.top: prev.top
+      anchors.left: prev.right
+      margin-top: 30
+      margin-left: 10
+      image-source: /images/ui/rotate_button
+      image-clip: 20 0 20 20
+      visible: false
+      $pressed:
+        image-clip: 20 20 20 20
+      padding: 1
+      @onClick:
+
+    HorizontalScrollBar
+      id: rewardsInfoScrollBar
+      anchors.bottom: rewardsInfoPanel.bottom
+      anchors.right: rewardsInfoPanel.right
+      anchors.left: rewardsInfoPanel.left
+      step: 65
+      margin: 0 1 1 2
+      pixels-scroll: true
+      visible: true
+
+    UIButton
+      id: previousButton
+      size: 20 20
+      anchors.top: next.top
+      anchors.right: next.left
+      margin-top: 30
+      margin-right: 10
+      image-source: /images/ui/rotate_button
+      image-clip: 0 0 20 20
+      visible: false
+      $pressed:
+        image-clip: 0 20 20 20
+      padding: 1
+      @onClick:
+
+    TextList
+      id: outfitsInfoPanel
+      anchors.top: rewardsInfoPanel.bottom
+      anchors.horizontalCenter: parent.horizontalCenter
+      height: 85
+      width: 315
+      margin-top: 10
+      margin-bottom: 10
+      padding-top: 9
+      padding-left: 10
+      visible: false
+      layout:
+        type: grid
+        cell-size: 66 66
+        cell-spacing: 10
+        num-lines: 1
+        num-columns: 50
+      RewardInfoSlot
+        id: outfitPreview0
+        visible: true
+      RewardInfoSlot
+        id: outfitPreview1
+        visible: true
+      RewardInfoSlot
+        id: outfitPreview2
+        visible: true
+      RewardInfoSlot
+        id: outfitPreview3
+        visible: true
+
+    UIButton
+      id: nextButton
+      size: 20 20
+      anchors.top: prev.top
+      anchors.left: prev.right
+      margin-top: 30
+      margin-left: 10
+      image-source: /images/ui/rotate_button
+      image-clip: 20 0 20 20
+      visible: false
+      $pressed:
+        image-clip: 20 20 20 20
+      padding: 1
+      @onClick:
+
+    HorizontalSeparator
+      id: separator
+      anchors.bottom: next.top
+      anchors.left: parent.left
+      anchors.right: parent.right
+      margin-bottom: 10
+    Button
+      id: close
+      anchors.bottom: parent.bottom
+      anchors.right: parent.right
+      !text: tr('Close')
+      size: 43 20
+    Button
+      id: collectRewardButton
+      size: 63 20
+      image-source: /images/ui/buttons-blue
+      image-border: 2
+      anchors.bottom: parent.bottom
+      anchors.right: prev.left
+      margin-right: 5
+      !text: tr('Collect')
+    UIWidget
+      id: border
+      size: 65 22
+      anchors.top: prev.top
+      anchors.left: prev.left
+      margin-left: -1
+      margin-top: -1
+      phantom: true
+      image-source: /images/store/rectangle-highlight
+
+PlaceHolder < UIWidget
+  size: 16380 384
+  phantom: true
+
+  UICreature
+    id: playerOutfit
+    phantom: true
+    size: 64 64
+    anchors.top: parent.top
+    anchors.left: parent.left
+    margin-left: 165
+    margin-top: 175
+
+MapFragment < UIWidget
+  size: 384 384
+  anchors.top: parent.top
+  anchors.left: parent.left
+
+DailyMissionWidget < UIWidget
+  id: dailyMissionWidget
+  size: 100 154
+  image-source: /images/game/battlepass/dailyMissionBg
+  image-border: 18
+  Panel
+    id: dailyMissionPanel
+    size: 86 80
+    anchors.top: parent.top
+    anchors.left: parent.left
+    margin-top: 9
+    margin-left: 9
+    UIWidget
+      id: dailyMissionIconImage
+      size: 40 40
+      anchors.horizontalCenter: parent.horizontalCenter
+      anchors.verticalCenter: parent.verticalCenter
+      image-source: /images/game/battlepass/daily-vip-icon
+      margin-left: -2
+    UIWidget
+      id: dailyMissionInformation
+      size: 12 12
+      anchors.top: parent.top
+      anchors.right: parent.right
+      margin-top: 5
+      margin-right: 7
+      image-source: /images/skin/show-gui-help-blue
+      !tooltip: tr('Here we gonna print the mission information')
+    Label
+      id: dailyMissionPoints
+      !text: tr("?")
+      anchors.bottom: parent.bottom
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-left: -4
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-auto-resize: true
+  Label
+    id: dailyMissionName
+    size: 92 30
+    !text: tr('Locked')
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    margin-top: 10
+    margin-left: 4
+    font: verdana-11px-rounded
+    color: #c0c0c0
+    text-wrap: true
+    text-align: center
+  Panel
+    id: dailyProgressPanel
+    size: 85 15
+    anchors.bottom: parent.bottom
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin-bottom: 7
+    ProgressBarSD
+      id: dailyMissionProgress
+      anchors.fill: parent
+      image-source: /images/ui/bosstiary-progress
+      margin: 1 1 1 1
+      percent: 0
+      opacity: 0.9
+    Label
+      id: dailyMissionProgressText
+      !text: tr('? / ?')
+      anchors.top: parent.top
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-top: -1
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-auto-resize: true
+  UIWidget
+    id: dailyCompletedIcon
+    size: 13 13
+    anchors.bottom: parent.bottom
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin-bottom: 9
+    image-source: /images/game/battlepass/completed
+    visible: false
+  UIWidget
+    id: dailyBlockedMissionIcon
+    anchors.fill: parent
+    image-source: /images/game/battlepass/dailyBlockPattern
+    visible: true
+  UIWidget
+    id: dailyRerollButton
+    size: 14 14
+    anchors.top: parent.top
+    anchors.left: parent.left
+    margin-top: 12
+    margin-left: 10
+    image-source: /images/store/store-rerol
+    image-clip: 0 0 14 14
+    !tooltip: tr('Reroll Daily Mission')
+    tooltip-delayed: true
+    visible: false
+    $hover !pressed:
+      image-clip: 0 0 14 14
+    $pressed:
+      image-clip: 0 14 14 14
+  UIWidget
+    id: dailyFreeIcon
+    size: 36 36
+    anchors.top: parent.top
+    anchors.left: parent.left
+    image-source: /images/game/premium/icon-banner-premium
+    margin: 2
+    visible: true
+    !tooltip: tr('Deluxe Daily Mission,\nExclusive for Deluxe Battle Pass holders.')
+
+MissionWidget < UIWidget
+  id: missionWidget
+  size: 104 154
+  image-source: /images/game/battlepass/missionBg
+  image-border: 18
+  Panel
+    id: missionPanel
+    size: 86 80
+    anchors.top: parent.top
+    anchors.left: parent.left
+    margin-top: 9
+    margin-left: 9
+    UIWidget
+      id: missionIconImage
+      size: 40 40
+      anchors.horizontalCenter: parent.horizontalCenter
+      anchors.verticalCenter: parent.verticalCenter
+      image-source: /images/game/battlepass/mission-locked-icon
+    UIWidget
+      id: missionInformation
+      size: 12 12
+      anchors.top: parent.top
+      anchors.right: parent.right
+      margin-top: 5
+      margin-right: 5
+      image-source: /images/skin/show-gui-help-blue
+      !tooltip: tr('Here we gonna print the mission information')
+    Label
+      id: missionPoints
+      !text: tr("?")
+      anchors.bottom: parent.bottom
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-left: -1
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-auto-resize: true
+  Label
+    id: missionName
+    size: 96 30
+    !text: tr('Locked')
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    margin-top: 10
+    margin-left: 4
+    font: verdana-11px-rounded
+    color: #c0c0c0
+    text-wrap: true
+    text-align: center
+  Panel
+    id: progressPanel
+    size: 85 15
+    anchors.bottom: parent.bottom
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin-bottom: 7
+    ProgressBarSD
+      id: missionProgress
+      anchors.fill: parent
+      image-source: /images/ui/bosstiary-progress
+      margin: 1 1 1 1
+      percent: 0
+      opacity: 0.9
+    Label
+      id: missionProgressText
+      !text: tr('? / ?')
+      anchors.top: parent.top
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-top: -1
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-auto-resize: true
+  UIWidget
+    id: completedIcon
+    size: 13 13
+    anchors.bottom: parent.bottom
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin-bottom: 9
+    image-source: /images/game/battlepass/completed
+    visible: false
+  UIWidget
+    id: blockedMissionIcon
+    anchors.fill: parent
+    image-source: /images/game/battlepass/blockPattern
+    visible: true
+  UIWidget
+    id: newMissionIcon
+    size: 20 20
+    anchors.top: parent.top
+    anchors.left: parent.left
+    image-source: /images/store/button-store-new
+    margin: 2
+    visible: false
+  UIWidget
+    id: freeIcon
+    size: 36 36
+    anchors.top: parent.top
+    anchors.left: parent.left
+    image-source: /images/game/premium/icon-banner-premium
+    margin: 2
+    visible: false
+
+MissionPanel < Panel
+  anchors.fill: parent
+  Panel
+    id: bannerPanel
+    size: 220 235
+    image-source: /images/ui/2pixel-up-frame-borderimage
+    image-border: 5
+    anchors.top: parent.top
+    anchors.left: parent.left
+    Panel
+      id: content
+      anchors.fill: parent
+      margin: 5
+      Panel
+        id: bannerBg
+        size: 210 225
+        image-source: /images/game/destiny_wheel/menuBg
+        image-border: 1
+        anchors.top: parent.top
+        anchors.left: parent.left
+        UIWidget
+          id: passBanner
+          anchors.fill: parent
+          margin: 1 1 1 1
+          image-source: /images/game/battlepass/battlePass-anim
+
+  Panel
+    id: dailyBg
+    size: 220 225
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    margin-top: 7
+    image-source: /images/ui/minipanel
+    image-border: 19
+    Label
+      id: dailyTitle
+      !text: tr('Daily Missions')
+      anchors.top: parent.top
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-top: 2
+      font: verdana-11px-rounded
+      color: #888888
+      text-auto-resize: true
+    Panel
+      id: dailyMissionsBg
+      size: 210 164
+      image-source: /images/game/destiny_wheel/menuBg
+      image-border: 1
+      anchors.top: parent.top
+      anchors.left: parent.left
+      margin-top: 24
+      margin-left: 5
+      padding: 3
+      padding-top: 5
+      layout:
+        type: grid
+        cell-size: 100 154
+        cell-spacing: 4
+        num-lines: 1
+        num-columns: 2
+      DailyMissionWidget
+        @onSetup: |
+          local imageBackground = self:recursiveGetChildById('dailyMissionIconImage')
+          imageBackground:setImageSource('/images/game/battlepass/daily-free-icon')
+      DailyMissionWidget
+        @onSetup: |
+          local imageBackground = self:recursiveGetChildById('dailyMissionIconImage')
+          imageBackground:setImageSource('/images/game/battlepass/daily-vip-icon')
+    UIWidget
+      id: dailyTimeBg
+      height: 21
+      anchors.bottom: parent.bottom
+      anchors.left: parent.left
+      anchors.right: parent.right
+      image-source: /images/ui/bosstiary-bg
+      margin-bottom: 9
+      margin-left: 5
+      margin-right: 5
+      image-border: 5
+      ProgressBarSD
+        id: dailyTimeProgress
+        anchors.fill: parent
+        margin: 1 1 1 1
+        image-source: /images/ui/bosstiary-progress
+        percent: 0
+      Label
+        id: dailyTimeText
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.horizontalCenter: parent.horizontalCenter
+        !text: tr("22 Hours left")
+        font: verdana-11px-rounded
+        color: #c0c0c0
+        text-auto-resize: true
+      UIWidget
+        id: hourglassIcon
+        size: 10 15
+        anchors.top: prev.top
+        anchors.left: prev.right
+        margin-left: 5
+        tooltip-delayed: true
+        image-source: /images/game/battlepass/battlepass-hourglass
+  Panel
+    id: playerProgressPanel
+    height: 120
+    anchors.top: parent.top
+    anchors.left: prev.right
+    anchors.right: parent.right
+    image-source: /images/ui/minipanel
+    image-border: 20
+    margin-left: 10
+    Label
+      id: panelTitle
+      !text: tr('Battle Pass')
+      anchors.top: parent.top
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-top: 2
+      font: verdana-11px-rounded
+      color: #888888
+      text-auto-resize: true
+    Panel
+      id: progressPanel
+      anchors.top: parent.top
+      anchors.fill: parent
+      margin: 18 5 5 5
+      UIWidget
+        id: playerLevelBg
+        size: 90 85
+        anchors.top: parent.top
+        anchors.left: parent.left
+        margin-top: 8
+        margin-left: 5
+        image-source: /images/ui/item66
+        image-border: 5
+        UIWidget
+          id: playerLevelBanner
+          size: 81 75
+          anchors.centerIn: parent
+          image-source: /images/game/battlepass/player-icon-level
+          Label
+            id: playerLevel
+            text: 100
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            margin-bottom: 4
+            margin-left: -3
+            font: verdana-11px-rounded
+            color: #c0c0c0
+            text-auto-resize: true
+            text-align: center
+      Label
+        id: battlePassDesc
+        !text: tr('Complete missions to earn points and unlock rewards!')
+        anchors.top: parent.top
+        anchors.left: playerLevelBg.right
+        margin-top: 7
+        margin-left: 45
+        font: verdana-11px-rounded
+        color: #c0c0c0
+        text-auto-resize: true
+      Label
+        id: unlockInfo
+        !text: tr('New missions available in: 00:00:00:00')
+        anchors.top: prev.bottom
+        anchors.left: playerLevelBg.right
+        margin-top: 5
+        margin-left: 95
+        font: verdana-11px-rounded
+        color: #c0c0c0
+        text-auto-resize: true
+
+      HorizontalSeparator
+        id: battlePassDescSep
+        anchors.top: battlePassDesc.bottom
+        anchors.left: playerLevelBg.right
+        anchors.right: parent.right
+        margin-top: 24
+        margin-left: 8
+        margin-right: 4
+      Label
+        id: progressTitle
+        !text: tr('Level Progress')
+        anchors.bottom: progressBarBg.top
+        anchors.horizontalCenter: progressBarBg.horizontalCenter
+        margin-bottom: 5
+        font: verdana-11px-rounded
+        color: #c0c0c0
+        text-auto-resize: true
+      UIWidget
+        id: progressBarBg
+        size: 195 20
+        anchors.bottom: parent.bottom
+        anchors.left: playerLevelBg.right
+        image-source: /images/ui/bosstiary-bg
+        margin-bottom: 4
+        margin-left: 8
+        image-border: 15
+        ProgressBarSD
+          id: levelProgress
+          anchors.fill: parent
+          margin: 1 1 1 1
+          image-source: /images/ui/bosstiary-progress
+          percent: 0
+        Label
+          id: currentlyLevelText
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.horizontalCenter: parent.horizontalCenter
+          margin-left: -5
+          text: 0
+          font: verdana-11px-rounded
+          color: #c0c0c0
+          text-auto-resize: true
+      VerticalSeparator
+        id: separator
+        anchors.top: battlePassDescSep.bottom
+        anchors.left: progressBarBg.right
+        anchors.bottom: parent.bottom
+        margin-top: 7
+        margin-left: 17
+        margin-bottom: 4
+      Label
+        id: seasonTimeTitle
+        !text: tr('Season ends in')
+        anchors.bottom: seasonTimeBg.top
+        anchors.horizontalCenter: seasonTimeBg.horizontalCenter
+        margin-bottom: 5
+        font: verdana-11px-rounded
+        color: #c0c0c0
+        text-auto-resize: true
+      UIWidget
+        id: seasonTimeBg
+        size: 195 20
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        image-source: /images/ui/bosstiary-bg
+        margin-bottom: 4
+        margin-right: 4
+        image-border: 15
+        ProgressBarSD
+          id: seasonTimeProgress
+          anchors.fill: parent
+          margin: 1 1 1 1
+          image-source: /images/ui/bosstiary-progress
+          percent: 0
+        Label
+          id: seasonTimeText
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.horizontalCenter: parent.horizontalCenter
+          !text: tr("48 Days left")
+          margin-left: -5
+          margin-top: 1
+          font: verdana-11px-rounded
+          color: #c0c0c0
+          text-auto-resize: true
+        UIWidget
+          id: seasonHourglassIcon
+          size: 10 15
+          anchors.top: prev.top
+          anchors.left: prev.right
+          margin-left: 5
+          image-source: /images/game/battlepass/battlepass-hourglass
+  ScrollablePanel
+    id: missionsBackground
+    image-source: /images/game/destiny_wheel/menuBg
+    image-border: 1
+    anchors.top: prev.bottom
+    anchors.left: prev.left
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    horizontal-scrollbar: missionsListScrollBar
+    margin-top: 10
+    padding: 4
+    padding-top: 7
+    layout:
+      type: grid
+      cell-size: 104 154
+      cell-spacing: 3
+      num-lines: 2
+      num-columns: 13
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+    MissionWidget
+
+
+  HorizontalScrollBar
+    id: missionsListScrollBar
+    anchors.bottom: prev.bottom
+    anchors.right: prev.right
+    anchors.left: prev.left
+    step: 65
+    margin: 0 1 1 2
+    pixels-scroll: true
+    visible: true
+
+BlockedRewardWidget < Panel
+  size: 120 71
+  anchors.top: parent.top
+  anchors.left: parent.left
+  UIWidget
+    id: rewardBox
+    size: 120 71
+    anchors.top: parent.top
+    anchors.left: parent.left
+    image-source: /images/game/battlepass/reward-button
+    image-clip: 0 0 120 71
+    opacity: 0.8
+    visible: true
+    enabled: false
+    $hover !pressed:
+      image-clip: 0 0 120 71
+    $pressed:
+      image-clip: 0 71 120 71
+    Label
+      id: lockedRewardLabel
+      !text: tr('Locked')
+      anchors.bottom: parent.bottom
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-bottom: 22
+      margin-left: 2
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-align: center
+  UIWidget
+    id: lockedBoxImage
+    size: 29 31
+    anchors.top: parent.top
+    anchors.horizontalCenter: parent.horizontalCenter
+    tooltip-delayed: true
+    image-source: /images/game/battlepass/vip-reward-chest
+    image-clip: 30 32 29 31
+
+RewardWidget < Panel
+  size: 120 71
+  anchors.top: parent.top
+  anchors.left: parent.left
+  UIWidget
+    id: rewardBox
+    size: 120 71
+    anchors.top: parent.top
+    anchors.left: parent.left
+    image-source: /images/game/battlepass/reward-button
+    image-clip: 0 0 120 71
+    visible: true
+    $hover !pressed:
+      image-clip: 0 0 120 71
+    $pressed:
+      image-clip: 0 71 120 71
+    Label
+      id: collectRewardLabel
+      !text: tr('Claim Reward')
+      anchors.bottom: parent.bottom
+      anchors.horizontalCenter: parent.horizontalCenter
+      margin-bottom: 22
+      margin-left: 2
+      font: verdana-11px-rounded
+      color: #c0c0c0
+      text-align: center
+  UIWidget
+    id: rewardBoxImage
+    size: 29 31
+    anchors.top: parent.top
+    anchors.horizontalCenter: parent.horizontalCenter
+    tooltip-delayed: true
+    image-source: /images/game/battlepass/vip-reward-chest
+    image-clip: 0 0 29 31
+
+ProgressPanel < Panel
+  anchors.fill: parent
+  ScrollablePanel
+    id: missionsBackground
+    height: 386
+    image-source: /images/ui/1pixel-down-frame
+    image-border: 1
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    horizontal-scrollbar: progressPanelScrollBar
+    padding: 1
+    phantom: true
+    inverted-view: true
+    Panel
+      id: progressPanelContent
+      size: 18045 384
+      anchors.top: parent.top
+      anchors.left: parent.left
+      @onSetup: |
+        for i = 0, 46 do
+          local widget = g_ui.createWidget('MapFragment', self)
+          widget:setImageSource("/images/game/battlepass/map/battlepass-background_" .. i)
+          widget:setMarginLeft(384 * i)
+        end
+
+    UICreature
+      id: playerOutfit
+      focusable: false
+      phantom: true
+      size: 64 64
+      anchors.top: parent.top
+      anchors.left: parent.left
+      idle-animate: true
+      margin-left: 165
+      margin-top: 165
+
+  HorizontalScrollBar
+    id: progressPanelScrollBar
+    anchors.bottom: prev.bottom
+    anchors.right: prev.right
+    anchors.left: prev.left
+    step: 100
+    margin: 0 1 1 1
+    pixels-scroll: true
+    visible: true
+    phantom: true
+    inverted-view: true
+
+// MAIN WINDOW
+NewHeadlessWindow
+  id: battlePassWindow
+  anchors.horizontalCenter: parent.horizontalCenter
+  size: 795 595
+  @onEscape: modules.game_battlepass.hide()
+  UIWidget
+    size: 145 56
+    anchors.top: parent.top
+    anchors.horizontalCenter: parent.horizontalCenter
+    margin-top: -33
+    image-source: /images/game/tutorial/backdrop_crestr
+    phantom: true
+  Panel
+    id: mainPanel
+    anchors.fill: parent
+    margin: 15 13 17 13
+    Panel
+      id: optionsTabBar
+      height: 36
+      image-source: /images/game/destiny_wheel/menuBg
+      image-border: 1
+      anchors.top: parent.top
+      anchors.left: parent.left
+      anchors.right: parent.right
+      margin-top: 12
+      Button
+        id: challengesMenu
+        anchors.top: parent.top
+        anchors.left: parent.left
+        size: 384 34
+        margin-left: 1
+        margin-top: 1
+        image-source: /images/game/battlepass/battlepass_menu
+        image-clip: 0 0 384 34
+        $hover !checked:
+          image-clip: 0 0 384 34
+        $pressed:
+          image-clip: 0 34 384 34
+        $checked:
+          image-clip: 0 34 384 34
+        @onClick: loadMenu('challengesMenu')
+      Button
+        id: rewardsMenu
+        anchors.top: parent.top
+        anchors.left: prev.right
+        size: 383 34
+        margin-left: 1
+        margin-top: 1
+        image-source: /images/game/battlepass/battlepass_menu
+        image-clip: 0 68 383 34
+        $hover !checked:
+          image-clip: 0 68 383 34
+        $pressed:
+          image-clip: 0 102 383 34
+        $checked:
+          image-clip: 0 102 383 34
+        @onClick: loadMenu('rewardsMenu')
+
+    Panel
+      id: contentPanel
+      anchors.top: optionsTabBar.bottom
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: separator.top
+      margin-top: 12
+      margin-bottom: 8
+      MissionPanel
+        id: missionPanel
+        visible: true
+      ProgressPanel
+        id: progressPanel
+        visible: false
+
+    HorizontalSeparator
+      id: separator
+      anchors.bottom: next.top
+      anchors.left: parent.left
+      anchors.right: parent.right
+      margin-bottom: 10
+    Button
+      id: close
+      anchors.bottom: parent.bottom
+      anchors.right: parent.right
+      !text: tr('Close')
+      size: 43 20
+      @onClick: modules.game_battlepass.hide()
+
+    Button
+      id: bPassWiki
+      size: 80 20
+      image-source: /images/ui/buttons-blue
+      image-border: 2
+      anchors.bottom: parent.bottom
+      anchors.right: prev.left
+      margin-right: 9
+      !text: tr('Battle Pass Wiki')
+      @onClick: g_platform.openUrl("https://wiki.rubinot.com/pt-BR/passe-de-batalha/season-2")
+
+    Button
+      id: getVipPassTicket
+      size: 130 20
+      image-source: /images/ui/buttons-blue
+      image-border: 2
+      anchors.bottom: parent.bottom
+      anchors.right: prev.left
+      margin-right: 9
+      !text: tr('Get Deluxe Battle Pass')
+      @onClick: modules.game_battlepass.redirectToStore()
+      UIWidget
+        id: getVipIcon
+        size: 16 16
+        anchors.top: parent.top
+        anchors.left: parent.left
+        margin-left: -10
+        margin-top: -10
+        phantom: true
+        image-source: /images/game/premium/icon-banner-premium-16x16
+    UIWidget
+      id: getVipPassTicketBorder
+      size: 133 22
+      anchors.top: prev.top
+      anchors.left: prev.left
+      margin-left: -1
+      margin-top: -1
+      phantom: true
+      image-source: /images/store/rectangle-highlight
+
+    Panel
+      id: rCoinPanel
+      size: 130 20
+      anchors.bottom: parent.bottom
+      anchors.left: parent.left
+      image-source: /images/ui/progress
+      image-border: 7
+      Panel
+        image-source: /images/store/icon-goldcoin
+        anchors.right: parent.right
+        anchors.top: parent.top
+        margin-top: 6
+        margin-right: 3
+      UIWidget
+        id: rCoins
+        !text: tr('0')
+        anchors.top: parent.top
+        anchors.right: prev.left
+        margin-right: 5
+        margin-top: 3
+        text-auto-resize: true
+        color: #c0c0c0
+        font: Verdana Bold-11px
+        tooltip-font: Verdana Bold-11px

--- a/modules/game_battlepass/battlepass.otui
+++ b/modules/game_battlepass/battlepass.otui
@@ -803,32 +803,6 @@ MissionPanel < Panel
       cell-spacing: 3
       num-lines: 2
       num-columns: 13
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
-    MissionWidget
 
 
   HorizontalScrollBar

--- a/modules/game_battlepass/classes/rewards.lua
+++ b/modules/game_battlepass/classes/rewards.lua
@@ -144,7 +144,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         self.confirmRewardWindow:recursiveGetChildById('textContent'):setText(self.textReward)
     end
 
-    BattlePass.window:hide()
+    BattlePass.hide()
 
     self.textReward = ''
     local infoLabel = self.claimRewardWindow:recursiveGetChildById("infoLabel")

--- a/modules/game_battlepass/classes/rewards.lua
+++ b/modules/game_battlepass/classes/rewards.lua
@@ -228,7 +228,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
             width = width + self.rewardWidthIncrement
         end
 
-        local message = "You will receive a random item from the list bellow:"
+        local message = "You will receive a random item from the list below:"
         if reward.stuck then
             message = message .. "\n[color=white]The reward will be bound to your character.[/color]"
         end
@@ -251,7 +251,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
             width = width + self.rewardWidthIncrement
         end
 
-        infoLabel:setText("You will receive a random mount from the list bellow:")
+        infoLabel:setText("You will receive a random mount from the list below:")
         self.textReward = string.format("You will receive a random mount from the list.")
     elseif BattleRewardTypes[reward.rewardType] == "Item" then
         local widget = widgetsPanel:recursiveGetChildById("rewardSlot0")
@@ -542,21 +542,21 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
             widget.rewardItem:setVisible(true)
             widget.rewardItem:setItemId(v.itemId)
             widget.rewardItem.rewardItemCount:setText(v.count > 1 and tostring(v.count) or "")
-            local itemName = getItemNameById(v.itemId)
-            widget.rewardItem:setTooltip(string.capitalize(itemName))
+            local childName = getItemNameById(v.itemId)
+            widget.rewardItem:setTooltip(string.capitalize(childName))
 
             width = width + self.rewardWidthIncrement
             if v.stuck then
                 stuck = true
             end
             if itemName ~= '' then
-                itemName = itemName .. ", " .. v.count .. " " .. string.capitalize(itemName)
+                itemName = itemName .. ", " .. v.count .. " " .. string.capitalize(childName)
             else
-                itemName = v.count .. " " .. string.capitalize(itemName)
+                itemName = v.count .. " " .. string.capitalize(childName)
             end
         end
 
-        local message = "You will receive these items from the list bellow:"
+        local message = "You will receive these items from the list below:"
         if stuck then
             message = message .. "\n[color=white]The reward will be bound to your character.[/color]"
         end
@@ -623,6 +623,10 @@ function BattlePassRewards:getRewardDescription(reward)
 end
 
 function BattlePassRewards:getReward(index, rewardType)
+    if not BattlePass or type(BattlePass.rewardSteps) ~= "table" then
+        return nil
+    end
+
     local isFreeReward = (rewardType == "free")
     for _, step in ipairs(BattlePass.rewardSteps) do
         if step.stepId == index then

--- a/modules/game_battlepass/classes/rewards.lua
+++ b/modules/game_battlepass/classes/rewards.lua
@@ -1,0 +1,639 @@
+local function getItemNameById(itemId)
+    local itemType = g_things.getThingType(itemId, ThingCategoryItem)
+    if itemType and itemType.getName and type(itemType.getName) == "function" then
+        return itemType:getName() or "Unknown Item"
+    end
+    return "Unknown Item"
+end
+
+if not BattlePassRewards then
+    BattlePassRewards = {}
+    BattlePassRewards.__index = BattlePassRewards
+
+    BattlePassRewards.claimRewardWindow = nil
+    BattlePassRewards.confirmRewardWindow = nil
+
+    BattlePassRewards.rewardWidthIncrement = 80
+    BattlePassRewards.rewardEmptyHeight = 140
+
+    BattlePassRewards.selectedItemId = -1
+
+    BattlePassRewards.textReward = ''
+end
+
+local skillName = {
+    [0] = "Fist Fighting",
+    [1] = "Club Fighting",
+    [2] = "Sword Fighting",
+    [3] = "Axe Fighting",
+    [4] = "Distance Fighting",
+    [5] = "Shielding",
+    [13] = "Magic Level"
+}
+
+local self = BattlePassRewards
+function BattlePassRewards:onConfirmClaimReward(index, rewardType)
+    local reward = self:getReward(index, rewardType)
+    if not reward then
+        return
+    end
+
+    if self.confirmRewardWindow then
+        self.confirmRewardWindow:destroy()
+        self.confirmRewardWindow = nil
+    end
+
+    self.claimRewardWindow = g_ui.createWidget("SelectRewardWindow", rootWidget)
+    local widgetsPanel = self.claimRewardWindow:recursiveGetChildById("rewardsInfoPanel")
+
+    local rewardLabel = self.claimRewardWindow:recursiveGetChildById("rewardLabel")
+    local text = rewardLabel:getText()
+    rewardLabel:setText(string.format(text, index))
+
+    self.claimRewardWindow.onEscape = function()
+        self.claimRewardWindow:destroy()
+        self.claimRewardWindow = nil
+        BattlePass:showBattlePass()
+    end
+
+    self.claimRewardWindow:recursiveGetChildById("close").onClick = function()
+        self.claimRewardWindow:destroy()
+        self.claimRewardWindow = nil
+        BattlePass:showBattlePass()
+
+        -- g_client.setInputLockWidget(BattlePass.window)
+    end
+
+    local function okfunction()
+        if self.selectedItemId == -1 and (BattleRewardTypes[reward.rewardType] == "Boosted Exercise" or BattleRewardTypes[reward.rewardType] == "Exercise Item" or
+         BattleRewardTypes[reward.rewardType] == "Extra Skill" or BattleRewardTypes[reward.rewardType] == "Elemental Outfit" or BattleRewardTypes[reward.rewardType] == "Choosable Item") then
+            modules.game_textmessage.displayFailureMessage("You must select an item before collecting the reward.")
+            return
+        end
+
+        self.confirmRewardWindow:destroy()
+        self.confirmRewardWindow = nil
+        -- g_client.setInputLockWidget(nil)
+        BattlePass:showBattlePass()
+
+        self:onRedeemReward(index, reward.rewardId, reward.rewardType, self.selectedItemId)
+    end
+
+    local cancelFunc = function()
+        self.confirmRewardWindow:destroy()
+        self.confirmRewardWindow = nil
+        self.claimRewardWindow:show()
+        -- g_client.setInputLockWidget(self.claimRewardWindow)
+    end
+
+    self.claimRewardWindow:recursiveGetChildById("collectRewardButton").onClick = function()
+        if self.selectedItemId == -1 and (BattleRewardTypes[reward.rewardType] == "Boosted Exercise" or BattleRewardTypes[reward.rewardType] == "Exercise Item" or
+         BattleRewardTypes[reward.rewardType] == "Extra Skill" or BattleRewardTypes[reward.rewardType] == "Elemental Outfit" or BattleRewardTypes[reward.rewardType] == "Choosable Item") then
+            modules.game_textmessage.displayFailureMessage("You must select an item before collecting the reward.")
+            return
+        end
+
+        if BattleRewardTypes[reward.rewardType] == "Extra Skill" then
+            self.textReward = string.format("You will receive +%d skill points in %s\nfor %d hours (Scroll 30 days).", reward.count, skillName[self.selectedItemId], reward.durationTime)
+        elseif BattleRewardTypes[reward.rewardType] == "Elemental Outfit" then
+            local elements = {
+                [1] = "Death",
+                [2] = "Energy",
+                [3] = "Holy",
+                [4] = "Ice",
+                [5] = "Earth",
+                [6] = "Fire"
+            }
+            self.textReward = string.format("You will receive the %s Elemental Outfits\nwith addons %s.", elements[self.selectedItemId], reward.addons and "enabled" or "disabled")
+        elseif BattleRewardTypes[reward.rewardType] == "Choosable Item" then
+            local selectedItemName = ""
+            for _, v in pairs(reward.choosableValues) do
+                if v.thingId == self.selectedItemId then
+                    selectedItemName = getItemNameById(v.thingId)
+                    break
+                end
+            end
+            self.textReward = string.format("You will receive %dx %s.", reward.count, string.capitalize(selectedItemName))
+        end
+
+        self.claimRewardWindow:hide()
+        self.confirmRewardWindow = g_ui.createWidget("ConfirmReward", rootWidget)
+
+        self.confirmRewardWindow.onEscape = cancelFunc
+        self.confirmRewardWindow:recursiveGetChildById('cancel').onClick = cancelFunc
+        self.confirmRewardWindow:recursiveGetChildById('confirm').onClick = okfunction
+        self.confirmRewardWindow:recursiveGetChildById('textContent'):setText(self.textReward)
+
+        -- g_client.setInputLockWidget(self.confirmRewardWindow)
+    end
+
+    BattlePass.window:hide()
+
+    self.textReward = ''
+    local infoLabel = self.claimRewardWindow:recursiveGetChildById("infoLabel")
+    local rewardsInfoPanel = self.claimRewardWindow:recursiveGetChildById("rewardsInfoPanel")
+    local outfitsInfoPanel = self.claimRewardWindow:recursiveGetChildById("outfitsInfoPanel")
+    rewardsInfoPanel:setVisible(true)
+    outfitsInfoPanel:setVisible(false)
+    rewardsInfoPanel:setWidth(self.rewardWidthIncrement)
+    local rewardsInfoScrollBar = self.claimRewardWindow:recursiveGetChildById("rewardsInfoScrollBar")
+    rewardsInfoScrollBar:setVisible(true)
+
+    local width = 0
+    local normalHeight = 250
+
+    self.selectedItemId = -1
+    if BattleRewardTypes[reward.rewardType] == "Outfit" then
+        local function rotateOutfit(value)
+            self.currentOutfitDirection = self.currentOutfitDirection or Directions.North
+            local direction = self.currentOutfitDirection + value
+            if direction < Directions.North then
+                direction = Directions.West
+            elseif direction > Directions.West then
+                direction = Directions.North
+            end
+            self.currentOutfitDirection = direction
+
+            local index = 1
+            while true do
+                local outfitWidget = rewardsInfoPanel:recursiveGetChildById("rewardSlot" .. index - 1)
+                if not outfitWidget then break end
+                if outfitWidget:isVisible() then
+                    outfitWidget.rewardOutfit:setDirection(direction)
+                end
+                index = index + 1
+            end
+        end
+
+        local function setupOutfitWidget(outfitWidget, outfitData, currentOutfit)
+            outfitWidget.rewardOutfit:setVisible(true)
+            outfitWidget.rewardOutfit:setOutfit({
+                type = outfitData.thingId,
+                head = currentOutfit.head,
+                body = currentOutfit.body,
+                legs = currentOutfit.legs,
+                feet = currentOutfit.feet,
+                addons = reward.addons
+            })
+
+            outfitWidget:setImageSource('/images/game/battlepass/ground-bg')
+            if self.currentOutfitDirection then
+                outfitWidget.rewardOutfit:setDirection(self.currentOutfitDirection)
+            end
+        end
+
+        local previousButton = self.claimRewardWindow:recursiveGetChildById("rotatePrevButton")
+        local nextButton = self.claimRewardWindow:recursiveGetChildById("rotateNextButton")
+
+        rewardsInfoPanel:setVisible(true)
+        nextButton:setVisible(true)
+        previousButton:setVisible(true)
+
+        nextButton.onClick = function()
+            rotateOutfit(-1)
+        end
+        previousButton.onClick = function()
+            rotateOutfit(1)
+        end
+
+        local outfitName = ''
+        local addonText = ''
+        for k, v in pairs(reward.randomValues) do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            widget:setVisible(true)
+            widget.rewardOutfit:setVisible(true)
+
+            local currentOutfit = g_game.getLocalPlayer():getOutfit()
+            local displayOutfit = {type = v.thingId, head = currentOutfit.head, body = currentOutfit.body, legs = currentOutfit.legs, feet = currentOutfit.feet, addons = reward.addons}
+            --widget.rewardOutfit:setOutfit(displayOutfit)
+            setupOutfitWidget(widget, v, currentOutfit)
+            addonText = reward.addons == 1 and "first addon" or (reward.addons == 2 and "second addon" or "full addons")
+            local tooltipText = string.format("%s with %s", v.thingName, addonText)
+            widget.rewardOutfit:setTooltip(tooltipText)
+            --widget.rewardOutfit:setImageSource('/images/game/battlepass/ground-bg')
+            width = width + self.rewardWidthIncrement
+            outfitName = tooltipText
+        end
+
+        infoLabel:setText(string.format("You will receive the following outfit with %s:", addonText))
+        self.textReward = string.format("You will receive the following outfit:\n%s.", outfitName)
+    elseif BattleRewardTypes[reward.rewardType] == "Random Item" then
+        for k, v in pairs(reward.randomValues) do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            widget:setVisible(true)
+            widget.rewardItem:setVisible(true)
+            widget.rewardItem:setItemId(v.thingId)
+            widget.rewardItem.rewardItemCount:setText(reward.count > 1 and tostring(reward.count) or "")
+            widget.rewardItem:setTooltip(string.capitalize(getItemNameById(v.thingId)))
+            width = width + self.rewardWidthIncrement
+        end
+
+        local message = "You will receive a random item from the list bellow:"
+        if reward.stuck then
+            message = message .. "\n[color=white]The reward will be bound to your character.[/color]"
+        end
+
+       self.textReward = string.format("You will receive a random item from the list.")
+       infoLabel:parseColoredText(message)
+    elseif BattleRewardTypes[reward.rewardType] == "Random Mount" then
+        for k, v in pairs(reward.randomValues) do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            if not widget then
+                widget = g_ui.createWidget("RewardInfoSlot", rewardsInfoPanel)
+                widget:setId("rewardSlot" .. k - 1)
+            end
+            widget:setVisible(true)
+            widget:setPhantom(false)
+            widget.rewardOutfit:setVisible(true)
+            widget.rewardOutfit:setTooltip(v.thingName)
+            widget:setImageSource('/images/game/battlepass/ground-bg')
+            widget.rewardOutfit:setOutfit({type = v.thingId})
+            width = width + self.rewardWidthIncrement
+        end
+
+        infoLabel:setText("You will receive a random mount from the list bellow:")
+        self.textReward = string.format("You will receive a random mount from the list.")
+    elseif BattleRewardTypes[reward.rewardType] == "Item" then
+        local widget = widgetsPanel:recursiveGetChildById("rewardSlot0")
+        widget:setVisible(true)
+        widget.rewardItem:setVisible(true)
+        widget.rewardItem:setItemId(reward.itemId)
+        widget.rewardItem.rewardItemCount:setText(reward.count > 1 and tostring(reward.count) or "")
+        local itemName = getItemNameById(reward.itemId)
+        local item = widget.rewardItem:getItem()
+
+        if reward.charges > 0 then
+            widget.rewardItem:setTooltip(string.format("%s\nCharges: %s", string.capitalize(itemName), reward.charges))
+        else
+            widget.rewardItem:setTooltip(string.format("%sx %s", reward.count, string.capitalize(itemName)))
+        end
+
+        if item then
+            widget.rewardItem:setFixedSize(not item:isWrapable())
+
+            if reward.itemId == 63246 then
+                widget.rewardItem:setFixedSize(true)
+            end
+
+        end
+
+        width = width + self.rewardWidthIncrement
+
+        local message = "You will receive the following item."
+        if reward.stuck then
+            message = message .. "\n[color=white]The reward will be bound to your character.[/color]"
+        end
+
+       infoLabel:parseColoredText(message)
+       self.textReward = string.format("You will receive the following item: %d %s.", reward.count, string.capitalize(itemName))
+
+    elseif BattleRewardTypes[reward.rewardType] == "Boosted Exercise" or BattleRewardTypes[reward.rewardType] == "Exercise Item" then
+        for k, v in pairs(reward.randomValues) do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            widget:setVisible(true)
+            widget.rewardItem:setVisible(true)
+            widget.rewardItem:setItemId(v.thingId)
+
+            local itemName = getItemNameById(v.thingId)
+
+            widget.rewardItem:setTooltip(string.capitalize(itemName))
+            widget:setFocusable(true)
+            normalHeight = 260
+
+            widget.rewardItem.onClick = function(w)
+                if w:isFocused() then
+                    self.selectedItemId = v.thingId
+
+                    self.textReward = string.format("You must choose one %s,\nhave %d charges.", string.capitalize(itemName), reward.charges)
+                end
+            end
+
+            width = width + self.rewardWidthIncrement
+        end
+
+        local message = "You must choose [color=white]one[/color] of the following items, have [color=white]" .. reward.charges .. " charges.[/color]"
+        if reward.stuck then
+            message = message .. "\n[color=white]The reward will be bound to your character.[/color]"
+        end
+
+       infoLabel:parseColoredText(message)
+    elseif BattleRewardTypes[reward.rewardType] == "Charms" then
+        infoLabel:parseColoredText("You will receive [color=white]+" .. reward.count .. " charm points[/color] on your character.")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive +%d charm points on your character.", reward.count)
+    elseif BattleRewardTypes[reward.rewardType] == "Prey" then
+        infoLabel:parseColoredText("You will receive [color=white]+" .. reward.count .. " prey wildcards[/color] on your character.")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive +%d prey wildcards on your character.", reward.count)
+    elseif BattleRewardTypes[reward.rewardType] == "Regen" then
+        infoLabel:parseColoredText("You will receive [color=white]" .. reward.durationTime .. " hours (Scroll 30 days) of Double Regeneration[/color].")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive %d hours (Scroll 30 days)\nof Double Regeneration.", reward.durationTime)
+    elseif BattleRewardTypes[reward.rewardType] == "Instant Reward" then
+        infoLabel:parseColoredText("You will receive [color=white]+" .. reward.count .. " instant rewards[/color] on your character.")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive +%d instant rewards on your character.", reward.count)
+    elseif BattleRewardTypes[reward.rewardType] == "Double Skill" then
+        infoLabel:parseColoredText("You will receive [color=white]" .. reward.durationTime .. " hours (Scroll 30 days) of Double Skill[/color].")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive %d hours (Scroll 30 days)\nof Double Skill.", reward.durationTime)
+    elseif BattleRewardTypes[reward.rewardType] == "Level" then
+        infoLabel:parseColoredText("You will receive [color=white]+" .. reward.count .. " Level[/color] on your character.")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive +%d Level on your character.", reward.count)
+    elseif BattleRewardTypes[reward.rewardType] == "Overload Forge" then
+        infoLabel:parseColoredText("You will receive [color=white]" .. reward.durationTime .. " hours (Scroll 30 days) of Exaltation Overload[/color].")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive %d hours (Scroll 30 days)\nof Exaltation Overload.", reward.durationTime)
+    elseif BattleRewardTypes[reward.rewardType] == "Exp Boost" then
+        infoLabel:parseColoredText("You will receive [color=white]" .. reward.durationTime .. " hours of store XP Boost[/color].")
+        rewardsInfoPanel:setVisible(false)
+        rewardsInfoScrollBar:setVisible(false)
+        normalHeight = self.rewardEmptyHeight
+        self.textReward = string.format("You will receive %d hours of store XP Boost,\nlinked to your skill tab.", reward.durationTime)
+    elseif BattleRewardTypes[reward.rewardType] == "Extra Skill" then
+        infoLabel:parseColoredText("You will receive [color=white]+" .. reward.count .. " skill points[/color] in the skill of your choice for [color=white]" .. reward.durationTime .. " hours[/color].")
+        rewardsInfoPanel:setVisible(true)
+        rewardsInfoScrollBar:setVisible(true)
+
+        local skills = {0, 1, 2, 3, 4, 5, 13}
+        for k, v in pairs(skills) do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            widget:setVisible(true)
+            widget.rewardSpecial:setVisible(true)
+            widget.rewardSpecial:setTooltip(skillName[v] .. " (" .. reward.count .. " points for " .. reward.durationTime .. " hours)")
+            widget.rewardSpecial:setImageSource('/images/game/battlepass/skills/' .. v)
+
+            widget:setFocusable(true)
+
+            widget.rewardSpecial.onClick = function(w)
+                if w:isFocused() then
+                    self.selectedItemId = v
+                end
+            end
+
+            width = width + self.rewardWidthIncrement
+        end
+
+    elseif BattleRewardTypes[reward.rewardType] == "Elemental Outfit" then
+        local function rotateOutfit(value)
+            self.currentOutfitDirection = self.currentOutfitDirection or Directions.North
+            local direction = self.currentOutfitDirection + value
+            if direction < Directions.North then
+                direction = Directions.West
+            elseif direction > Directions.West then
+                direction = Directions.North
+            end
+            self.currentOutfitDirection = direction
+
+            local index = 1
+            while true do
+                local outfitWidget = outfitsInfoPanel:recursiveGetChildById("outfitPreview" .. index - 1)
+                if not outfitWidget then break end
+                if outfitWidget:isVisible() then
+                    outfitWidget.rewardOutfit:setDirection(direction)
+                end
+                index = index + 1
+            end
+        end
+
+        local function setupOutfitWidget(outfitWidget, outfitData, currentOutfit)
+            outfitWidget.rewardOutfit:setVisible(true)
+            outfitWidget.rewardOutfit:setOutfit({
+                type = outfitData.looktype,
+                head = currentOutfit.head,
+                body = currentOutfit.body,
+                legs = currentOutfit.legs,
+                feet = currentOutfit.feet,
+                addons = reward.addons
+            })
+            outfitWidget.rewardOutfit:setTooltip(outfitData.name)
+            outfitWidget:setTooltip(outfitData.name)
+            outfitWidget:setImageSource('/images/game/battlepass/ground-bg')
+            if self.currentOutfitDirection then
+                outfitWidget.rewardOutfit:setDirection(self.currentOutfitDirection)
+            end
+        end
+
+        local previousButton = self.claimRewardWindow:recursiveGetChildById("previousButton")
+        local nextButton = self.claimRewardWindow:recursiveGetChildById("nextButton")
+
+        infoLabel:parseColoredText("You will receive the [color=white]Elemental Outfit[/color] of your choice.")
+        rewardsInfoPanel:setVisible(true)
+        outfitsInfoPanel:setVisible(true)
+        nextButton:setVisible(true)
+        previousButton:setVisible(true)
+
+        nextButton.onClick = function()
+            rotateOutfit(-1)
+        end
+        previousButton.onClick = function()
+            rotateOutfit(1)
+        end
+
+        normalHeight = 340
+
+        local elements = {
+            [1] = "Death",
+            [2] = "Energy",
+            [3] = "Holy",
+            [4] = "Ice",
+            [5] = "Earth",
+            [6] = "Fire"
+        }
+
+        for i = 1, 6 do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. i - 1)
+            widget:setVisible(true)
+            widget.rewardSpecial:setVisible(true)
+            widget.rewardSpecial:setImageSource('/images/game/battlepass/tiles/' .. i)
+            widget.rewardSpecial:setTooltip("Elemental Outfit " .. elements[i])
+            widget:setFocusable(true)
+
+            if i == 1 then
+                widget:recursiveFocus(2)
+                self.selectedItemId = i
+
+                local currentOutfit = g_game.getLocalPlayer():getOutfit()
+                local index = 1
+                for _, v in pairs(reward.maleOutfit[i]) do
+                    local outfitWidget = outfitsInfoPanel:recursiveGetChildById("outfitPreview" .. index - 1)
+                    setupOutfitWidget(outfitWidget, v, currentOutfit)
+                    index = index + 1
+                end
+                for _, v in pairs(reward.femaleOutfit[i]) do
+                    local outfitWidget = outfitsInfoPanel:recursiveGetChildById("outfitPreview" .. index - 1)
+                    setupOutfitWidget(outfitWidget, v, currentOutfit)
+                    index = index + 1
+                end
+            end
+
+            widget.rewardSpecial.onClick = function(w)
+                if w:isFocused() then
+                    self.selectedItemId = i
+                    local currentOutfit = g_game.getLocalPlayer():getOutfit()
+                    local index = 1
+                    for _, v in pairs(reward.maleOutfit[i]) do
+                        local outfitWidget = outfitsInfoPanel:recursiveGetChildById("outfitPreview" .. index - 1)
+                        setupOutfitWidget(outfitWidget, v, currentOutfit)
+                        index = index + 1
+                    end
+                    for _, v in pairs(reward.femaleOutfit[i]) do
+                        local outfitWidget = outfitsInfoPanel:recursiveGetChildById("outfitPreview" .. index - 1)
+                        setupOutfitWidget(outfitWidget, v, currentOutfit)
+                        index = index + 1
+                    end
+                end
+            end
+
+            width = width + self.rewardWidthIncrement
+        end
+    elseif BattleRewardTypes[reward.rewardType] == "Choosable Item" then
+        for k, v in pairs(reward.choosableValues) do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            widget:setVisible(true)
+            widget.rewardItem:setVisible(true)
+            widget.rewardItem:setItemId(v.thingId)
+            widget.rewardItem.rewardItemCount:setText(reward.count > 1 and tostring(reward.count) or "")
+
+            local itemName = getItemNameById(v.thingId)
+
+            widget.rewardItem:setTooltip(string.format("%dx %s", reward.count, string.capitalize(itemName)))
+            widget:setFocusable(true)
+            normalHeight = 260
+
+            widget.rewardItem.onClick = function(w)
+                if w:isFocused() then
+                    self.selectedItemId = v.thingId
+                    self.textReward = string.format("You have selected %dx %s.", reward.count, string.capitalize(itemName))
+                end
+            end
+
+            width = width + self.rewardWidthIncrement
+        end
+
+        local message = "You must choose [color=white]one[/color] of the following items:"
+        if reward.stuck then
+            message = message .. "\n[color=white]The reward will be bound to your character.[/color]"
+        end
+
+        infoLabel:parseColoredText(message)
+
+    elseif BattleRewardTypes[reward.rewardType] == "Multi Items" then
+        local stuck = reward.stuck or false
+        local itemName = ''
+        for k, v in pairs(reward.items) do
+            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            widget:setVisible(true)
+            widget.rewardItem:setVisible(true)
+            widget.rewardItem:setItemId(v.itemId)
+            widget.rewardItem.rewardItemCount:setText(v.count > 1 and tostring(v.count) or "")
+            local itemName = getItemNameById(v.itemId)
+            widget.rewardItem:setTooltip(string.capitalize(itemName))
+
+            width = width + self.rewardWidthIncrement
+            if v.stuck then
+                stuck = true
+            end
+            if itemName ~= '' then
+                itemName = itemName .. ", " .. v.count .. " " .. string.capitalize(itemName)
+            else
+                itemName = v.count .. " " .. string.capitalize(itemName)
+            end
+        end
+
+        local message = "You will receive these items from the list bellow:"
+        if stuck then
+            message = message .. "\n[color=white]The reward will be bound to your character.[/color]"
+        end
+
+       infoLabel:parseColoredText(message)
+         self.textReward = string.format("You will receive these items from the list:\n%s", itemName)
+    end
+
+    local rewardCount = 0
+    local i = 0
+    while true do
+        local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. i)
+        if not widget then
+            break
+        end
+        if widget:isVisible() then
+            rewardCount = rewardCount + 1
+        end
+        i = i + 1
+    end
+
+    if rewardCount >= 6 then
+        rewardsInfoPanel:setWidth(465)
+    else
+        rewardsInfoPanel:setWidth(math.min(430, width) + 10)
+    end
+
+    self.claimRewardWindow:setSize(tosize(500 .. " " .. normalHeight))
+
+    if width <= 175 then
+        rewardsInfoScrollBar:setVisible(false)
+        rewardsInfoPanel:setImageSource("")
+    end
+
+    -- g_client.setInputLockWidget(self.claimRewardWindow)
+end
+
+function BattlePassRewards:onRedeemReward(index, internalRewardId, internalRewardType, objectId)
+    if not g_game.isOnline() then
+        return
+    end
+
+    local protocol = g_game.getProtocolGame()
+    if protocol then
+        protocol:sendExtendedOpcode(BattlePass.opcode or 225, json.encode({
+            action = "redeem",
+            data = {
+                index = index,
+                rewardId = internalRewardId,
+                objectId = objectId or -1,
+            },
+        }))
+    end
+end
+
+
+function BattlePassRewards:getRewardDescription(reward)
+    if reward.rewardType == 1 then
+        local itemName = getItemNameById(reward.itemId)
+        return string.format("%dx %s", reward.count, string.capitalize(itemName))
+    end
+
+    return "Reward Type: " .. BattleRewardTypes[reward.rewardType]
+end
+
+function BattlePassRewards:getReward(index, rewardType)
+    local isFreeReward = (rewardType == "free")
+    for _, step in ipairs(BattlePass.rewardSteps) do
+        if step.stepId == index then
+            for _, reward in ipairs(step.rewards) do
+                if isFreeReward and reward.freeReward then
+                    return reward
+                elseif not isFreeReward and not reward.freeReward then
+                    return reward
+                end
+            end
+        end
+    end
+    return nil
+end

--- a/modules/game_battlepass/classes/rewards.lua
+++ b/modules/game_battlepass/classes/rewards.lua
@@ -31,7 +31,34 @@ local skillName = {
     [13] = "Magic Level"
 }
 
-local self = BattlePassRewards
+local selectableRewardTypes = {
+    ["Boosted Exercise"] = true,
+    ["Exercise Item"] = true,
+    ["Extra Skill"] = true,
+    ["Elemental Outfit"] = true,
+    ["Choosable Item"] = true,
+}
+
+local function validateSelectedItem(self, reward)
+    if self.selectedItemId == -1 and selectableRewardTypes[BattleRewardTypes[reward.rewardType]] then
+        modules.game_textmessage.displayFailureMessage("You must select an item before collecting the reward.")
+        return false
+    end
+
+    return true
+end
+
+local function getRewardInfoSlot(parent, index)
+    local widget = parent:recursiveGetChildById("rewardSlot" .. index)
+    if not widget then
+        widget = g_ui.createWidget("RewardInfoSlot", parent)
+        widget:setId("rewardSlot" .. index)
+        widget:setVisible(false)
+    end
+
+    return widget
+end
+
 function BattlePassRewards:onConfirmClaimReward(index, rewardType)
     local reward = self:getReward(index, rewardType)
     if not reward then
@@ -60,20 +87,15 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         self.claimRewardWindow:destroy()
         self.claimRewardWindow = nil
         BattlePass:showBattlePass()
-
-        -- g_client.setInputLockWidget(BattlePass.window)
     end
 
     local function okfunction()
-        if self.selectedItemId == -1 and (BattleRewardTypes[reward.rewardType] == "Boosted Exercise" or BattleRewardTypes[reward.rewardType] == "Exercise Item" or
-         BattleRewardTypes[reward.rewardType] == "Extra Skill" or BattleRewardTypes[reward.rewardType] == "Elemental Outfit" or BattleRewardTypes[reward.rewardType] == "Choosable Item") then
-            modules.game_textmessage.displayFailureMessage("You must select an item before collecting the reward.")
+        if not validateSelectedItem(self, reward) then
             return
         end
 
         self.confirmRewardWindow:destroy()
         self.confirmRewardWindow = nil
-        -- g_client.setInputLockWidget(nil)
         BattlePass:showBattlePass()
 
         self:onRedeemReward(index, reward.rewardId, reward.rewardType, self.selectedItemId)
@@ -83,13 +105,10 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         self.confirmRewardWindow:destroy()
         self.confirmRewardWindow = nil
         self.claimRewardWindow:show()
-        -- g_client.setInputLockWidget(self.claimRewardWindow)
     end
 
     self.claimRewardWindow:recursiveGetChildById("collectRewardButton").onClick = function()
-        if self.selectedItemId == -1 and (BattleRewardTypes[reward.rewardType] == "Boosted Exercise" or BattleRewardTypes[reward.rewardType] == "Exercise Item" or
-         BattleRewardTypes[reward.rewardType] == "Extra Skill" or BattleRewardTypes[reward.rewardType] == "Elemental Outfit" or BattleRewardTypes[reward.rewardType] == "Choosable Item") then
-            modules.game_textmessage.displayFailureMessage("You must select an item before collecting the reward.")
+        if not validateSelectedItem(self, reward) then
             return
         end
 
@@ -123,8 +142,6 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         self.confirmRewardWindow:recursiveGetChildById('cancel').onClick = cancelFunc
         self.confirmRewardWindow:recursiveGetChildById('confirm').onClick = okfunction
         self.confirmRewardWindow:recursiveGetChildById('textContent'):setText(self.textReward)
-
-        -- g_client.setInputLockWidget(self.confirmRewardWindow)
     end
 
     BattlePass.window:hide()
@@ -199,7 +216,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         local outfitName = ''
         local addonText = ''
         for k, v in pairs(reward.randomValues) do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            local widget = getRewardInfoSlot(widgetsPanel, k - 1)
             widget:setVisible(true)
             widget.rewardOutfit:setVisible(true)
 
@@ -219,7 +236,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         self.textReward = string.format("You will receive the following outfit:\n%s.", outfitName)
     elseif BattleRewardTypes[reward.rewardType] == "Random Item" then
         for k, v in pairs(reward.randomValues) do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            local widget = getRewardInfoSlot(widgetsPanel, k - 1)
             widget:setVisible(true)
             widget.rewardItem:setVisible(true)
             widget.rewardItem:setItemId(v.thingId)
@@ -237,11 +254,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
        infoLabel:parseColoredText(message)
     elseif BattleRewardTypes[reward.rewardType] == "Random Mount" then
         for k, v in pairs(reward.randomValues) do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
-            if not widget then
-                widget = g_ui.createWidget("RewardInfoSlot", rewardsInfoPanel)
-                widget:setId("rewardSlot" .. k - 1)
-            end
+            local widget = getRewardInfoSlot(widgetsPanel, k - 1)
             widget:setVisible(true)
             widget:setPhantom(false)
             widget.rewardOutfit:setVisible(true)
@@ -254,7 +267,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         infoLabel:setText("You will receive a random mount from the list below:")
         self.textReward = string.format("You will receive a random mount from the list.")
     elseif BattleRewardTypes[reward.rewardType] == "Item" then
-        local widget = widgetsPanel:recursiveGetChildById("rewardSlot0")
+        local widget = getRewardInfoSlot(widgetsPanel, 0)
         widget:setVisible(true)
         widget.rewardItem:setVisible(true)
         widget.rewardItem:setItemId(reward.itemId)
@@ -289,7 +302,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
 
     elseif BattleRewardTypes[reward.rewardType] == "Boosted Exercise" or BattleRewardTypes[reward.rewardType] == "Exercise Item" then
         for k, v in pairs(reward.randomValues) do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            local widget = getRewardInfoSlot(widgetsPanel, k - 1)
             widget:setVisible(true)
             widget.rewardItem:setVisible(true)
             widget.rewardItem:setItemId(v.thingId)
@@ -372,7 +385,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
 
         local skills = {0, 1, 2, 3, 4, 5, 13}
         for k, v in pairs(skills) do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            local widget = getRewardInfoSlot(widgetsPanel, k - 1)
             widget:setVisible(true)
             widget.rewardSpecial:setVisible(true)
             widget.rewardSpecial:setTooltip(skillName[v] .. " (" .. reward.count .. " points for " .. reward.durationTime .. " hours)")
@@ -457,7 +470,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         }
 
         for i = 1, 6 do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. i - 1)
+            local widget = getRewardInfoSlot(widgetsPanel, i - 1)
             widget:setVisible(true)
             widget.rewardSpecial:setVisible(true)
             widget.rewardSpecial:setImageSource('/images/game/battlepass/tiles/' .. i)
@@ -504,7 +517,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         end
     elseif BattleRewardTypes[reward.rewardType] == "Choosable Item" then
         for k, v in pairs(reward.choosableValues) do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            local widget = getRewardInfoSlot(widgetsPanel, k - 1)
             widget:setVisible(true)
             widget.rewardItem:setVisible(true)
             widget.rewardItem:setItemId(v.thingId)
@@ -537,7 +550,7 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         local stuck = reward.stuck or false
         local itemName = ''
         for k, v in pairs(reward.items) do
-            local widget = widgetsPanel:recursiveGetChildById("rewardSlot" .. k - 1)
+            local widget = getRewardInfoSlot(widgetsPanel, k - 1)
             widget:setVisible(true)
             widget.rewardItem:setVisible(true)
             widget.rewardItem:setItemId(v.itemId)
@@ -591,7 +604,6 @@ function BattlePassRewards:onConfirmClaimReward(index, rewardType)
         rewardsInfoPanel:setImageSource("")
     end
 
-    -- g_client.setInputLockWidget(self.claimRewardWindow)
 end
 
 function BattlePassRewards:onRedeemReward(index, internalRewardId, internalRewardType, objectId)
@@ -601,7 +613,7 @@ function BattlePassRewards:onRedeemReward(index, internalRewardId, internalRewar
 
     local protocol = g_game.getProtocolGame()
     if protocol then
-        protocol:sendExtendedOpcode(BattlePass.opcode or 225, json.encode({
+        protocol:sendExtendedOpcode(BattlePass.opcode or BATTLEPASS_OPCODE_DEFAULT, json.encode({
             action = "redeem",
             data = {
                 index = index,

--- a/modules/game_battlepass/const.lua
+++ b/modules/game_battlepass/const.lua
@@ -1,0 +1,103 @@
+MissionsDisplacement = {
+    1, 2, 14, 15, -- First week [2 de 100 pontos e 2 de 200 pontos]
+    3, 4, 16, 17, -- Second week [2 de 100 pontos e 2 de 200 pontos]
+    5, 6, 7, 18, 19, 20, -- Third week [3 de 100 pontos, 2 de 200 pontos e 1 de 300 pontos]
+    8, 9, 10, 21, 22, 23, -- Fourth week [2 de 100 pontos, 3 de 200 pontos e 1 de 300 pontos]
+    11, 12, 13, 24, 25, 26 -- Fifth week [2 de 100 pontos, 2 de 200 pontos e 2 de 300 pontos]
+}
+
+MissionTypesOrder = {
+    "bronze", "bronze", "silver", "silver", -- First week
+    "bronze", "bronze", "silver", "silver", -- Second week
+    "bronze", "bronze", "bronze", "silver", "silver", "gold", -- Third week
+    "bronze", "bronze", "silver", "silver", "silver", "gold", -- Fourth week
+    "bronze", "bronze", "silver", "silver", "gold", "gold" -- Fifth week
+}
+
+MissionRankIcons = {
+    [100] = "bronze-icon",
+    [150] = "silver-icon",
+    [200] = "silver-icon",
+    [300] = "gold-icon",
+}
+
+BattleRewardTypes = {
+    "Item",             -- índice 1
+    "Random Item",      -- índice 2
+    "Random Mount",     -- índice 3
+    "Exercise Item",    -- índice 4
+    "Double Skill",     -- índice 5
+    "Level",            -- índice 6
+    "Prey",             -- índice 7
+    "Exp Boost",        -- índice 8
+    "Regen",            -- índice 9
+    "Overload Forge",   -- índice 10
+    "Instant Reward",   -- índice 11
+    "Boosted Exercise", -- índice 12
+    "Charms",           -- índice 13
+    "Outfit",           -- índice 14
+    "Extra Skill",      -- índice 15
+    "Elemental Outfit", -- índice 16
+    "Multi Items",      -- índice 17
+    "Choosable Item",   -- índice 18
+}
+
+RewardWidgetOrder = {
+    "rewardSlot4", "rewardSlot2", "rewardSlot0", "rewardSlot1", "rewardSlot3",
+    "rewardSlot5", "rewardSlot10", "rewardSlot8", "rewardSlot6", "rewardSlot7",
+    "rewardSlot9", "rewardSlot11"
+}
+
+RewardPositions = {
+    [0] = {stepsTo = 0, scrollPosition = 0},
+    [1] = {stepsTo = 8, scrollPosition = 107, positions = {premium = {marginLeft = 430, marginTop = 60}}},
+    [2] = {stepsTo = 6, scrollPosition = 292, positions = {premium = {marginLeft = 622, marginTop = 60}}},
+    [3] = {stepsTo = 6, scrollPosition = 480, positions = {premium = {marginLeft = 808, marginTop = 55}, free = {marginLeft = 808, marginTop = 310}}},
+    [4] = {stepsTo = 14, scrollPosition = 930, positions = {premium = {marginLeft = 1255, marginTop = 55}}},
+    [5] = {stepsTo = 7, scrollPosition = 1150, positions = {premium = {marginLeft = 1480, marginTop = 55}}},
+    [6] = {stepsTo = 7, scrollPosition = 1380, positions = {premium = {marginLeft = 1705, marginTop = 55}, free = {marginLeft = 1705, marginTop = 275}}},
+    [7] = {stepsTo = 11, scrollPosition = 1730, positions = {premium = {marginLeft = 2065, marginTop = 60}}},
+    [8] = {stepsTo = 6, scrollPosition = 1930, positions = {premium = {marginLeft = 2255, marginTop = 60}}},
+    [9] = {stepsTo = 9, scrollPosition = 2210, positions = {premium = {marginLeft = 2541, marginTop = 60}, free = {marginLeft = 2541, marginTop = 310}}},
+    [10] = {stepsTo = 9, scrollPosition = 2500, positions = {premium = {marginLeft = 2830, marginTop = 60}}},
+    [11] = {stepsTo = 6, scrollPosition = 2698, positions = {premium = {marginLeft = 3023, marginTop = 60}}},
+    [12] = {stepsTo = 31, scrollPosition = 3665, positions = {premium = {marginLeft = 4010, marginTop = 55}, free = {marginLeft = 4006, marginTop = 275}}},
+    [13] = {stepsTo = 8, scrollPosition = 3925, positions = {premium = {marginLeft = 4265, marginTop = 55}}},
+    [14] = {stepsTo = 8, scrollPosition = 4185, positions = {premium = {marginLeft = 4520, marginTop = 55}}},
+    [15] = {stepsTo = 19, scrollPosition = 4800, positions = {premium = {marginLeft = 5136, marginTop = 60}, free = {marginLeft = 5130, marginTop = 275}}},
+    [16] = {stepsTo = 11, scrollPosition = 5145, positions = {premium = {marginLeft = 5486, marginTop = 60}}},
+    [17] = {stepsTo = 11, scrollPosition = 5505, positions = {premium = {marginLeft = 5840, marginTop = 60}}},
+    [18] = {stepsTo = 11, scrollPosition = 5820, positions = {premium = {marginLeft = 6155, marginTop = 55}, free = {marginLeft = 6155, marginTop = 275}}},
+    [19] = {stepsTo = 10, scrollPosition = 6145, positions = {premium = {marginLeft = 6478, marginTop = 60}}},
+    [20] = {stepsTo = 10, scrollPosition = 6460, positions = {premium = {marginLeft = 6830, marginTop = 60}}},
+    [21] = {stepsTo = 11, scrollPosition = 6855, positions = {premium = {marginLeft = 7182, marginTop = 60}, free = {marginLeft = 7177, marginTop = 275}}},
+    [22] = {stepsTo = 14, scrollPosition = 7300, positions = {premium = {marginLeft = 7625, marginTop = 55}}},
+    [23] = {stepsTo = 5, scrollPosition = 7460, positions = {premium = {marginLeft = 7784, marginTop = 85}}},
+    [24] = {stepsTo = 5, scrollPosition = 7620, positions = {premium = {marginLeft = 7945, marginTop = 55}, free = {marginLeft = 7945, marginTop = 275}}},
+    [25] = {stepsTo = 22, scrollPosition = 8325, positions = {premium = {marginLeft = 8640, marginTop = 80}}},
+    [26] = {stepsTo = 8, scrollPosition = 8570, positions = {premium = {marginLeft = 8895, marginTop = 80}}},
+    [27] = {stepsTo = 8, scrollPosition = 8835, positions = {premium = {marginLeft = 9151, marginTop = 80}, free = {marginLeft = 9156, marginTop = 275}}},
+    [28] = {stepsTo = 8, scrollPosition = 9090, positions = {premium = {marginLeft = 9406, marginTop = 80}}},
+    [29] = {stepsTo = 7, scrollPosition = 9310, positions = {premium = {marginLeft = 9640, marginTop = 80}}},
+    [30] = {stepsTo = 7, scrollPosition = 9530, positions = {premium = {marginLeft = 9857, marginTop = 80}, free = {marginLeft = 9862, marginTop = 275}}},
+    [31] = {stepsTo = 8, scrollPosition = 9785, positions = {premium = {marginLeft = 10112, marginTop = 80}}},
+    [32] = {stepsTo = 8, scrollPosition = 10045, positions = {premium = {marginLeft = 10367, marginTop = 80}}},
+    [33] = {stepsTo = 8, scrollPosition = 10300, positions = {premium = {marginLeft = 10622, marginTop = 80}, free = {marginLeft = 10629, marginTop = 275}}},
+    [34] = {stepsTo = 18, scrollPosition = 10880, positions = {premium = {marginLeft = 11212, marginTop = 95}}},
+    [35] = {stepsTo = 8, scrollPosition = 11135, positions = {premium = {marginLeft = 11466, marginTop = 95}}},
+    [36] = {stepsTo = 8, scrollPosition = 11390, positions = {premium = {marginLeft = 11722, marginTop = 95}, free = {marginLeft = 11718, marginTop = 275}}},
+    [37] = {stepsTo = 27, scrollPosition = 12255, positions = {premium = {marginLeft = 12575, marginTop = 80}}},
+    [38] = {stepsTo = 9, scrollPosition = 12540, positions = {premium = {marginLeft = 12861, marginTop = 80}}},
+    [39] = {stepsTo = 9, scrollPosition = 12830, positions = {premium = {marginLeft = 13150, marginTop = 80}, free = {marginLeft = 13158, marginTop = 275}}},
+    [40] = {stepsTo = 9, scrollPosition = 13115, positions = {premium = {marginLeft = 13439, marginTop = 80}}},
+    [41] = {stepsTo = 11, scrollPosition = 13465, positions = {premium = {marginLeft = 13792, marginTop = 80}}},
+    [42] = {stepsTo = 12, scrollPosition = 13850, positions = {premium = {marginLeft = 14175, marginTop = 80}, free = {marginLeft = 14180, marginTop = 275}}},
+    [43] = {stepsTo = 9, scrollPosition = 14140, positions = {premium = {marginLeft = 14462, marginTop = 80}}},
+    [44] = {stepsTo = 9, scrollPosition = 14425, positions = {premium = {marginLeft = 14750, marginTop = 80}}},
+    [45] = {stepsTo = 9, scrollPosition = 14715, positions = {premium = {marginLeft = 15040, marginTop = 80}, free = {marginLeft = 15045, marginTop = 275}}},
+    [46] = {stepsTo = 32, scrollPosition = 15740, positions = {premium = {marginLeft = 16078, marginTop = 90}}},
+    [47] = {stepsTo = 8, scrollPosition = 15995, positions = {premium = {marginLeft = 16335, marginTop = 90}}},
+    [48] = {stepsTo = 29, scrollPosition = 16925, positions = {premium = {marginLeft = 17256, marginTop = 87}, free = {marginLeft = 17256, marginTop = 275}}},
+    [49] = {stepsTo = 4, scrollPosition = 17050, positions = {premium = {marginLeft = 17384, marginTop = 87}, free = {marginLeft = 17384, marginTop = 275}}},
+    [50] = {stepsTo = 11, scrollPosition = 17278, positions = {premium = {marginLeft = 17734, marginTop = 87}, free = {marginLeft = 17734, marginTop = 245}}}
+}

--- a/modules/game_battlepass/const.lua
+++ b/modules/game_battlepass/const.lua
@@ -22,24 +22,24 @@ MissionRankIcons = {
 }
 
 BattleRewardTypes = {
-    "Item",             -- Ìndice 1
-    "Random Item",      -- Ìndice 2
-    "Random Mount",     -- Ìndice 3
-    "Exercise Item",    -- Ìndice 4
-    "Double Skill",     -- Ìndice 5
-    "Level",            -- Ìndice 6
-    "Prey",             -- Ìndice 7
-    "Exp Boost",        -- Ìndice 8
-    "Regen",            -- Ìndice 9
-    "Overload Forge",   -- Ìndice 10
-    "Instant Reward",   -- Ìndice 11
-    "Boosted Exercise", -- Ìndice 12
-    "Charms",           -- Ìndice 13
-    "Outfit",           -- Ìndice 14
-    "Extra Skill",      -- Ìndice 15
-    "Elemental Outfit", -- Ìndice 16
-    "Multi Items",      -- Ìndice 17
-    "Choosable Item",   -- Ìndice 18
+    "Item",             -- √çndice 1
+    "Random Item",      -- √çndice 2
+    "Random Mount",     -- √çndice 3
+    "Exercise Item",    -- √çndice 4
+    "Double Skill",     -- √çndice 5
+    "Level",            -- √çndice 6
+    "Prey",             -- √çndice 7
+    "Exp Boost",        -- √çndice 8
+    "Regen",            -- √çndice 9
+    "Overload Forge",   -- √çndice 10
+    "Instant Reward",   -- √çndice 11
+    "Boosted Exercise", -- √çndice 12
+    "Charms",           -- √çndice 13
+    "Outfit",           -- √çndice 14
+    "Extra Skill",      -- √çndice 15
+    "Elemental Outfit", -- √çndice 16
+    "Multi Items",      -- √çndice 17
+    "Choosable Item",   -- √çndice 18
 }
 
 RewardWidgetOrder = {

--- a/modules/game_battlepass/const.lua
+++ b/modules/game_battlepass/const.lua
@@ -7,6 +7,10 @@ function BattlePassConfig.isAllowedWikiUrl(url)
         return false
     end
 
+    if url:find("%.%.") then
+        return false
+    end
+
     return url == BattlePassConfig.wikiUrlPrefix or url:sub(1, #BattlePassConfig.wikiUrlPrefix + 1) == BattlePassConfig.wikiUrlPrefix .. "/"
 end
 

--- a/modules/game_battlepass/const.lua
+++ b/modules/game_battlepass/const.lua
@@ -1,3 +1,27 @@
+BattlePassConfig = BattlePassConfig or {}
+BattlePassConfig.wikiUrlDefault = BattlePassConfig.wikiUrlDefault or "https://wiki.rubinot.com/pt-BR/passe-de-batalha/season-2"
+BattlePassConfig.wikiUrlPrefix = BattlePassConfig.wikiUrlPrefix or "https://wiki.rubinot.com/pt-BR/passe-de-batalha"
+
+function BattlePassConfig.isAllowedWikiUrl(url)
+    if type(url) ~= "string" or url:find("[%c%s]") then
+        return false
+    end
+
+    return url == BattlePassConfig.wikiUrlPrefix or url:sub(1, #BattlePassConfig.wikiUrlPrefix + 1) == BattlePassConfig.wikiUrlPrefix .. "/"
+end
+
+function BattlePassConfig.setWikiUrl(url)
+    if not BattlePassConfig.isAllowedWikiUrl(url) then
+        url = BattlePassConfig.wikiUrlDefault
+    end
+
+    BattlePassConfig.wikiUrl = url
+    BATTLEPASS_WIKI_URL = url
+    return url
+end
+
+BattlePassConfig.setWikiUrl(BATTLEPASS_WIKI_URL or BattlePassConfig.wikiUrl or BattlePassConfig.wikiUrlDefault)
+
 MissionsDisplacement = {
     1, 2, 14, 15, -- First week [2 de 100 pontos e 2 de 200 pontos]
     3, 4, 16, 17, -- Second week [2 de 100 pontos e 2 de 200 pontos]

--- a/modules/game_battlepass/styles/battlepass_button.otui
+++ b/modules/game_battlepass/styles/battlepass_button.otui
@@ -29,7 +29,7 @@ BattlePassBarWidget < UIWidget
     margin-left: 9
     margin-right: 9
     margin-bottom: 1
-    @onClick: modules.game_battlepass.onBattlePassBarClick()
+    @onClick: modules.game_battlepass.BattlePass.onBattlePassBarClick()
 
   UIWidget
     id: highlight

--- a/modules/game_battlepass/styles/battlepass_button.otui
+++ b/modules/game_battlepass/styles/battlepass_button.otui
@@ -1,0 +1,42 @@
+BattlePassBarButton < UIButton
+  size: 108 24
+  font: Verdana Bold-11px
+  color: #c0c0c0
+  !text: tr('Battle Pass')
+  text-align: center
+  image-source: /images/ui/buttons-blue
+  image-clip: 0 0 22 20
+  image-border: 3
+  focusable: false
+  margin-top: 8
+  margin-left: 8
+  margin-right: 8
+
+  $hover:
+    color: #ffffff
+
+BattlePassBarWidget < UIWidget
+  size: 126 34
+  focusable: false
+  phantom: false
+  &noDrag: true
+  &alwaysOnTop: true
+
+  BattlePassBarButton
+    id: battlePassBarBtn
+    anchors.fill: parent
+    margin-top: 9
+    margin-left: 9
+    margin-right: 9
+    margin-bottom: 1
+    @onClick: modules.game_battlepass.onBattlePassBarClick()
+
+  UIWidget
+    id: highlight
+    anchors.left: battlePassBarBtn.left
+    anchors.right: battlePassBarBtn.right
+    anchors.top: battlePassBarBtn.top
+    anchors.bottom: battlePassBarBtn.bottom
+    margin: -1
+    image-source: /images/store/rectangle-highlight
+    phantom: true

--- a/modules/game_interface/interface.otmod
+++ b/modules/game_interface/interface.otmod
@@ -48,6 +48,7 @@ Module
     - game_dailyreward
     - game_memorial
     - game_trackers
+    - game_battlepass
     - game_wheel
     - game_monster_podium
     - game_player_podium


### PR DESCRIPTION
## What changed

- Adds the `game_battlepass` client module, UI, reward helpers, constants, and side button style.
- Registers `game_battlepass` in `game_interface/interface.otmod` so it loads with the game interface.
- Includes runtime compatibility fixes for AstraClient, including Battlepass reward chunk handling and safe outfit walking animation calls.

## Why

This ports the Battlepass client UI and protocol handling into AstraClient and keeps the client compatible with the 8.60 server-side extended opcode flow.

## Validation

- Ran `npx --yes luaparse` for `modules/game_battlepass/battlepass.lua`.
- Ran `npx --yes luaparse` for `modules/game_battlepass/classes/rewards.lua`.
- Ran `npx --yes luaparse` for `modules/game_battlepass/const.lua`.
- Ran `git diff --check` before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Implementação completa do Battle Pass: missões diárias/saizonais, progresso e recompensas.
  * Painel de progresso interativo com animações do avatar, scroll arrastável e navegação por passos.
  * UI de seleção e confirmação de recompensas com pré‑visualizações e opções escolhíveis.
  * Botão/widget de acesso rápido na interface, atalho para alternar menus e janela principal com abas.
  * Reroll de missões diárias, persistência local de posição/config e sincronização de saldo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->