### PR TITLE
perf(map): return text vectors by const ref (avoid per-frame copy)

### DIFF
--- a/src/client/map.h
+++ b/src/client/map.h
@@ -264,8 +264,8 @@ public:
     int getLastAwareFloor();
     const std::vector<MissilePtr>& getFloorMissiles(int z) { return m_floorMissiles[z]; }
 
-    std::vector<AnimatedTextPtr> getAnimatedTexts() { return m_animatedTexts; }
-    std::vector<StaticTextPtr> getStaticTexts() { return m_staticTexts; }
+    const std::vector<AnimatedTextPtr>& getAnimatedTexts() const { return m_animatedTexts; }
+    const std::vector<StaticTextPtr>& getStaticTexts() const { return m_staticTexts; }
 
     std::tuple<std::vector<Otc::Direction>, Otc::PathFindResult> findPath(const Position& start, const Position& goal, int maxComplexity, int flags = 0);
     PathFindResult_ptr newFindPath(const Position& start, const Position& goal, std::shared_ptr<std::list<Node*>> visibleNodes);


### PR DESCRIPTION
Map::getAnimatedTexts()/getStaticTexts() returned std::vector by value, copying the whole vector every frame in MapView::drawMapForeground. They are iterated read-only and not bound to Lua, so returning const ref avoids the per-frame allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Otimizações internas de performance na gestão de memória.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->