### PR TITLE
[codex] Fix UI layout regressions

### DIFF
--- a/mods/client_settings/classes/dataset.lua
+++ b/mods/client_settings/classes/dataset.lua
@@ -1,20 +1,6 @@
 local function setHealthManaCircleVisible(value)
-    local gameMapPanel = m_interface and m_interface.getMapPanel and m_interface.getMapPanel()
-    if gameMapPanel and gameMapPanel.setShowArcs then
-        gameMapPanel:setShowArcs(false)
-    end
-
-    if modules.game_healthcircle then
-        if modules.game_healthcircle.handleShowArc then
-            modules.game_healthcircle.handleShowArc(value)
-        else
-            if modules.game_healthcircle.setHealthCircle then
-                modules.game_healthcircle.setHealthCircle(value)
-            end
-            if modules.game_healthcircle.setManaCircle then
-                modules.game_healthcircle.setManaCircle(value)
-            end
-        end
+    if modules.client_settings and modules.client_settings.setHealthCircleModules then
+        modules.client_settings.setHealthCircleModules(value)
     end
 end
 

--- a/mods/client_settings/classes/dataset.lua
+++ b/mods/client_settings/classes/dataset.lua
@@ -1,3 +1,23 @@
+local function setHealthManaCircleVisible(value)
+    local gameMapPanel = m_interface and m_interface.getMapPanel and m_interface.getMapPanel()
+    if gameMapPanel and gameMapPanel.setShowArcs then
+        gameMapPanel:setShowArcs(false)
+    end
+
+    if modules.game_healthcircle then
+        if modules.game_healthcircle.handleShowArc then
+            modules.game_healthcircle.handleShowArc(value)
+        else
+            if modules.game_healthcircle.setHealthCircle then
+                modules.game_healthcircle.setHealthCircle(value)
+            end
+            if modules.game_healthcircle.setManaCircle then
+                modules.game_healthcircle.setManaCircle(value)
+            end
+        end
+    end
+end
+
 return {
     layout = {
         value = DEFAULT_LAYOUT,
@@ -799,12 +819,7 @@ return {
 	showHealthManaCircle = {
     value = false,
     apply = function(value)
-        local gameMapPanel = m_interface.getMapPanel()
-        gameMapPanel:setShowArcs(value)
-        if modules.game_healthcircle then
-            modules.game_healthcircle.setHealthCircle(value)
-            modules.game_healthcircle.setManaCircle(value)
-        end
+        setHealthManaCircleVisible(value)
         return true
     end,
     tempApply = function(value)
@@ -830,12 +845,7 @@ return {
                 end
             end
         end
-        local gameMapPanel = m_interface.getMapPanel()
-        gameMapPanel:setShowArcs(value)
-        if modules.game_healthcircle then
-            modules.game_healthcircle.setHealthCircle(value)
-            modules.game_healthcircle.setManaCircle(value)
-        end
+        setHealthManaCircleVisible(value)
         return true
     end
   },
@@ -1831,7 +1841,13 @@ return {
 	customisableBars = {
 		value = true,
         apply = function(value)
-            modules.game_topbar.toggle(value)
+            if modules.game_topbar then
+                if modules.game_topbar.reloadFromSettings then
+                    modules.game_topbar.reloadFromSettings(value)
+                elseif modules.game_topbar.toggle then
+                    modules.game_topbar.toggle(value)
+                end
+            end
             return true
         end,
 	},

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -58,6 +58,7 @@ local extraOptions = {}
 local tmpResetActions = {}
 local autoApplyEvent = nil
 local applyingOptions = false
+local pendingInterfaceRefreshEvents = {}
 
 local globalGeneralHotkey = {}
 local actionBarHotkey = {}
@@ -260,7 +261,7 @@ function terminate()
   loadedWindows = {}
 end
 
-local function setHealthCircleModules(value)
+function setHealthCircleModules(value)
   local gameMapPanel = m_interface and m_interface.getMapPanel and m_interface.getMapPanel()
   if gameMapPanel and gameMapPanel.setShowArcs then
     gameMapPanel:setShowArcs(false)
@@ -297,8 +298,20 @@ local function refreshOnlineInterfaceOptions()
 end
 
 local function scheduleOnlineInterfaceOptionsRefresh()
-  for _, delay in ipairs({50, 250, 750, 1500, 3000}) do
-    scheduleEvent(refreshOnlineInterfaceOptions, delay)
+  for _, event in ipairs(pendingInterfaceRefreshEvents) do
+    removeEvent(event)
+  end
+  pendingInterfaceRefreshEvents = {}
+
+  -- Retry through the login/layout settle window because interface modules finish at different ticks.
+  local delays = {50, 250, 750, 1500, 3000}
+  for index, delay in ipairs(delays) do
+    pendingInterfaceRefreshEvents[#pendingInterfaceRefreshEvents + 1] = scheduleEvent(function()
+      refreshOnlineInterfaceOptions()
+      if index == #delays then
+        pendingInterfaceRefreshEvents = {}
+      end
+    end, delay)
   end
 end
 

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -260,6 +260,48 @@ function terminate()
   loadedWindows = {}
 end
 
+local function setHealthCircleModules(value)
+  local gameMapPanel = m_interface and m_interface.getMapPanel and m_interface.getMapPanel()
+  if gameMapPanel and gameMapPanel.setShowArcs then
+    gameMapPanel:setShowArcs(false)
+  end
+
+  if modules.game_healthcircle then
+    if modules.game_healthcircle.handleShowArc then
+      modules.game_healthcircle.handleShowArc(value)
+    else
+      if modules.game_healthcircle.setHealthCircle then
+        modules.game_healthcircle.setHealthCircle(value)
+      end
+      if modules.game_healthcircle.setManaCircle then
+        modules.game_healthcircle.setManaCircle(value)
+      end
+    end
+  end
+end
+
+local function refreshOnlineInterfaceOptions()
+  if not g_game.isOnline() then
+    return
+  end
+
+  setHealthCircleModules(getOption("showHealthManaCircle"))
+
+  if modules.game_topbar then
+    if modules.game_topbar.reloadFromSettings then
+      modules.game_topbar.reloadFromSettings(getOption("customisableBars"))
+    elseif modules.game_topbar.toggle then
+      modules.game_topbar.toggle(getOption("customisableBars"))
+    end
+  end
+end
+
+local function scheduleOnlineInterfaceOptionsRefresh()
+  for _, delay in ipairs({50, 250, 750, 1500, 3000}) do
+    scheduleEvent(refreshOnlineInterfaceOptions, delay)
+  end
+end
+
 function online()
   local benchmark = g_clock.millis()
   tmpResetActions = {}
@@ -275,6 +317,7 @@ function online()
 
   ActionHotkey.configureActionBarHotkeys()
   ConditionsHUD:onGameStart()
+  scheduleOnlineInterfaceOptionsRefresh()
   consoleln("Settings loaded in " .. (g_clock.millis() - benchmark) / 1000 .. " seconds.")
 end
 
@@ -315,7 +358,6 @@ function toggleDisplays()
       gameMapPanel:setDrawHarmonyBar(true)
     end
     if getOption("showHealthManaCircle") then
-      gameMapPanel:setShowArcs(true)
       setHealthCircleModules(true)
     end
   elseif displayState == 1 then
@@ -325,7 +367,6 @@ function toggleDisplays()
     gameMapPanel:setDrawOwnManaBar(false)
     gameMapPanel:setDrawOwnManaShieldBar(false)
     gameMapPanel:setDrawPlayerBars(false)
-    gameMapPanel:setShowArcs(false)
     setHealthCircleModules(false)
   elseif displayState == 2 then
     -- Ocultar others e mostrar own
@@ -341,7 +382,6 @@ function toggleDisplays()
       gameMapPanel:setDrawOwnManaShieldBar(true)
     end
     if getOption("showHealthManaCircle") then
-      gameMapPanel:setShowArcs(true)
       setHealthCircleModules(true)
     end
   elseif displayState == 3 then
@@ -358,16 +398,8 @@ function toggleDisplays()
       gameMapPanel:setDrawOwnManaShieldBar(false)
     end
     if getOption("showHealthManaCircle") then
-      gameMapPanel:setShowArcs(false)
       setHealthCircleModules(false)
     end
-  end
-end
-
-local function setHealthCircleModules(value)
-  if modules.game_healthcircle and modules.game_healthcircle.setHealthCircle then
-    modules.game_healthcircle.setHealthCircle(value)
-    modules.game_healthcircle.setManaCircle(value)
   end
 end
 

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -26,6 +26,21 @@ local cachedItemWidget = {}
 local dragButton = nil
 local dragItem = nil
 
+function updateGameMapPanelMargin()
+	local gameMapPanel = nil
+	if m_interface then
+		gameMapPanel = m_interface.getMapPanel and m_interface.getMapPanel() or m_interface.gameMapPanel
+	end
+
+	if gameMapPanel and gameMapPanel:getMarginBottom() ~= 0 then
+		gameMapPanel:setMarginBottom(0)
+	end
+
+	if modules.game_textmessage and modules.game_textmessage.updateActionBarMessageMargin then
+		modules.game_textmessage.updateActionBarMessageMargin(7)
+	end
+end
+
 local function refreshActionButtonRarity(button)
 	if not button or not button.item or not ItemsDatabase or not ItemsDatabase.setRarityItem then
 		return
@@ -360,9 +375,6 @@ function onCreateActionBars()
 	if #actionBars == 0 then
 		createActionBars()
 	end
-	local margins = {41, 80, 119}
-	local totalMargin = 2
-
 	for i = 1, #actionBars do
 		local actionbar = actionBars[i]
 		local enabled = Options.actionBar[i].isVisible
@@ -374,22 +386,12 @@ function onCreateActionBars()
 		end
 
 		table.insert(activeActionBars, actionbar)
-		local previousEnabled = true
-		for j = 1, i - 1 do
-			if not g_settings.getBoolean("actionbar" .. j, false) then
-				previousEnabled = false
-				break
-			end
-		end
-		if previousEnabled then
-			totalMargin = margins[i]
-		end
 
 		:: continue ::
 	end
 
 	resizeLockButtons()
-	gameMapPanel:setMarginBottom(totalMargin)
+	updateGameMapPanelMargin()
 end
 
 function createActionBars()
@@ -2618,6 +2620,7 @@ function configureActionBar(barStr, visible)
 				end
 			end
 		end
+		updateGameMapPanelMargin()
 		scheduleEvent(function() modules.game_actionbar.updateVisibleWidgets() end, 10)
 		return
 	end

--- a/modules/game_healthcircle/game_healthcircle.lua
+++ b/modules/game_healthcircle/game_healthcircle.lua
@@ -26,6 +26,8 @@ isExpCircle = g_settings.getBoolean('healthcircle_expcircle')
 isSkillCircle = g_settings.getBoolean('healthcircle_skillcircle')
 skillTypes = g_settings.getNode('healthcircle_skilltypes')
 skillsLoaded = false
+local mapResizeEvents = {}
+local healthCirclePositioned = false
 
 if not skillTypes then
     skillTypes = {}
@@ -33,6 +35,129 @@ end
 
 distanceFromCenter = g_settings.getNumber('healthcircle_distfromcenter') or 0
 opacityCircle = g_settings.getNumber('healthcircle_opacity') or 0.35
+
+local function normalizeShowOverride(value)
+    return type(value) == 'boolean' and value or nil
+end
+
+local function getShowHealthManaCircleSetting(showOverride)
+    showOverride = normalizeShowOverride(showOverride)
+    if showOverride ~= nil then
+        return showOverride
+    end
+
+    if TempOptions and type(TempOptions.getOption) == 'function' then
+        local value = TempOptions:getOption('showHealthManaCircle')
+        if value ~= nil then
+            return toboolean(value)
+        end
+    end
+
+    if GameOptions and type(GameOptions.getOption) == 'function' then
+        local ok, value = pcall(GameOptions.getOption, GameOptions, 'showHealthManaCircle')
+        if ok and value ~= nil then
+            return toboolean(value)
+        end
+    end
+
+    if m_settings and type(m_settings.getOption) == 'function' then
+        local ok, value = pcall(m_settings.getOption, 'showHealthManaCircle')
+        if ok and value ~= nil then
+            return toboolean(value)
+        end
+    end
+
+    return g_settings.getBoolean('showHealthManaCircle')
+end
+
+local function disableMapNativeArcs()
+    local mapPanel = modules.game_interface and modules.game_interface.getMapPanel and modules.game_interface.getMapPanel()
+    if mapPanel and mapPanel.setShowArcs then
+        mapPanel:setShowArcs(false)
+    end
+end
+
+local function getMapPanel()
+    return modules.game_interface and modules.game_interface.getMapPanel and modules.game_interface.getMapPanel()
+end
+
+local function hasValidMapGeometry(mapPanel)
+    return mapPanel
+        and mapPanel:getWidth() > 0
+        and mapPanel:getHeight() > 0
+        and imageSizeBroad > 0
+        and imageSizeThin > 0
+end
+
+local function getBarDistance(mapHeight)
+    local barDistance = 90
+    if not (math.floor(mapHeight / 2 * 0.2) < 100) then
+        barDistance = math.floor(mapHeight / 2 * 0.2)
+    end
+    return barDistance
+end
+
+local function hasStableMapGeometry(mapPanel)
+    if not hasValidMapGeometry(mapPanel) then
+        return false
+    end
+
+    local barDistance = getBarDistance(mapPanel:getHeight())
+    local minimumWidth = math.max(480, imageSizeThin * 2 + barDistance * 2 + 64)
+    local minimumHeight = math.max(320, imageSizeBroad + 64)
+    return mapPanel:getWidth() >= minimumWidth and mapPanel:getHeight() >= minimumHeight
+end
+
+local function hideHealthCircleWidgets()
+    if healthCircle then healthCircle:setVisible(false) end
+    if healthCircleFront then healthCircleFront:setVisible(false) end
+    if type(setMonkWidgetsVisible) == 'function' then
+        setMonkWidgetsVisible(false)
+    end
+end
+
+local function hideManaCircleWidgets()
+    if manaCircle then manaCircle:setVisible(false) end
+    if manaCircleFront then manaCircleFront:setVisible(false) end
+    if manaShieldCircle then manaShieldCircle:setVisible(false) end
+    if manaShieldCircleFront then manaShieldCircleFront:setVisible(false) end
+end
+
+local function hideExtraCircleWidgets()
+    if expCircle then expCircle:setVisible(false) end
+    if expCircleFront then expCircleFront:setVisible(false) end
+    if skillCircle then skillCircle:setVisible(false) end
+    if skillCircleFront then skillCircleFront:setVisible(false) end
+end
+
+local function applyHealthManaCircleVisibility(showOverride)
+    local mapPanel = getMapPanel()
+    if not g_game.isOnline() or not healthCirclePositioned or not hasStableMapGeometry(mapPanel) or not getShowHealthManaCircleSetting(showOverride) then
+        hideHealthCircleWidgets()
+        hideManaCircleWidgets()
+        return false
+    end
+
+    local useMonkWidgets = false
+    if isHealthCircle and type(checkMonkVocation) == 'function' then
+        useMonkWidgets = checkMonkVocation()
+    end
+
+    if healthCircle then healthCircle:setVisible(isHealthCircle and not useMonkWidgets) end
+    if healthCircleFront then healthCircleFront:setVisible(isHealthCircle and not useMonkWidgets) end
+    if type(setMonkWidgetsVisible) == 'function' then
+        setMonkWidgetsVisible(isHealthCircle and useMonkWidgets)
+    end
+
+    if manaCircle then manaCircle:setVisible(isManaCircle) end
+    if manaCircleFront then manaCircleFront:setVisible(isManaCircle) end
+    if not isManaCircle then
+        if manaShieldCircle then manaShieldCircle:setVisible(false) end
+        if manaShieldCircleFront then manaShieldCircleFront:setVisible(false) end
+    end
+
+    return true
+end
 
 function init()
     g_ui.importStyle("game_healthcircle.otui")
@@ -55,10 +180,12 @@ function init()
     manaShieldImageSizeThin = manaShieldCircle:getWidth()
     manaShieldCircle:setVisible(false)
     manaShieldCircleFront:setVisible(false)
+    hideHealthCircleWidgets()
+    hideManaCircleWidgets()
 
     initMonkWidgets()
 
-    whenMapResizeChange()
+    scheduleMapResizeUpdates()
     initOnHpAndMpChange()
     initOnGeometryChange()
     initOnLoginChange()
@@ -85,10 +212,13 @@ function init()
         skillCircleFront:setVisible(false)
     end
 
+    handleShowArc(getShowHealthManaCircleSetting())
+
     addToOptionsModule()
 
     connect(g_game, {
-        onGameStart = setPlayerValues
+        onGameStart = setPlayerValues,
+        onGameEnd = resetHealthCircleLayout
     })
 
     if StatusIconBar and StatusIconBar.init then
@@ -121,6 +251,7 @@ function terminate()
 
     terminateMonkWidgets()
 
+    resetHealthCircleLayout()
     terminateOnHpAndMpChange()
     terminateOnGeometryChange()
     terminateOnLoginChange()
@@ -128,7 +259,8 @@ function terminate()
     destroyOptionsModule()
 
     disconnect(g_game, {
-        onGameStart = setPlayerValues
+        onGameStart = setPlayerValues,
+        onGameEnd = resetHealthCircleLayout
     })
 
     if StatusIconBar and StatusIconBar.terminate then
@@ -161,30 +293,63 @@ end
 function initOnGeometryChange()
     local mapPanel = modules.game_interface.getMapPanel()
     connect(mapPanel, {
-        onGeometryChange = whenMapResizeChange
+        onGeometryChange = whenMapResizeChange,
+        onVisibleDimensionChange = whenMapResizeChange
     })
 end
 
 function terminateOnGeometryChange()
     local mapPanel = modules.game_interface.getMapPanel()
     disconnect(mapPanel, {
-        onGeometryChange = whenMapResizeChange
+        onGeometryChange = whenMapResizeChange,
+        onVisibleDimensionChange = whenMapResizeChange
     })
 end
 
 function initOnLoginChange()
     connect(g_game, {
-        onGameStart = whenMapResizeChange
+        onGameStart = scheduleMapResizeUpdates
     })
 end
 
 function terminateOnLoginChange()
     disconnect(g_game, {
-        onGameStart = whenMapResizeChange
+        onGameStart = scheduleMapResizeUpdates
     })
 end
 
-function whenHealthChange()
+function clearScheduledMapResizeUpdates()
+    for _, event in pairs(mapResizeEvents) do
+        removeEvent(event)
+    end
+    mapResizeEvents = {}
+end
+
+function resetHealthCircleLayout()
+    clearScheduledMapResizeUpdates()
+    healthCirclePositioned = false
+    hideHealthCircleWidgets()
+    hideManaCircleWidgets()
+    hideExtraCircleWidgets()
+end
+
+function scheduleMapResizeUpdates(showOverride)
+    clearScheduledMapResizeUpdates()
+    whenMapResizeChange(showOverride)
+
+    for _, delay in ipairs({50, 150, 350, 750, 1500, 3000, 5000, 8000, 12000}) do
+        table.insert(mapResizeEvents, scheduleEvent(function()
+            whenMapResizeChange(showOverride)
+        end, delay))
+    end
+end
+
+function whenHealthChange(showOverride)
+    if not g_game.isOnline() or not healthCirclePositioned or not getShowHealthManaCircleSetting(showOverride) or not hasStableMapGeometry(getMapPanel()) then
+        hideHealthCircleWidgets()
+        return
+    end
+
     if g_game.isOnline() then
         if isMonkMode then
             whenMonkHealthChange()
@@ -249,12 +414,12 @@ local function resetManaCircleImages()
     end
 end
 
-local function updateManaShieldDisplay()
+local function updateManaShieldDisplay(showOverride)
     if not manaShieldCircle or not manaShieldCircleFront or not manaCircle or not manaCircleFront then
         return
     end
 
-    if not g_game.isOnline() or not isManaCircle then
+    if not g_game.isOnline() or not healthCirclePositioned or not isManaCircle or not getShowHealthManaCircleSetting(showOverride) or not hasStableMapGeometry(getMapPanel()) then
         manaShieldCircle:setVisible(false)
         manaShieldCircleFront:setVisible(false)
         resetManaCircleImages()
@@ -284,8 +449,9 @@ local function updateManaShieldDisplay()
     manaCircleFront:setImageSource(defaultManaWithManaShieldCircleFull)
     manaShieldCircle:setImageSource(manaShieldManaCircleEmpty)
     manaShieldCircleFront:setImageSource(manaShieldManaCircleFull)
-    manaShieldCircle:setVisible(true)
-    manaShieldCircleFront:setVisible(true)
+    local geometryReady = hasStableMapGeometry(getMapPanel())
+    manaShieldCircle:setVisible(geometryReady)
+    manaShieldCircleFront:setVisible(geometryReady)
 
     local clampedShield = math.max(math.min(remainingShield, maxShield), 0)
     local shieldPercent = clampedShield / maxShield
@@ -322,7 +488,13 @@ function whenManaShieldChange()
     updateManaShieldDisplay()
 end
 
-function whenManaChange()
+function whenManaChange(showOverride)
+    if not g_game.isOnline() or not healthCirclePositioned or not getShowHealthManaCircleSetting(showOverride) or not hasStableMapGeometry(getMapPanel()) then
+        hideManaCircleWidgets()
+        resetManaCircleImages()
+        return
+    end
+
     if g_game.isOnline() then
         local player = g_game.getLocalPlayer()
         if not player then return end
@@ -341,7 +513,7 @@ function whenManaChange()
             manaCircleFront:setVisible(true)
         end
 
-        updateManaShieldDisplay()
+        updateManaShieldDisplay(showOverride)
 
         local manaPercent = math.floor(player:getMana() / maxMana * 100)
 
@@ -361,13 +533,8 @@ function whenManaChange()
                     width = imageSizeThin,
                     height = restYmppc
                 })
-    end
-
-    -- Auto-show on first run (no config saved yet)
-    if distanceFromCenter == 0 then
-        toggleOptionsPanel()
-    end
-end
+            end
+        end
 
         manaCircle:setHeight(ymppc)
         manaCircle:setImageClip({
@@ -461,31 +628,39 @@ function whenSkillsChange()
     end
 end
 
-function whenMapResizeChange()
+function whenMapResizeChange(showOverride)
     if g_game.isOnline() then
-        local mapPanel = modules.game_interface.getMapPanel()
-        if not mapPanel then return end
-
-        local barDistance = 90
-        if not (math.floor(mapPanel:getHeight() / 2 * 0.2) < 100) then
-            barDistance = math.floor(mapPanel:getHeight() / 2 * 0.2)
+        local mapPanel = getMapPanel()
+        if not hasStableMapGeometry(mapPanel) then
+            healthCirclePositioned = false
+            hideHealthCircleWidgets()
+            hideManaCircleWidgets()
+            hideExtraCircleWidgets()
+            return false
         end
 
-        healthCircleFront:setX(mapPanel:getX() + mapPanel:getWidth() / 2 - imageSizeThin - barDistance -
-            distanceFromCenter)
-        manaCircleFront:setX(mapPanel:getX() + mapPanel:getWidth() / 2 + barDistance + distanceFromCenter)
+        local barDistance = getBarDistance(mapPanel:getHeight())
+        local centerX = mapPanel:getX() + mapPanel:getWidth() / 2
+        local centerY = mapPanel:getY() + mapPanel:getHeight() / 2
 
-        healthCircle:setX(mapPanel:getX() + mapPanel:getWidth() / 2 - imageSizeThin - barDistance -
-            distanceFromCenter)
-        manaCircle:setX(mapPanel:getX() + mapPanel:getWidth() / 2 + barDistance + distanceFromCenter)
+        local leftX = centerX - imageSizeThin - barDistance - distanceFromCenter
+        local rightX = centerX + barDistance + distanceFromCenter
+        local verticalY = centerY - imageSizeBroad / 2
+        local horizontalX = centerX - imageSizeBroad / 2
+
+        healthCircleFront:setX(leftX)
+        manaCircleFront:setX(rightX)
+
+        healthCircle:setX(leftX)
+        manaCircle:setX(rightX)
 
         if manaShieldCircle and manaShieldCircleFront then
             manaShieldCircle:setX(manaCircle:getX() - manaShieldImageSizeThin - manaShieldCircleOffsetX)
             manaShieldCircleFront:setX(manaShieldCircle:getX())
         end
 
-        healthCircle:setY(mapPanel:getY() + mapPanel:getHeight() / 2 - imageSizeBroad / 2)
-        manaCircle:setY(mapPanel:getY() + mapPanel:getHeight() / 2 - imageSizeBroad / 2)
+        healthCircle:setY(verticalY)
+        manaCircle:setY(verticalY)
 
         if manaShieldCircle and manaShieldCircleFront then
             manaShieldCircle:setY(manaCircle:getY() + manaShieldCircleOffsetY)
@@ -493,60 +668,61 @@ function whenMapResizeChange()
         end
 
         if isExpCircle then
-            expCircleFront:setY(mapPanel:getY() + mapPanel:getHeight() / 2 - imageSizeThin - barDistance -
-                distanceFromCenter)
+            local expY = centerY - imageSizeThin - barDistance - distanceFromCenter
 
-            expCircleFront:setX(mapPanel:getX() + mapPanel:getWidth() / 2 - imageSizeBroad / 2)
-            expCircle:setY(mapPanel:getY() + mapPanel:getHeight() / 2 - imageSizeThin - barDistance -
-                distanceFromCenter)
+            expCircleFront:setY(expY)
+            expCircleFront:setX(horizontalX)
+            expCircle:setX(horizontalX)
+            expCircle:setY(expY)
         end
+        if expCircle then expCircle:setVisible(isExpCircle) end
+        if expCircleFront then expCircleFront:setVisible(isExpCircle) end
 
         if isSkillCircle then
-            skillCircleFront:setY(mapPanel:getY() + mapPanel:getHeight() / 2 + barDistance + distanceFromCenter)
+            local skillY = centerY + barDistance + distanceFromCenter
 
-            skillCircleFront:setX(mapPanel:getX() + mapPanel:getWidth() / 2 - imageSizeBroad / 2)
-            skillCircle:setY(mapPanel:getY() + mapPanel:getHeight() / 2 + barDistance + distanceFromCenter)
+            skillCircleFront:setY(skillY)
+            skillCircleFront:setX(horizontalX)
+            skillCircle:setX(horizontalX)
+            skillCircle:setY(skillY)
         end
+        if skillCircle then skillCircle:setVisible(isSkillCircle) end
+        if skillCircleFront then skillCircleFront:setVisible(isSkillCircle) end
 
-        whenHealthChange()
-        whenManaChange()
+        healthCirclePositioned = true
+        applyHealthManaCircleVisibility(showOverride)
+        whenHealthChange(showOverride)
+        whenManaChange(showOverride)
         if isExpCircle or isSkillCircle then
             whenSkillsChange()
         end
 
         positionMonkWidgets()
+        return true
     end
 
-    updateManaShieldDisplay()
+    healthCirclePositioned = false
+    hideHealthCircleWidgets()
+    hideManaCircleWidgets()
+    hideExtraCircleWidgets()
+    updateManaShieldDisplay(showOverride)
     if StatusIconBar and StatusIconBar.updatePosition then
         StatusIconBar.updatePosition()
     end
+    return false
 end
 
 function setHealthCircle(value)
     value = toboolean(value)
     isHealthCircle = value
     if value then
-        checkMonkVocation()
-        if isMonkMode then
-            healthCircle:setVisible(false)
-            healthCircleFront:setVisible(false)
-            setMonkWidgetsVisible(true)
-        else
-            healthCircle:setVisible(true)
-            healthCircleFront:setVisible(true)
+        if not whenMapResizeChange() then
+            applyHealthManaCircleVisibility()
+            scheduleMapResizeUpdates()
         end
-        whenMapResizeChange()
         updateManaShieldDisplay()
     else
-        healthCircle:setVisible(false)
-        healthCircleFront:setVisible(false)
-        setMonkWidgetsVisible(false)
-        if manaShieldCircle and manaShieldCircleFront then
-            manaShieldCircle:setVisible(false)
-            manaShieldCircleFront:setVisible(false)
-        end
-        resetManaCircleImages()
+        hideHealthCircleWidgets()
     end
 
     g_settings.set('healthcircle_hpcircle', not value)
@@ -556,15 +732,25 @@ function setManaCircle(value)
     value = toboolean(value)
     isManaCircle = value
     if value then
-        manaCircle:setVisible(true)
-        manaCircleFront:setVisible(true)
-        whenMapResizeChange()
+        if not whenMapResizeChange() then
+            applyHealthManaCircleVisibility()
+            scheduleMapResizeUpdates()
+        end
     else
-        manaCircle:setVisible(false)
-        manaCircleFront:setVisible(false)
+        hideManaCircleWidgets()
+        resetManaCircleImages()
     end
 
     g_settings.set('healthcircle_mpcircle', not value)
+end
+
+function handleShowArc(value)
+    value = toboolean(value)
+    disableMapNativeArcs()
+
+    applyHealthManaCircleVisibility(value)
+    updateManaShieldDisplay(value)
+    scheduleMapResizeUpdates(value)
 end
 
 function setExpCircle(value)
@@ -572,9 +758,9 @@ function setExpCircle(value)
     isExpCircle = value
 
     if value then
-        expCircle:setVisible(true)
-        expCircleFront:setVisible(true)
-        whenMapResizeChange()
+        if not whenMapResizeChange() then
+            scheduleMapResizeUpdates()
+        end
     else
         expCircle:setVisible(false)
         expCircleFront:setVisible(false)
@@ -588,9 +774,9 @@ function setSkillCircle(value)
     isSkillCircle = value
 
     if value then
-        skillCircle:setVisible(true)
-        skillCircleFront:setVisible(true)
-        whenMapResizeChange()
+        if not whenMapResizeChange() then
+            scheduleMapResizeUpdates()
+        end
     else
         skillCircle:setVisible(false)
         skillCircleFront:setVisible(false)
@@ -623,17 +809,18 @@ local arcStyleSizes = { "small", "", "large" }
 function setArcStyle(value)
     local size = arcStyleSizes[value + 1] or ""
     local prefix = size ~= "" and (size .. "-") or ""
-    local function setImages(widget, frontWidget, name)
+    local function setImages(widget, frontWidget, name, imagePrefix)
         if not widget then return end
-        widget:setImageSource("/data/images/game/healthcircle/" .. prefix .. name .. "_empty")
+        imagePrefix = imagePrefix or prefix
+        widget:setImageSource("/data/images/game/healthcircle/" .. imagePrefix .. name .. "_empty")
         if frontWidget then
-            frontWidget:setImageSource("/data/images/game/healthcircle/" .. prefix .. name .. "_full")
+            frontWidget:setImageSource("/data/images/game/healthcircle/" .. imagePrefix .. name .. "_full")
         end
     end
     setImages(healthCircle, healthCircleFront, "left")
     setImages(manaCircle, manaCircleFront, "right")
-    setImages(expCircle, expCircleFront, "top")
-    setImages(skillCircle, skillCircleFront, "bottom")
+    setImages(expCircle, expCircleFront, "top", "")
+    setImages(skillCircle, skillCircleFront, "bottom", "")
     imageSizeBroad = healthCircle:getHeight()
     imageSizeThin = healthCircle:getWidth()
     whenMapResizeChange()
@@ -776,6 +963,7 @@ function setPlayerValues()
     if chooseSkillComboBox then
         chooseSkillComboBox:setCurrentOptionByData(skillType, true)
     end
+    handleShowArc(getShowHealthManaCircleSetting())
 end
 
 function destroyOptionsModule()

--- a/modules/game_healthcircle/game_healthcircle.lua
+++ b/modules/game_healthcircle/game_healthcircle.lua
@@ -61,7 +61,7 @@ local function getShowHealthManaCircleSetting(showOverride)
     end
 
     if m_settings and type(m_settings.getOption) == 'function' then
-        local ok, value = pcall(m_settings.getOption, 'showHealthManaCircle')
+        local ok, value = pcall(m_settings.getOption, m_settings, 'showHealthManaCircle')
         if ok and value ~= nil then
             return toboolean(value)
         end
@@ -350,51 +350,49 @@ function whenHealthChange(showOverride)
         return
     end
 
-    if g_game.isOnline() then
-        if isMonkMode then
-            whenMonkHealthChange()
-            return
-        end
+    if isMonkMode then
+        whenMonkHealthChange()
+        return
+    end
 
-        local player = g_game.getLocalPlayer()
-        if not player then return end
-        local maxHp = player:getMaxHealth()
-        if maxHp <= 0 then return end
-        local healthPercent = math.floor(player:getHealth() / maxHp * 100)
+    local player = g_game.getLocalPlayer()
+    if not player then return end
+    local maxHp = player:getMaxHealth()
+    if maxHp <= 0 then return end
+    local healthPercent = math.floor(player:getHealth() / maxHp * 100)
 
-        local yhppc = math.floor(imageSizeBroad * (1 - (healthPercent / 100)))
-        local restYhppc = imageSizeBroad - yhppc
+    local yhppc = math.floor(imageSizeBroad * (1 - (healthPercent / 100)))
+    local restYhppc = imageSizeBroad - yhppc
 
-        healthCircleFront:setY(healthCircle:getY() + yhppc)
-        healthCircleFront:setHeight(restYhppc)
-        healthCircleFront:setImageClip({
-            x = 0,
-            y = yhppc,
-            width = imageSizeThin,
-            height = restYhppc
-        })
+    healthCircleFront:setY(healthCircle:getY() + yhppc)
+    healthCircleFront:setHeight(restYhppc)
+    healthCircleFront:setImageClip({
+        x = 0,
+        y = yhppc,
+        width = imageSizeThin,
+        height = restYhppc
+    })
 
-        healthCircle:setHeight(yhppc)
-        healthCircle:setImageClip({
-            x = 0,
-            y = 0,
-            width = imageSizeThin,
-            height = yhppc
-        })
+    healthCircle:setHeight(yhppc)
+    healthCircle:setImageClip({
+        x = 0,
+        y = 0,
+        width = imageSizeThin,
+        height = yhppc
+    })
 
-        if healthPercent > 92 then
-            healthCircleFront:setImageColor('#00BC00')
-        elseif healthPercent > 60 then
-            healthCircleFront:setImageColor('#50A150')
-        elseif healthPercent > 30 then
-            healthCircleFront:setImageColor('#A1A100')
-        elseif healthPercent > 8 then
-            healthCircleFront:setImageColor('#BF0A0A')
-        elseif healthPercent > 3 then
-            healthCircleFront:setImageColor('#910F0F')
-        else
-            healthCircleFront:setImageColor('#850C0C')
-        end
+    if healthPercent > 92 then
+        healthCircleFront:setImageColor('#00BC00')
+    elseif healthPercent > 60 then
+        healthCircleFront:setImageColor('#50A150')
+    elseif healthPercent > 30 then
+        healthCircleFront:setImageColor('#A1A100')
+    elseif healthPercent > 8 then
+        healthCircleFront:setImageColor('#BF0A0A')
+    elseif healthPercent > 3 then
+        healthCircleFront:setImageColor('#910F0F')
+    else
+        healthCircleFront:setImageColor('#850C0C')
     end
 end
 

--- a/modules/game_healthcircle/game_healthcircle.otui
+++ b/modules/game_healthcircle/game_healthcircle.otui
@@ -2,71 +2,85 @@ HealthCircle < UIProgressBar
   image-source: /data/images/game/healthcircle/left_empty
   opacity: 0.7
   phantom: true
+  visible: false
 
 ManaCircle < UIProgressBar
   image-source: /data/images/game/healthcircle/right_empty
   opacity: 0.7
   phantom: true
+  visible: false
 
 ManaShieldCircle < UIProgressBar
   image-source: /data/images/game/healthcircle/right_extra_empty
   opacity: 0.7
   phantom: true
+  visible: false
 
 ExpCircle < UIProgressBar
   image-source: /data/images/game/healthcircle/top_empty
   opacity: 0.7
   phantom: true
+  visible: false
 
 SkillCircle < UIProgressBar
   image-source: /data/images/game/healthcircle/bottom_empty
   opacity: 0.7
   phantom: true
+  visible: false
 
 HealthCircleFront < UIProgressBar
   image-source: /data/images/game/healthcircle/left_full
   opacity: 0.7
   phantom: true
+  visible: false
 
 ManaCircleFront < UIProgressBar
   image-source: /data/images/game/healthcircle/right_full
   opacity: 0.7
   image-color: #3F92EA
   phantom: true
+  visible: false
 
 ManaShieldCircleFront < UIProgressBar
   image-source: /data/images/game/healthcircle/right_extra_full
   opacity: 0.7
   image-color: #7F00A9
   phantom: true
+  visible: false
 
 ExpCircleFront < UIProgressBar
   image-source: /data/images/game/healthcircle/top_full
   opacity: 0.7
   image-color: #ecff57
   phantom: true
+  visible: false
 
 SkillCircleFront < UIProgressBar
   image-source: /data/images/game/healthcircle/bottom_full
   opacity: 0.7
   image-color: #FC8CFF
   phantom: true
+  visible: false
 
 MonkCircleBackground < UIWidget
   image-source: /data/images/game/healthcircle/left/default-bg-full-monk
   opacity: 0.5
   phantom: true
+  visible: false
 
 MonkHealthCircle < UIProgressBar
   image-source: /data/images/game/healthcircle/left/default-maximal-monk
   opacity: 0.7
   phantom: true
+  visible: false
 
 MonkSereneCircle < UIWidget
   image-source: /data/images/game/healthcircle/left/default-circle-purple-monk
   opacity: 0.7
   phantom: true
+  visible: false
 
 MonkHarmonySlot < UIWidget
   opacity: 0.7
   phantom: true
+  visible: false

--- a/modules/game_healthcircle/game_healthcircle_monk.lua
+++ b/modules/game_healthcircle/game_healthcircle_monk.lua
@@ -101,13 +101,13 @@ end
 
 function switchToMonkMode(enabled)
     isMonkMode = enabled
-    healthCircle:setVisible(not enabled and isHealthCircle)
-    healthCircleFront:setVisible(not enabled and isHealthCircle)
-    if monkCircleBackground then monkCircleBackground:setVisible(enabled) end
-    if monkHealthCircle then monkHealthCircle:setVisible(enabled) end
-    if monkSereneCircle then monkSereneCircle:setVisible(enabled) end
+    healthCircle:setVisible(false)
+    healthCircleFront:setVisible(false)
+    if monkCircleBackground then monkCircleBackground:setVisible(false) end
+    if monkHealthCircle then monkHealthCircle:setVisible(false) end
+    if monkSereneCircle then monkSereneCircle:setVisible(false) end
     for i = 1, 5 do
-        if monkHarmonySlots[i] then monkHarmonySlots[i]:setVisible(enabled) end
+        if monkHarmonySlots[i] then monkHarmonySlots[i]:setVisible(false) end
     end
     if enabled then
         local player = g_game.getLocalPlayer()
@@ -119,9 +119,8 @@ function switchToMonkMode(enabled)
             monkSerene = false
         end
         refreshMonkDynamicOpacity()
-        whenMapResizeChange()
-        whenMonkHealthChange()
     end
+    whenMapResizeChange()
 end
 
 function checkMonkVocation()

--- a/modules/game_healthcircle/game_healthcircle_monk.lua
+++ b/modules/game_healthcircle/game_healthcircle_monk.lua
@@ -101,8 +101,8 @@ end
 
 function switchToMonkMode(enabled)
     isMonkMode = enabled
-    healthCircle:setVisible(false)
-    healthCircleFront:setVisible(false)
+    if healthCircle then healthCircle:setVisible(false) end
+    if healthCircleFront then healthCircleFront:setVisible(false) end
     if monkCircleBackground then monkCircleBackground:setVisible(false) end
     if monkHealthCircle then monkHealthCircle:setVisible(false) end
     if monkSereneCircle then monkSereneCircle:setVisible(false) end

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -28,6 +28,8 @@ arcLifeDistance = 0
 focusReason = {}
 hookedMenuOptions = {}
 lastDirTime = g_clock.millis()
+local healthCircleResizeEvent = nil
+local scheduleTopBarSettingsRefresh = nil
 
 local keybindStopAll = KeyBind:getKeyBind("Movement", "Stop All Actions")
 local keybindLogout = KeyBind:getKeyBind("Misc.", "Logout")
@@ -169,6 +171,11 @@ function terminate()
   hookedMenuOptions = {}
   markThing = nil
 
+  if healthCircleResizeEvent then
+    removeEvent(healthCircleResizeEvent)
+    healthCircleResizeEvent = nil
+  end
+
   disconnect(g_game, {
     onGameStart = onGameStart,
     onGameEnd = onGameEnd,
@@ -271,6 +278,8 @@ function onGameStart()
     LoadedPlayer:setId(player:getId())
     LoadedPlayer:setName(player:getName())
     LoadedPlayer:setVocation(player:getVocation())
+
+    scheduleTopBarSettingsRefresh()
   end
 
   -- open Astra has delay in auto walking
@@ -1870,44 +1879,92 @@ function getRightBar()
   return gameRightBar
 end
 
+local function replaceAnchor(widget, anchor, target, targetAnchor)
+  if not widget then
+    return
+  end
+
+  widget:removeAnchor(anchor)
+  widget:addAnchor(anchor, target, targetAnchor)
+end
+
+local function anchorGameAreaToParentTop()
+  replaceAnchor(gameMapPanel, AnchorTop, 'parent', AnchorTop)
+  replaceAnchor(gameLeftActionPanel, AnchorTop, 'parent', AnchorTop)
+  replaceAnchor(gameRightActionPanel, AnchorTop, 'parent', AnchorTop)
+  gameLeftActionPanel:setPaddingTop(54)
+  gameRightActionPanel:setPaddingTop(54)
+end
+
+local function anchorGameAreaToTopBar()
+  replaceAnchor(gameMapPanel, AnchorTop, 'gameTopBar', AnchorBottom)
+  replaceAnchor(gameLeftActionPanel, AnchorTop, 'gameTopBar', AnchorBottom)
+  replaceAnchor(gameRightActionPanel, AnchorTop, 'gameTopBar', AnchorBottom)
+  gameLeftActionPanel:setPaddingTop(1)
+  gameRightActionPanel:setPaddingTop(1)
+end
+
+local function scheduleHealthCircleResizeUpdates()
+  if healthCircleResizeEvent then
+    removeEvent(healthCircleResizeEvent)
+  end
+
+  healthCircleResizeEvent = scheduleEvent(function()
+    healthCircleResizeEvent = nil
+    if modules.game_healthcircle and modules.game_healthcircle.scheduleMapResizeUpdates then
+      modules.game_healthcircle.scheduleMapResizeUpdates()
+    end
+  end, 50)
+end
+
+function scheduleTopBarSettingsRefresh()
+  for _, delay in ipairs({50, 250, 750, 1500, 3000}) do
+    scheduleEvent(function()
+      if modules.game_topbar and modules.game_topbar.reloadFromSettings then
+        modules.game_topbar.reloadFromSettings()
+      end
+    end, delay)
+  end
+end
+
 function updateTopBar(side)
   if side == "bottom" then
+    gameTopBar:setVisible(true)
     gameTopBar:setParent(gameBottomActionPanel)
     gameMapPanel:addAnchor(AnchorLeft, 'gameLeftActionPanel', AnchorRight)
     gameMapPanel:addAnchor(AnchorRight, 'gameRightActionPanel', AnchorLeft)
     gameMapPanel:addAnchor(AnchorBottom, 'bottomSplitter', AnchorTop)
-    gameMapPanel:addAnchor(AnchorTop, 'parent', AnchorTop)
-
-    gameLeftActionPanel:addAnchor(AnchorTop, 'parent', AnchorTop)
-    gameRightActionPanel:addAnchor(AnchorTop, 'parent', AnchorTop)
-    gameLeftActionPanel:setPaddingTop(54)
-    gameRightActionPanel:setPaddingTop(54)
+    anchorGameAreaToParentTop()
   elseif side == "top" then
+    gameTopBar:setVisible(true)
     gameTopBar:setParent(gameRootPanel)
-    gameTopBar:addAnchor(AnchorTop, 'parent', AnchorTop)
-    gameTopBar:addAnchor(AnchorLeft, 'gameBottomActionPanel', AnchorLeft)
-    gameTopBar:addAnchor(AnchorRight, 'gameBottomActionPanel', AnchorRight)
+    replaceAnchor(gameTopBar, AnchorTop, 'parent', AnchorTop)
+    replaceAnchor(gameTopBar, AnchorLeft, 'gameBottomActionPanel', AnchorLeft)
+    replaceAnchor(gameTopBar, AnchorRight, 'gameBottomActionPanel', AnchorRight)
 
     gameRootPanel:moveChildToIndex(gameTopBar, 1)
     gameMapPanel:addAnchor(AnchorLeft, 'gameLeftActionPanel', AnchorRight)
     gameMapPanel:addAnchor(AnchorRight, 'gameRightActionPanel', AnchorLeft)
     gameMapPanel:addAnchor(AnchorBottom, 'bottomSplitter', AnchorTop)
-    gameMapPanel:addAnchor(AnchorTop, 'gameTopBar', AnchorBottom)
-
-    gameLeftActionPanel:setPaddingTop(1)
-    gameRightActionPanel:setPaddingTop(1)
-    gameLeftActionPanel:addAnchor(AnchorTop, 'gameTopBar', AnchorBottom)
-    gameRightActionPanel:addAnchor(AnchorTop, 'gameTopBar', AnchorBottom)
+    anchorGameAreaToTopBar()
 
   elseif side == "left" or side == "right" then
-    gameLeftActionPanel:addAnchor(AnchorTop, 'parent', AnchorTop)
-    gameRightActionPanel:addAnchor(AnchorTop, 'parent', AnchorTop)
-    gameLeftActionPanel:setPaddingTop(54)
-    gameRightActionPanel:setPaddingTop(54)
+    gameTopBar:setVisible(false)
+    anchorGameAreaToParentTop()
+    gameMapPanel:addAnchor(AnchorBottom, 'bottomSplitter', AnchorTop)
+  else
+    gameTopBar:setVisible(false)
+    anchorGameAreaToParentTop()
     gameMapPanel:addAnchor(AnchorBottom, 'bottomSplitter', AnchorTop)
   end
 
-  gameMapPanel:setMarginBottom(0)
+  if g_settings.getBoolean("classicView") and modules.game_actionbar and modules.game_actionbar.updateGameMapPanelMargin then
+    modules.game_actionbar.updateGameMapPanelMargin()
+  else
+    gameMapPanel:setMarginBottom(0)
+  end
+
+  scheduleHealthCircleResizeUpdates()
 end
 
 function refreshViewMode()
@@ -1982,7 +2039,20 @@ function refreshViewMode()
     gameMapPanel:addAnchor(AnchorRight, 'gameRightActionPanel', AnchorLeft)
     gameMapPanel:addAnchor(AnchorBottom, 'gameBottomActionPanel', AnchorTop)
     gameMapPanel:addAnchor(AnchorBottom, 'gameBottomCooldownPanel', AnchorTop)
-    gameMapPanel:addAnchor(AnchorTop, 'gameTopBar', AnchorBottom)
+    local customisableTopBarEnabled = false
+    if modules.game_topbar then
+      if modules.game_topbar.shouldShowCustomisableBar then
+        customisableTopBarEnabled = modules.game_topbar.shouldShowCustomisableBar()
+      elseif modules.game_topbar.isCustomisableBarVisible then
+        customisableTopBarEnabled = modules.game_topbar.isCustomisableBarVisible()
+      end
+    end
+
+    if customisableTopBarEnabled then
+      updateTopBar(modules.game_topbar.getCurrentDirection())
+    else
+      updateTopBar("hidden")
+    end
     gameMapPanel:setKeepAspectRatio(true)
     gameMapPanel:setLimitVisibleRange(false)
     gameMapPanel:setZoom(11)
@@ -2065,7 +2135,13 @@ function updateSize()
 
   gameMapPanel:setWidth(width)
   gameMapPanel:setHeight(height)
-  gameMapPanel:setMarginBottom(0)
+  if classic and modules.game_actionbar and modules.game_actionbar.updateGameMapPanelMargin then
+    modules.game_actionbar.updateGameMapPanelMargin()
+  else
+    gameMapPanel:setMarginBottom(0)
+  end
+
+  scheduleHealthCircleResizeUpdates()
 end
 
 function setupLeftActions()

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -29,7 +29,6 @@ focusReason = {}
 hookedMenuOptions = {}
 lastDirTime = g_clock.millis()
 local healthCircleResizeEvent = nil
-local scheduleTopBarSettingsRefresh = nil
 
 local keybindStopAll = KeyBind:getKeyBind("Movement", "Stop All Actions")
 local keybindLogout = KeyBind:getKeyBind("Misc.", "Logout")
@@ -264,6 +263,16 @@ function applyMouseCursorOptions()
 
   if nativeCursor then
     g_window.restoreMouseCursor()
+  end
+end
+
+local function scheduleTopBarSettingsRefresh()
+  for _, delay in ipairs({50, 250, 750, 1500, 3000}) do
+    scheduleEvent(function()
+      if modules.game_topbar and modules.game_topbar.reloadFromSettings then
+        modules.game_topbar.reloadFromSettings()
+      end
+    end, delay)
   end
 end
 
@@ -1915,16 +1924,6 @@ local function scheduleHealthCircleResizeUpdates()
       modules.game_healthcircle.scheduleMapResizeUpdates()
     end
   end, 50)
-end
-
-function scheduleTopBarSettingsRefresh()
-  for _, delay in ipairs({50, 250, 750, 1500, 3000}) do
-    scheduleEvent(function()
-      if modules.game_topbar and modules.game_topbar.reloadFromSettings then
-        modules.game_topbar.reloadFromSettings()
-      end
-    end, delay)
-  end
 end
 
 function updateTopBar(side)

--- a/modules/game_interface/gameinterface.otui
+++ b/modules/game_interface/gameinterface.otui
@@ -47,7 +47,6 @@ UIWidget
     anchors.right: gameRightPanels.left
     anchors.top: parent.top
     anchors.bottom: bottomSplitter.top
-    margin-bottom: 41
     focusable: false
     UIWidget
       id: mapTemplate

--- a/modules/game_interface/interface.otmod
+++ b/modules/game_interface/interface.otmod
@@ -16,6 +16,7 @@ Module
     - game_console
     - game_outfit
     - game_healthinfo
+    - game_topbar
     - game_statusiconbar
     - game_inventory
     - game_containers

--- a/modules/game_npctrade/npctrade.lua
+++ b/modules/game_npctrade/npctrade.lua
@@ -203,6 +203,43 @@ function terminate()
   })
 end
 
+local function refreshNpcWindowLayout()
+  if not npcWindow or not npcWindow:getParent() then
+    return
+  end
+
+  local parent = npcWindow:getParent()
+  if parent:getClassName() == 'UIMiniWindowContainer' and parent.fitAll then
+    parent:fitAll(npcWindow)
+  end
+
+  if itemsPanel then
+    local layout = itemsPanel:getLayout()
+    if layout then
+      layout:update()
+    end
+  end
+end
+
+local function scheduleNpcWindowLayoutRefresh()
+  addEvent(refreshNpcWindowLayout)
+  scheduleEvent(refreshNpcWindowLayout, 50)
+  scheduleEvent(refreshNpcWindowLayout, 150)
+end
+
+local function ensureNpcWindowExpanded()
+  if not npcWindow then
+    return
+  end
+
+  npcWindow.save = false
+  if npcWindow.minimized and npcWindow.maximize then
+    npcWindow:maximize()
+  elseif npcWindow:getHeight() < npcWindow:getMinimumHeight() then
+    npcWindow:setHeight(npcWindow:getMinimumHeight())
+  end
+end
+
 function show()
   if g_game.isOnline() then
     if #tradeItems[BUY] > 0 then
@@ -213,7 +250,8 @@ function show()
       quickSellButton:setEnabled(true)
     end
 
-    npcWindow:show()
+    ensureNpcWindowExpanded()
+
     local addedToPanel
     if m_interface.addToPanelsWithPriority then
       addedToPanel = m_interface.addToPanelsWithPriority(npcWindow, true)
@@ -225,8 +263,12 @@ function show()
       return false
     end
 
-    if npcWindow and npcWindow:isVisible() then
-      npcWindow:getParent():moveChildToIndex(npcWindow, #npcWindow:getParent():getChildren())
+    npcWindow:show()
+    scheduleNpcWindowLayoutRefresh()
+
+    if npcWindow and npcWindow:isVisible() and npcWindow:getParent() then
+      local parent = npcWindow:getParent()
+      parent:moveChildToIndex(npcWindow, #parent:getChildren())
       npcWindow.close = function() closeNpcTrade() end
       npcWindow:focus()
       setupPanel:enable()
@@ -627,6 +669,10 @@ function refreshTradeItems()
 
   layout:enableUpdates()
   layout:update()
+
+  if npcWindow and npcWindow:isVisible() then
+    scheduleNpcWindowLayoutRefresh()
+  end
 end
 
 function refreshPlayerGoods()
@@ -692,6 +738,10 @@ function refreshPlayerGoods()
 
   if selectedItem then
     refreshItem(selectedItem)
+  end
+
+  if npcWindow and npcWindow:isVisible() then
+    scheduleNpcWindowLayoutRefresh()
   end
 end
 

--- a/modules/game_npctrade/npctrade.lua
+++ b/modules/game_npctrade/npctrade.lua
@@ -54,6 +54,7 @@ quickSellButton = nil
 
 cancelNextRelease = nil
 sellAllWithDelayEvent = nil
+local npcWindowLayoutRefreshScheduled = false
 
 function saveData()
   if not LoadedPlayer:isLoaded() then return end
@@ -222,9 +223,17 @@ local function refreshNpcWindowLayout()
 end
 
 local function scheduleNpcWindowLayoutRefresh()
+  if npcWindowLayoutRefreshScheduled then
+    return
+  end
+
+  npcWindowLayoutRefreshScheduled = true
   addEvent(refreshNpcWindowLayout)
   scheduleEvent(refreshNpcWindowLayout, 50)
-  scheduleEvent(refreshNpcWindowLayout, 150)
+  scheduleEvent(function()
+    refreshNpcWindowLayout()
+    npcWindowLayoutRefreshScheduled = false
+  end, 150)
 end
 
 local function ensureNpcWindowExpanded()

--- a/modules/game_npctrade/npctrade.otui
+++ b/modules/game_npctrade/npctrade.otui
@@ -48,6 +48,7 @@ NpcWindow
   !text: tr('NPC Trade')
   height: 175
   icon: /images/icons/icon-trade
+  &save: false
   @onEscape: hide()
   @onExtra: onExtraMenu()
   focusable: true

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -16,7 +16,10 @@ function terminate()
 
   disconnect(g_game, 'onGameEnd', clearMessages)
   clearMessages()
-  messagesPanel:destroy()
+  if messagesPanel and not messagesPanel:isDestroyed() then
+    messagesPanel:destroy()
+  end
+  messagesPanel = nil
 end
 
 function displayMessage(mode, text)
@@ -58,7 +61,7 @@ function displayMessage(mode, text)
 end
 
 function updateActionBarMessageMargin(margin)
-  if not messagesPanel then
+  if not messagesPanel or messagesPanel:isDestroyed() then
     return
   end
 
@@ -89,6 +92,10 @@ function displayBroadcastMessage(text)
 end
 
 function clearMessages()
+  if not messagesPanel or messagesPanel:isDestroyed() then
+    return
+  end
+
   for _i,child in pairs(messagesPanel:recursiveGetChildren()) do
     if child:getId():match('Label') then
       child:hide()

--- a/modules/game_textmessage/textmessage.lua
+++ b/modules/game_textmessage/textmessage.lua
@@ -57,6 +57,17 @@ function displayMessage(mode, text)
   end
 end
 
+function updateActionBarMessageMargin(margin)
+  if not messagesPanel then
+    return
+  end
+
+  local statusLabel = messagesPanel:recursiveGetChildById('statusLabel')
+  if statusLabel then
+    statusLabel:setMarginBottom(margin or 7)
+  end
+end
+
 function displayPrivateMessage(text)
   displayMessage(254, text)
 end

--- a/modules/game_topbar/topbar.lua
+++ b/modules/game_topbar/topbar.lua
@@ -26,6 +26,8 @@ local healthBar = nil
 local manaBar = nil
 local manaBarSecond = nil
 local manaShieldBar = nil
+local manaShieldText = nil
+local manaText = nil
 local topBar = nil
 local states = nil
 local useManaShield = nil
@@ -407,9 +409,6 @@ local function refreshTopBarValues(player)
     onHealthChange(player, player:getHealth(), player:getMaxHealth())
     onManaChange(player, player:getMana(), player:getMaxMana())
     onMagicLevelChange(player, player:getMagicLevel(), player:getMagicLevelPercent())
-    onHealthChange(player, player:getHealth(), player:getMaxHealth())
-    onManaChange(player, player:getMana(), player:getMaxMana())
-    onLevelChange(player, player:getLevel(), player:getLevelPercent())
     onManaShieldChange(player, player:getMagicShield(), player:getMaxMagicShield())
     onHarmonyChange(player, player.getHarmony and player:getHarmony() or 0)
     onSerenityChange(player, player.isSerenity and player:isSerenity() or false)

--- a/modules/game_topbar/topbar.lua
+++ b/modules/game_topbar/topbar.lua
@@ -34,6 +34,9 @@ local currentDirection = 'top'
 
 local statusBarData = {}
 local lastProficiencyCache = {}
+local topBarLoadEvent = nil
+local topBarLayoutEvents = {}
+local pendingVisibility = nil
 
 local progressPath = '/images/game/topbar/progress/'
 
@@ -52,6 +55,86 @@ local layouts = {
     rightlarge = 'layouts/left-large',
 }
 
+local validDirections = {
+    top = true,
+    bottom = true,
+    left = true,
+    right = true
+}
+
+local validLayouts = {
+    compact = true,
+    default = true,
+    parallel = true,
+    large = true
+}
+
+local function clearTopBarLoadEvent()
+    if topBarLoadEvent then
+        removeEvent(topBarLoadEvent)
+        topBarLoadEvent = nil
+    end
+end
+
+local function clearTopBarLayoutEvents()
+    for _, event in pairs(topBarLayoutEvents) do
+        removeEvent(event)
+    end
+    topBarLayoutEvents = {}
+end
+
+local function clearTopBarWidgetRefs()
+    healthBar = nil
+    manaBar = nil
+    manaBarSecond = nil
+    manaShieldBar = nil
+    manaShieldText = nil
+    manaText = nil
+    states = nil
+    topBar = nil
+end
+
+local function normalizeStatusBarData()
+    if not validDirections[currentDirection] then
+        currentDirection = 'top'
+        statusBarData["position"] = currentDirection
+    end
+
+    if not validLayouts[currentLayout] then
+        currentLayout = 'default'
+        statusBarData["style"] = currentLayout
+    end
+end
+
+local function isCustomisableBarsEnabled()
+    if TempOptions and type(TempOptions.getOption) == 'function' then
+        local value = TempOptions:getOption("customisableBars")
+        if value ~= nil then
+            return toboolean(value)
+        end
+    end
+
+    if g_settings then
+        return g_settings.getBoolean("customisableBars")
+    end
+
+    if GameOptions and type(GameOptions.getOption) == 'function' then
+        local ok, value = pcall(GameOptions.getOption, GameOptions, "customisableBars")
+        if ok and value ~= nil then
+            return toboolean(value)
+        end
+    end
+
+    if m_settings and type(m_settings.getOption) == 'function' then
+        local ok, value = pcall(m_settings.getOption, "customisableBars")
+        if ok and value ~= nil then
+            return toboolean(value)
+        end
+    end
+
+    return false
+end
+
 function init()
     connect(LocalPlayer, {
         onHealthChange = onHealthChange,
@@ -69,10 +152,13 @@ function init()
     })
     connect(g_game, {onGameStart = online, onGameEnd = offline})
 
-    if g_game.isOnline() then refresh() end
+    if g_game.isOnline() then online() end
 end
 
 function terminate()
+    clearTopBarLoadEvent()
+    clearTopBarLayoutEvents()
+
     disconnect(LocalPlayer, {
         onHealthChange = onHealthChange,
         onManaChange = onManaChange,
@@ -128,51 +214,85 @@ local function ensureLoadedPlayer()
 end
 
 function setupTopBar()
+    normalizeStatusBarData()
+
     local isSideBar = (currentDirection == "left" or currentDirection == "right")
     local direction = isSideBar and (currentDirection .. currentLayout) or currentLayout
-    local layout = layouts[direction]
+    local layout = layouts[direction] or layouts[currentLayout] or layouts.default
 
     local topPanel = m_interface.getTopBar()
     local leftPanel = m_interface.getLeftBar()
     local rightPanel = m_interface.getRightBar()
+    local parent = topPanel
+    if currentDirection == "left" then
+        parent = leftPanel
+    elseif currentDirection == "right" then
+        parent = rightPanel
+    end
+
+    if not parent then
+        g_logger.warning("Unable to setup top bar parent for direction: " .. tostring(currentDirection))
+        if topBar and topBar:getParent() then
+            topBar:destroy()
+        end
+        clearTopBarWidgetRefs()
+        return false
+    end
+
     if topBar and topBar:getParent() then
         topBar:destroy()
     end
+    clearTopBarWidgetRefs()
 
-    if currentDirection == "left" then
-        topBar = g_ui.loadUI(layout, leftPanel)
-    elseif currentDirection == "right" then
-        topBar = g_ui.loadUI(layout, rightPanel)
-    else
-        topBar = g_ui.loadUI(layout, topPanel)
+    local ok, widget = pcall(function()
+        return g_ui.loadUI(layout, parent)
+    end)
+    if not ok or not widget then
+        g_logger.warning("Unable to load top bar layout: " .. tostring(layout))
+        clearTopBarWidgetRefs()
+        return false
     end
 
+    topBar = widget
     topBar:setId(layout)
-    topBar:show()
-    m_interface.updateTopBar(currentDirection)
 
-    healthBar = topBar.topbarBackground.healthContainer.healthBar
-    manaBar = topBar.topbarBackground.manaContainer.manaBar
-    manaBarSecond = topBar.topbarBackground.manaContainer.manaBarSecond
-    manaShieldBar = topBar.topbarBackground.manaContainer.manaShield
-    manaShieldText = topBar.topbarBackground.manaContainer.statusManaShield
-    manaText = topBar.topbarBackground.manaContainer.statusMana
+    local topbarBackground = topBar:recursiveGetChildById('topbarBackground')
+    local healthContainer = topBar:recursiveGetChildById('healthContainer')
+    local manaContainer = topBar:recursiveGetChildById('manaContainer')
+    local skillsPanel = topBar:recursiveGetChildById('skills')
 
-    if currentLayout == 'compact' then
-        states = topBar.topbarBackground.stats.box
-    elseif currentLayout == 'default' then
-        states = topBar.bottomBar.stats.box
-    elseif currentLayout == 'parallel' then
-        states = topBar.bottomBar.stats.box
-    elseif currentLayout == 'large' then
-        states = topBar.topbarBackground.stats.box
+    healthBar = healthContainer and healthContainer:recursiveGetChildById('healthBar') or nil
+    manaBar = manaContainer and manaContainer:recursiveGetChildById('manaBar') or nil
+    manaBarSecond = manaContainer and manaContainer:recursiveGetChildById('manaBarSecond') or nil
+    manaShieldBar = manaContainer and manaContainer:recursiveGetChildById('manaShield') or nil
+    manaShieldText = manaContainer and manaContainer:recursiveGetChildById('statusManaShield') or nil
+    manaText = manaContainer and manaContainer:recursiveGetChildById('statusMana') or nil
+
+    if not topbarBackground or not healthBar or not manaBar or not manaBarSecond or not manaShieldBar or not manaShieldText or not manaText or not skillsPanel then
+        g_logger.warning("Unable to setup top bar layout: " .. tostring(layout))
+        topBar:destroy()
+        clearTopBarWidgetRefs()
+        return false
     end
 
-    m_settings.ConditionsHUD:startTopPanel(states)
+    topBar.topbarBackground = topbarBackground
+    topBar.skills = skillsPanel
+
+    local statsPanel = topBar:recursiveGetChildById('stats')
+    states = statsPanel and statsPanel:recursiveGetChildById('box') or nil
+
+    if states and m_settings and m_settings.ConditionsHUD and m_settings.ConditionsHUD.startTopPanel then
+        m_settings.ConditionsHUD:startTopPanel(states)
+    end
 
     topBar.onMouseRelease = function(widget, mousePos, mouseButton)
         menu(mouseButton)
     end
+
+    topBar:show()
+    m_interface.updateTopBar(currentDirection)
+
+    return true
 end
 
 local function getDefaultStatusBarData()
@@ -192,13 +312,14 @@ local function getDefaultStatusBarData()
 end
 
 local function loadStatusBarData()
-    statusBarData = loadJsonStruct("/characterdata/" .. LoadedPlayer:getId() .. "/statusBarData.json")
-    if table.empty(statusBarData) then
+    statusBarData = loadJsonStruct("/characterdata/" .. LoadedPlayer:getId() .. "/statusBarData.json") or {}
+    if type(statusBarData) ~= 'table' or table.empty(statusBarData) then
         statusBarData = getDefaultStatusBarData()
     end
 
     currentLayout = statusBarData["style"]
     currentDirection = statusBarData["position"]
+    normalizeStatusBarData()
     lastProficiencyCache = {}
 end
 
@@ -211,7 +332,9 @@ local function ensureTopBarInitialized()
     end
 
     loadStatusBarData()
-    setupTopBar()
+    if not setupTopBar() then
+        return false
+    end
     if not topBar then
         return false
     end
@@ -221,25 +344,61 @@ local function ensureTopBarInitialized()
     return true
 end
 
-function online()
-    local benchmark = g_clock.millis()
-    if not ensureLoadedPlayer() then return end
+local function scheduleTopBarLayoutRefresh()
+    clearTopBarLayoutEvents()
 
+    for _, delay in ipairs({50, 150, 350, 750, 1500, 3000, 5000}) do
+        table.insert(topBarLayoutEvents, scheduleEvent(function()
+            if not g_game.isOnline() then
+                return
+            end
+
+            reloadFromSettings()
+
+            if modules.game_healthcircle and modules.game_healthcircle.scheduleMapResizeUpdates then
+                modules.game_healthcircle.scheduleMapResizeUpdates()
+            end
+        end, delay))
+    end
+end
+
+local function retryOnline(attempt)
+    clearTopBarLoadEvent()
+
+    if not g_game.isOnline() or attempt >= 120 then
+        return
+    end
+
+    topBarLoadEvent = scheduleEvent(function()
+        topBarLoadEvent = nil
+        online(attempt + 1)
+    end, 100)
+end
+
+function online(attempt)
+    local benchmark = g_clock.millis()
+    attempt = attempt or 0
+    local visibility = pendingVisibility
+
+    if not ensureLoadedPlayer() then
+        retryOnline(attempt)
+        return
+    end
+
+    clearTopBarLoadEvent()
     loadStatusBarData()
-    refresh()
+    if not refresh(nil, nil, visibility) then
+        return
+    end
+
+    pendingVisibility = nil
+    scheduleTopBarLayoutRefresh()
     consoleln("TopBar loaded in " .. (g_clock.millis() - benchmark) / 1000 .. " seconds.")
 end
 
-function refresh(profileChange, skipSetup)
-    local player = g_game.getLocalPlayer()
-    if not player then return end
-
-    if not skipSetup then
-        setupTopBar()
-    end
-
+local function refreshTopBarValues(player)
+    if not topBar or not player then return end
     setupSkills()
-    show()
     refreshVisibleBars()
 
     useManaShield = canUseManaShield()
@@ -262,7 +421,25 @@ function refresh(profileChange, skipSetup)
 
     topBar.skills:insertLuaCall("onGeometryChange")
     topBar.skills.onGeometryChange = setSkillsLayout
-    toggle(m_settings.getOption("customisableBars"))
+end
+
+function refresh(profileChange, skipSetup, visibility)
+    local player = g_game.getLocalPlayer()
+    if not player then return false end
+
+    if not skipSetup then
+        if not setupTopBar() then
+            retryOnline(0)
+            return false
+        end
+    end
+
+    show()
+    refreshTopBarValues(player)
+    if visibility == nil then
+        visibility = isCustomisableBarsEnabled()
+    end
+    return toggle(visibility)
 end
 
 function refreshVisibleBars()
@@ -295,10 +472,15 @@ function setSkillsLayout()
 end
 
 function offline()
+    clearTopBarLoadEvent()
+    clearTopBarLayoutEvents()
+    pendingVisibility = nil
+
     local player = g_game.getLocalPlayer()
     useManaShield = false
 
     if not LoadedPlayer:isLoaded() then return end
+    if table.empty(statusBarData) then return end
     saveJsonStruct("/characterdata/" .. LoadedPlayer:getId() .. "/statusBarData.json", statusBarData)
 end
 
@@ -530,28 +712,73 @@ function show()
 end
 
 function toggle(value)
+    value = toboolean(value)
+    pendingVisibility = value
+
     if not g_game.isOnline() then
-        return
+        return false
     end
 
     if not ensureTopBarInitialized() then
-        return
+        retryOnline(0)
+        return false
     end
 
+    pendingVisibility = nil
     topBar:setVisible(value)
+    if value then
+        refreshTopBarValues(g_game.getLocalPlayer())
+    end
+
+    if m_interface and m_interface.updateTopBar then
+        m_interface.updateTopBar(value and currentDirection or "hidden")
+    end
+
     local leftPanel = m_interface.getLeftActionPanel()
     local rightPanel = m_interface.getRightActionPanel()
     if not leftPanel or not rightPanel then
-        return
+        return true
     end
 
-    if value then
+    if value and currentDirection == "top" then
         leftPanel:setPaddingTop(1)
         rightPanel:setPaddingTop(1)
     else
         leftPanel:setPaddingTop(54)
         rightPanel:setPaddingTop(54)
     end
+
+    return true
+end
+
+function reloadFromSettings(valueOverride)
+    local value = valueOverride
+    if value == nil then
+        value = isCustomisableBarsEnabled()
+    else
+        value = toboolean(value)
+    end
+    pendingVisibility = value
+
+    if not g_game.isOnline() then
+        return
+    end
+
+    if not ensureLoadedPlayer() then
+        retryOnline(0)
+        return
+    end
+
+    local previousLayout = currentLayout
+    local previousDirection = currentDirection
+    loadStatusBarData()
+    local skipSetup = topBar and previousLayout == currentLayout and previousDirection == currentDirection
+    if not refresh(nil, skipSetup, value) then
+        return false
+    end
+
+    pendingVisibility = nil
+    return true
 end
 
 function setupSkillPanel(id, parent, experience, defaultOff)
@@ -616,13 +843,13 @@ function menu(mouseButton)
     }
 
     if not currentDirection then
-        currentDirection = top
+        currentDirection = "top"
     end
 
     local currentTable = directionMappings[currentDirection]
     if not currentTable then
         currentTable = directionMappings["top"]
-        currentDirection = top
+        currentDirection = "top"
     end
 
     local directionsOptions = {}
@@ -635,8 +862,9 @@ function menu(mouseButton)
         menu:addOption(text, function()
             currentDirection = option.value
             statusBarData["position"] = currentDirection
-            setupTopBar()
-            refresh(nil, true)
+            if setupTopBar() then
+                refresh(nil, true)
+            end
         end)
     end
 
@@ -660,9 +888,10 @@ function menu(mouseButton)
         menu:addOption(text, function()
             currentLayout = option.value
             statusBarData["style"] = currentLayout
-            setupTopBar()
-            refresh(nil, true)
-            switchCurrentLayout()
+            if setupTopBar() then
+                refresh(nil, true)
+                switchCurrentLayout()
+            end
         end)
     end
 
@@ -846,20 +1075,41 @@ function updateLevelTooltip(text)
 end
 
 function isBottomBarActive()
-    return currentDirection == "bottom"
+    return topBar and topBar:isVisible() and currentDirection == "bottom"
 end
 
 function getCurrentHeight()
-    return topBar:getHeight()
+    return topBar and topBar:getHeight() or 0
+end
+
+function isCustomisableBarVisible()
+    return topBar and topBar:isVisible()
+end
+
+function shouldShowCustomisableBar()
+    if pendingVisibility ~= nil then
+        return pendingVisibility
+    end
+    return isCustomisableBarsEnabled()
+end
+
+function isTopBarActive()
+    return isCustomisableBarVisible() and currentDirection == "top"
+end
+
+function getCurrentDirection()
+    return currentDirection
 end
 
 function onHarmonyChange(localPlayer, value)
+    if not topBar then return end
+
     local harmonyPanel = topBar:recursiveGetChildById('harmony')
     local manaContainer = topBar:recursiveGetChildById('manaContainer')
     local stats = topBar:recursiveGetChildById('stats')
     local isHarmonyVisible = localPlayer.isMonk and localPlayer:isMonk() or false
 
-    if not harmonyPanel then
+    if not harmonyPanel or not manaContainer or not stats then
         return
     end
 
@@ -897,6 +1147,8 @@ function onHarmonyChange(localPlayer, value)
 end
 
 function onSerenityChange(localPlayer, value)
+    if not topBar then return end
+
     local serenityIcon = topBar:recursiveGetChildById('serenity')
     if serenityIcon then
         serenityIcon:setImageSource(value and '/images/game/topbar/icon-serene-on' or '/images/game/topbar/icon-serene-off')

--- a/modules/game_topbar/topbar.otmod
+++ b/modules/game_topbar/topbar.otmod
@@ -4,7 +4,8 @@ Module
   author: Vithrax
   discord: Vithrax#5814
   sandboxed: true
-  autoload: true
+  autoload: false
+  dependencies: [ game_interface, client_settings ]
   scripts: [ topbar ]
   @onLoad: init()
   @onUnload: terminate()


### PR DESCRIPTION
## Summary
- Reworks custom top bar and health/mana circle refresh timing so saved settings apply reliably after login and resize.
- Adjusts action bar, game map anchoring, text message positioning, and NPC trade window layout refreshes to avoid clipped or stale UI states.
- Keeps NPC trade window transient and forces layout recalculation after item/player-good updates.

## Validation
- `git diff --cached --check`
- `npx --yes luaparse mods\client_settings\classes\dataset.lua`
- `npx --yes luaparse modules\game_topbar\topbar.lua`
- `npx --yes luaparse modules\game_healthcircle\game_healthcircle.lua`
- `npx --yes luaparse modules\game_healthcircle\game_healthcircle_monk.lua`
- `npx --yes luaparse modules\game_textmessage\textmessage.lua`

Parser note: `mods/client_settings/settings.lua`, `modules/game_actionbar/actionbar.lua`, `modules/game_npctrade/npctrade.lua`, and `modules/game_interface/gameinterface.lua` still contain existing `goto` labels that this JS parser reports as syntax errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorado o comportamento dos círculos de vida e mana com tratamento mais robusto de visibilidade e posicionamento.
  * Corrigido o layout da interface do jogo para melhor adaptação ao redimensionar elementos.
  * Aprimorada a janela de comércio com NPCs com expansão e ajuste automático.

* **Improvements**
  * Reorganização interna da barra superior para melhor estabilidade.
  * Otimizado o carregamento e sincronização das configurações de interface quando o jogo inicia.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->