### PR TITLE
Add persistent loot highlight rendering for AstraClient.

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -337,8 +337,11 @@ GameLoadTibiaAssets = 133
 GameGroupInMessage = 134
 GameExevoVisHur = 135
 GameNewCreatureStacking = 136 -- Ignore MAX_THINGS limit while adding to tile
+GameEffectSource = 137
+GamePlayerFamiliars = 138
+GameItemLootHighlight = 139
 
-LastGameFeature = 137
+LastGameFeature = 140
 
 TextColors = {
   red        = '#F55E5E',

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -499,8 +499,9 @@ namespace Otc
         GameNewCreatureStacking = 136,
         GameEffectSource = 137,
         GamePlayerFamiliars = 138,
+        GameItemLootHighlight = 139,
 
-        LastGameFeature = 139
+        LastGameFeature = 140
     };
 
     enum PathFindResult {

--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -29,6 +29,7 @@
 #include "map.h"
 #include "houses.h"
 #include "game.h"
+#include "client.h"
 
 #include <framework/core/clock.h>
 #include <framework/core/eventdispatcher.h>
@@ -47,6 +48,7 @@ Item::Item() :
     m_async(true),
     m_quickLootFlags(0),
     m_obtainFlags(0),
+    m_lootHighlight(false),
     m_tier(0),
     m_phase(0),
     m_lastPhase(0),
@@ -104,6 +106,27 @@ void Item::draw(const Point& dest, bool animate, LightView* lightView)
     }
     if (m_marked) {
         g_drawQueue->setMark(drawQueueSize, updatedMarkedColor());
+    }
+
+    constexpr uint16 LootHighlightEffectId = 252;
+    constexpr int LootHighlightTicksPerFrame = 75;
+    if (m_lootHighlight && g_things.isValidDatId(LootHighlightEffectId, ThingCategoryEffect)) {
+        auto effectType = g_things.rawGetThingType(LootHighlightEffectId, ThingCategoryEffect);
+        if (effectType) {
+            const int effectPhases = std::max<int>(1, effectType->getAnimationPhases());
+            const int effectPhase = static_cast<int>((g_clock.millis() / LootHighlightTicksPerFrame) % effectPhases);
+            const int effectPatternXCount = std::max<int>(1, effectType->getNumPatternX());
+            const int effectPatternYCount = std::max<int>(1, effectType->getNumPatternY());
+            int effectXPattern = m_position.x % effectPatternXCount;
+            int effectYPattern = m_position.y % effectPatternYCount;
+            if (effectXPattern < 0)
+                effectXPattern += effectPatternXCount;
+            if (effectYPattern < 0)
+                effectYPattern += effectPatternYCount;
+            const auto source = g_game.getFeature(Otc::GameEffectSource) ? Otc::ME_SOURCE_DEFAULT : Otc::ME_SOURCE_OWN;
+            const float alpha = g_client.getEffectAlpha(source);
+            effectType->draw(dest, 0, effectXPattern, effectYPattern, 0, effectPhase, Color(255, 255, 255, static_cast<int>(alpha * 255)), lightView);
+        }
     }
 }
 

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -95,6 +95,7 @@ public:
     void setTooltip(const std::string& str) { m_tooltip = str; }
     void setQuickLootFlags(uint32 flags) { m_quickLootFlags = flags; }
     void setObtainFlags(uint32 flags) { m_obtainFlags = flags; }
+    void setLootHighlight(bool value) { m_lootHighlight = value; }
     void setShader(const std::string& str) { m_shader = str; }
     void setHash(const std::string& hash) { m_hash = hash; }
     void setDurationTime(uint64 value) { m_durationTime = value; }
@@ -118,6 +119,7 @@ public:
     std::string getTooltip() { return m_tooltip; }
     uint32 getQuickLootFlags() { return m_quickLootFlags; }
     uint32 getObtainFlags() { return m_obtainFlags; }
+    bool hasLootHighlight() const { return m_lootHighlight; }
     std::string getShader() { return m_shader; }
     std::string getItemHash() { return m_hash; }
     uint64 getDurationTime() { return m_durationTime; }
@@ -209,6 +211,7 @@ private:
 
     uint32 m_quickLootFlags;
     uint32 m_obtainFlags;
+    bool m_lootHighlight;
     int m_tier;
     uint8 m_phase;
     ticks_t m_lastPhase;

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4662,6 +4662,9 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, int id, bool hasDescri
             item->setQuickLootFlags(msg->getU32()); // quick loot flags
         }
     }
+    if (item->rawGetThingType()->isContainer() && g_game.getFeature(Otc::GameItemLootHighlight)) {
+        item->setLootHighlight(msg->getU8() != 0);
+    }
 
     if (g_game.getFeature(Otc::GameItemTierByte)) {
         item->setTier(msg->getU8());


### PR DESCRIPTION
- Adds support for the ItemLootHighlight protocol feature and renders corpse loot highlights persistently on the client while the server marks the item as highlighted.