### PR TITLE
[codex] Fix animated cursor flicker

### DIFF
--- a/src/client/uimap.cpp
+++ b/src/client/uimap.cpp
@@ -190,21 +190,33 @@ TilePtr UIMap::getTile(const Point& mousePos)
 
 void UIMap::resetCursorToDefault()
 {
-    if (g_mouse.isCursorChanged() || g_mouse.isUsingNativeCursor())
+    if (g_mouse.isCursorChanged() || g_mouse.isUsingNativeCursor()) {
+        m_currentCursorId = -1;
         return;
+    }
 
-    m_currentCursorId = -1;
     int cursorId = g_mouse.getCursorId("native");
-    if (cursorId != -1)
+    if (cursorId != -1) {
+        if (m_currentCursorId == cursorId)
+            return;
+
+        m_currentCursorId = cursorId;
         g_window.setMouseCursor(cursorId);
-    else
+    } else {
+        m_currentCursorId = -1;
         g_window.restoreMouseCursor();
+    }
 }
 
 void UIMap::updateCursor(const TilePtr& tile)
 {
-    if (!m_cursorAnimations || g_mouse.isCursorChanged() || g_mouse.isUsingNativeCursor())
+    if (!m_cursorAnimations)
         return;
+
+    if (g_mouse.isCursorChanged() || g_mouse.isUsingNativeCursor()) {
+        m_currentCursorId = -1;
+        return;
+    }
 
     const char* cursorName = nullptr;
     if (tile) {
@@ -231,14 +243,21 @@ void UIMap::updateCursor(const TilePtr& tile)
     }
 
     if (!cursorName) {
+        resetCursorToDefault();
         return;
     }
 
     int cursorId = g_mouse.getCursorId(cursorName);
-    if (cursorId != -1 && cursorId != m_currentCursorId) {
-        m_currentCursorId = cursorId;
-        g_window.setMouseCursor(cursorId);
+    if (cursorId == -1) {
+        resetCursorToDefault();
+        return;
     }
+
+    if (cursorId == m_currentCursorId)
+        return;
+
+    m_currentCursorId = cursorId;
+    g_window.setMouseCursor(cursorId);
 }
 
 void UIMap::setCursorAnimations(bool enable)

--- a/src/framework/graphics/image.cpp
+++ b/src/framework/graphics/image.cpp
@@ -62,9 +62,10 @@ ImagePtr Image::loadPNG(const std::string& file)
         image = std::make_shared<Image>(Size(apng.width, apng.height), apng.bpp, apng.pdata);
         if (apng.num_frames > 1 && apng.frames_delay) {
             const size_t frameSize = static_cast<size_t>(apng.width) * apng.height * apng.bpp;
-            const uint32_t frameCount = std::min(apng.num_frames, apng.last_frame);
+            const uint32_t availableFrames = apng.last_frame >= apng.first_frame ? apng.last_frame - apng.first_frame + 1 : 0;
+            const uint32_t frameCount = std::min(apng.num_frames, availableFrames);
             for (uint32_t i = 0; i < frameCount; ++i) {
-                auto frame = std::make_shared<Image>(Size(apng.width, apng.height), apng.bpp, apng.pdata + (static_cast<size_t>(i) * frameSize));
+                auto frame = std::make_shared<Image>(Size(apng.width, apng.height), apng.bpp, apng.pdata + (static_cast<size_t>(apng.first_frame + i) * frameSize));
                 image->addAnimationFrame(frame, apng.frames_delay[i]);
             }
         }
@@ -83,9 +84,10 @@ ImagePtr Image::loadPNG(const void* data, uint32_t size)
         image = std::make_shared<Image>(Size(apng.width, apng.height), apng.bpp, apng.pdata);
         if (apng.num_frames > 1 && apng.frames_delay) {
             const size_t frameSize = static_cast<size_t>(apng.width) * apng.height * apng.bpp;
-            const uint32_t frameCount = std::min(apng.num_frames, apng.last_frame);
+            const uint32_t availableFrames = apng.last_frame >= apng.first_frame ? apng.last_frame - apng.first_frame + 1 : 0;
+            const uint32_t frameCount = std::min(apng.num_frames, availableFrames);
             for (uint32_t i = 0; i < frameCount; ++i) {
-                auto frame = std::make_shared<Image>(Size(apng.width, apng.height), apng.bpp, apng.pdata + (static_cast<size_t>(i) * frameSize));
+                auto frame = std::make_shared<Image>(Size(apng.width, apng.height), apng.bpp, apng.pdata + (static_cast<size_t>(apng.first_frame + i) * frameSize));
                 image->addAnimationFrame(frame, apng.frames_delay[i]);
             }
         }

--- a/src/framework/platform/win32window.cpp
+++ b/src/framework/platform/win32window.cpp
@@ -688,6 +688,9 @@ LRESULT WIN32Window::windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     switch(uMsg)
     {
         case WM_SETCURSOR: {
+            if (LOWORD(lParam) != HTCLIENT)
+                return DefWindowProc(hWnd, uMsg, wParam, lParam);
+
             if(m_cursor)
                 SetCursor(m_cursor);
             else
@@ -1012,29 +1015,46 @@ int WIN32Window::internalLoadMouseCursor(const ImagePtr& image, const Point& hot
         const ImagePtr& frameImage = frame.image;
         int width = frameImage->getWidth();
         int height = frameImage->getHeight();
-        int pixelCount = width * height;
-        std::vector<uint32> cursorPixels(pixelCount);
+        BITMAPINFO bitmapInfo = {};
+        bitmapInfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+        bitmapInfo.bmiHeader.biWidth = width;
+        bitmapInfo.bmiHeader.biHeight = -height;
+        bitmapInfo.bmiHeader.biPlanes = 1;
+        bitmapInfo.bmiHeader.biBitCount = 32;
+        bitmapInfo.bmiHeader.biCompression = BI_RGB;
+
+        void* colorBits = nullptr;
+        HDC screenDc = GetDC(nullptr);
+        HBITMAP colorBitmap = screenDc ? CreateDIBSection(screenDc, &bitmapInfo, DIB_RGB_COLORS, &colorBits, nullptr, 0) : nullptr;
+        if (screenDc)
+            ReleaseDC(nullptr, screenDc);
 
         const int maskStride = ((width + 15) / 16) * 2;
         std::vector<uint8> maskPixels(maskStride * height, 0);
 
-        for (int i = 0; i < pixelCount; ++i) {
-            uint8* pixel = reinterpret_cast<uint8*>(&cursorPixels[i]);
-            pixel[2] = *(frameImage->getPixelData() + (i * 4) + 0);
-            pixel[1] = *(frameImage->getPixelData() + (i * 4) + 1);
-            pixel[0] = *(frameImage->getPixelData() + (i * 4) + 2);
-            pixel[3] = *(frameImage->getPixelData() + (i * 4) + 3);
+        if (colorBitmap && colorBits) {
+            auto* cursorPixels = static_cast<uint8*>(colorBits);
+            for (int i = 0; i < width * height; ++i) {
+                const uint8 red = *(frameImage->getPixelData() + (i * 4) + 0);
+                const uint8 green = *(frameImage->getPixelData() + (i * 4) + 1);
+                const uint8 blue = *(frameImage->getPixelData() + (i * 4) + 2);
+                const uint8 alpha = *(frameImage->getPixelData() + (i * 4) + 3);
 
-            if (pixel[3] == 0) {
-                const int x = i % width;
-                const int y = i / width;
-                maskPixels[(y * maskStride) + (x / 8)] |= 0x80 >> (x % 8);
+                cursorPixels[(i * 4) + 0] = blue;
+                cursorPixels[(i * 4) + 1] = green;
+                cursorPixels[(i * 4) + 2] = red;
+                cursorPixels[(i * 4) + 3] = alpha;
+
+                if (alpha == 0) {
+                    const int x = i % width;
+                    const int y = i / width;
+                    maskPixels[(y * maskStride) + (x / 8)] |= 0x80 >> (x % 8);
+                }
             }
         }
 
-        HBITMAP colorBitmap = CreateBitmap(width, height, 1, 32, &cursorPixels[0]);
-        HBITMAP maskBitmap = CreateBitmap(width, height, 1, 1, &maskPixels[0]);
-        if (!colorBitmap || !maskBitmap) {
+        HBITMAP maskBitmap = CreateBitmap(width, height, 1, 1, maskPixels.data());
+        if (!colorBitmap || !colorBits || !maskBitmap) {
             if (colorBitmap)
                 DeleteObject(colorBitmap);
             if (maskBitmap)
@@ -1077,13 +1097,8 @@ void WIN32Window::setMouseCursor(int cursorId)
         if (cursorId >= (int)m_cursors.size() || cursorId < 0)
             return;
 
-        if (m_currentCursorId == cursorId) {
-            if (m_cursor) {
-                SetCursor(m_cursor);
-                ShowCursor(true);
-            }
+        if (m_currentCursorId == cursorId)
             return;
-        }
 
         m_currentCursorId = cursorId;
         m_cursorFrame = 0;


### PR DESCRIPTION
## Summary

Fixes animated map cursor flicker for cursors such as walk, attack, open, use, talk, and quick loot.

## Root Cause

`Image::loadPNG` loaded APNG animation frames from slot `0`, while these cursor APNGs use `first_frame = 1`. That made the native cursor animation loop include the decoder canvas/base frame instead of the correct rendered frame sequence, producing a visible blink at the loop boundary.

## Changes

- Load APNG animation frames starting at `apng.first_frame` in `Image::loadPNG`.
- Avoid reapplying the same Win32 cursor id, so cursor animation is not restarted unnecessarily.
- Keep the map cursor fallback state synchronized when leaving interactive tiles.
- Preserve 32-bit alpha when creating native Win32 cursor frame bitmaps.

## Validation

- `git diff --check`
- `git diff --cached --check`

Full client build was not run in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorado o comportamento de cursores do mouse em diferentes cenários.
  * Corrigido o carregamento de imagens animadas para considerar o frame inicial corretamente.
  * Otimizado o tratamento de cursores na plataforma Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->