### PR TITLE
fix: protege chamadas a g_sounds e widget:close() contra nil

### DIFF
--- a/mods/game_helper/classes/alarms/full_dust_alarm.lua
+++ b/mods/game_helper/classes/alarms/full_dust_alarm.lua
@@ -34,7 +34,7 @@ _Helper.FullDustAlarm.toggle = function(checked)
   local config = _Helper.AlarmSettings.getConfig()
   config.dust.enabled = checked
 
-  if not checked then
+  if not checked and g_sounds then
     g_sounds.stopAlarm()
   end
 
@@ -86,7 +86,9 @@ _Helper.FullDustAlarm.resetCheckbox = function()
     removeEvent(pendingEvent)
     pendingEvent = nil
   end
-  g_sounds.stopAlarm()
+  if g_sounds then
+    g_sounds.stopAlarm()
+  end
   wasDustFull = true
 end
 

--- a/mods/game_helper/classes/alarms/low_capacity_alarm.lua
+++ b/mods/game_helper/classes/alarms/low_capacity_alarm.lua
@@ -33,7 +33,7 @@ _Helper.LowCapacityAlarm.toggle = function(checked)
   local config = _Helper.AlarmSettings.getConfig()
   config.cap.enabled = checked
 
-  if not checked then
+  if not checked and g_sounds then
     g_sounds.stopAlarm()
   end
 
@@ -101,7 +101,9 @@ _Helper.LowCapacityAlarm.resetCheckbox = function()
     _Helper.AlarmSettings.close()
   end
 
-  g_sounds.stopAlarm()
+  if g_sounds then
+    g_sounds.stopAlarm()
+  end
   lastPlayTime = 0
 
   _Helper.AlarmSettings.clearCache()

--- a/mods/game_helper/classes/alarms/low_health_alarm.lua
+++ b/mods/game_helper/classes/alarms/low_health_alarm.lua
@@ -34,7 +34,9 @@ _Helper.LowHealthAlarm.toggle = function(checked)
   config.health.enabled = checked
 
   if not checked then
-    g_sounds.stopAlarm()
+    if g_sounds then
+      g_sounds.stopAlarm()
+    end
   end
 
   if not checked then
@@ -97,7 +99,9 @@ end
 
 -- Reset state (stop sound)
 _Helper.LowHealthAlarm.resetCheckbox = function()
-  g_sounds.stopAlarm()
+  if g_sounds then
+    g_sounds.stopAlarm()
+  end
   lastPlayTime = 0
 end
 

--- a/mods/game_helper/classes/alarms/low_mana_alarm.lua
+++ b/mods/game_helper/classes/alarms/low_mana_alarm.lua
@@ -33,7 +33,7 @@ _Helper.LowManaAlarm.toggle = function(checked)
   local config = _Helper.AlarmSettings.getConfig()
   config.mana.enabled = checked
 
-  if not checked then
+  if not checked and g_sounds then
     g_sounds.stopAlarm()
   end
 
@@ -102,7 +102,9 @@ end
 
 -- Reset state (stop sound)
 _Helper.LowManaAlarm.resetCheckbox = function()
-  g_sounds.stopAlarm()
+  if g_sounds then
+    g_sounds.stopAlarm()
+  end
   lastPlayTime = 0
 end
 

--- a/mods/game_helper/classes/alarms/low_supply_alarm.lua
+++ b/mods/game_helper/classes/alarms/low_supply_alarm.lua
@@ -90,7 +90,9 @@ _Helper.LowSupplyAlarm.toggle = function(checked)
   config.supply.enabled = checked
 
   if not checked then
-    g_sounds.stopAlarm()
+    if g_sounds then
+      g_sounds.stopAlarm()
+    end
   end
 
   if not checked then
@@ -174,7 +176,9 @@ _Helper.LowSupplyAlarm.check = function()
 end
 
 _Helper.LowSupplyAlarm.resetCheckbox = function()
-  g_sounds.stopAlarm()
+  if g_sounds then
+    g_sounds.stopAlarm()
+  end
   lastPlayTime = 0
 
   -- Fechar settings window se aberta

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -2305,7 +2305,7 @@ function onPlayerLoad(config)
       if panel then
         for _, widget in pairs(panel:getChildren()) do
           if widget:isVisible() and not string.containsTable(widget:getId(), primordial) then
-            widget:close()
+            if widget.close then widget:close() end
           end
         end
 
@@ -2321,7 +2321,7 @@ function onPlayerLoad(config)
       if panel then
         for _, widget in pairs(panel:getChildren()) do
           if widget:isVisible() and not string.containsTable(widget:getId(), primordial) then
-            widget:close()
+            if widget.close then widget:close() end
           end
         end
 
@@ -2335,7 +2335,7 @@ function onPlayerLoad(config)
     if config.openWidgetsHorizontalRight then
       for _, widget in pairs(horizontalRightPanel:getChildren()) do
         if widget:isVisible() and not string.containsTable(widget:getId(), primordial) then
-          widget:close()
+          if widget.close then widget:close() end
         end
       end
 
@@ -2381,7 +2381,7 @@ function onPlayerLoad(config)
     if config.openWidgetsHorizontalLeft then
       for _, widget in pairs(horizontalLeftPanel:getChildren()) do
         if widget:isVisible() and not string.containsTable(widget:getId(), primordial) then
-          widget:close()
+          if widget.close then widget:close() end
         end
       end
 


### PR DESCRIPTION
- Alarmes do game_helper: g_sounds não existe em builds sem áudio (FEATURE_SOUND off); guards em stopAlarm nos 5 alarmes, completando o fix parcial do low_mana_alarm (preload/play já eram guardados).
- gameinterface.lua (onPlayerLoad): painéis podem conter widgets sem o método close (ex.: widgets simples adicionados por mods); chamar widget:close() neles aborta o carregamento do layout do personagem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrigidas exceções potenciais nos sistemas de alarme quando recursos de áudio não estão disponíveis durante offline ou logout.
  * Melhorada estabilidade na restauração de painéis de interface durante recarregamento de sessão.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->