### PR TITLE
Enable FPS optimizations by default

### DIFF
--- a/data/fonts/var-cip-font-wheel.otfont
+++ b/data/fonts/var-cip-font-wheel.otfont
@@ -1,7 +1,6 @@
 Font
   name: $var-cip-font-wheel
-  texture: verdana-11px-monochrome_underline_cp1252
-  height: 14
-  glyph-size: 16 16
-  space-width: 3
-  spacing: -1 0
+  texture: Verdana Bold-11px-wheel
+  height: 15
+  glyph-size: 22 15
+  space-width: 4

--- a/mods/client_settings/classes/conditions.lua
+++ b/mods/client_settings/classes/conditions.lua
@@ -767,14 +767,20 @@ function ConditionsHUD:configure()
                 ConditionsHUD:changeVisibilityInHud(condition:getId(), checked)
             end
 
-            local visibleHud = ConditionsHUD.settings.visibleHud[condition:getId()] == nil and condition:isVisibleHud() or ConditionsHUD.settings.visibleHud[condition:getId()]
+            local visibleHud = ConditionsHUD.settings.visibleHud[condition:getId()]
+            if visibleHud == nil then
+                visibleHud = condition:isVisibleHud()
+            end
             condition:setVisibleHud(visibleHud)
             syncStatusIconBarHudVisibility(condition:getId(), visibleHud)
             widget.showInHudCheckBox:setChecked(visibleHud)
             widget.showInBarCheckBox.onCheckChange = function(widget, checked)
                 ConditionsHUD:changeVisibilityInBar(condition:getId(), checked)
             end
-            local visibleBar = ConditionsHUD.settings.visibleBar[condition:getId()] == nil and condition:isVisibleBar() or ConditionsHUD.settings.visibleBar[condition:getId()]
+            local visibleBar = ConditionsHUD.settings.visibleBar[condition:getId()]
+            if visibleBar == nil then
+                visibleBar = condition:isVisibleBar()
+            end
             condition:setVisibleBar(visibleBar)
             widget.showInBarCheckBox:setChecked(visibleBar)
 

--- a/mods/client_settings/classes/conditions.lua
+++ b/mods/client_settings/classes/conditions.lua
@@ -1,4 +1,7 @@
 -- data/images/arcs/conditions/player-state-flags.png
+local EMBLEM_HUD_ICON_PATH = '/images/arcs/conditions/player-state-guildwar-flag'
+local HUNGRY_HUD_ICON_PATH = '/images/arcs/conditions/player-state-flags-client-02'
+
 local widgets = {
     [1] = {
         icon = Icons[PlayerStates.Poison].path,
@@ -397,8 +400,8 @@ local widgets = {
         )
     },
     [34] = {
-        icon = "/images/game/emblems/emblem_green",
-        path = "/images/game/emblems/emblem_green",
+        icon = EMBLEM_HUD_ICON_PATH,
+        path = EMBLEM_HUD_ICON_PATH,
         name = "in guild war",
         id = "emblem",
         visibleHud = false,
@@ -411,7 +414,7 @@ local widgets = {
     [35] = {
         icon = Icons[PlayerStates.Hungry].path,
         name = "hungry",
-        path = '/images/arcs/conditions/player-state-flags-client-02',
+        path = HUNGRY_HUD_ICON_PATH,
         id = Icons[PlayerStates.Hungry].id,
         visibleHud = false,
         visibleBar = true,
@@ -508,11 +511,131 @@ if not ConditionsHUD then
 end
 
 local function refreshStatusIconBar()
+    local refreshed = false
+
     if StatusIconBar and type(StatusIconBar.refreshIcons) == 'function' then
+        refreshed = true
         addEvent(function()
             StatusIconBar.refreshIcons()
         end)
     end
+
+    local healthCircle = modules and modules.game_healthcircle
+    if healthCircle and type(healthCircle.refreshStatusIcons) == 'function' then
+        refreshed = true
+        addEvent(function()
+            healthCircle.refreshStatusIcons()
+        end)
+    end
+
+    local statusIconBar = modules and modules.game_statusiconbar
+    if statusIconBar and type(statusIconBar.refreshStatusIcons) == 'function' then
+        refreshed = true
+        addEvent(function()
+            statusIconBar.refreshStatusIcons()
+        end)
+    end
+
+    return refreshed
+end
+
+local function syncStatusIconBarHudVisibility(id, visible)
+    if StatusIconBar and type(StatusIconBar.setNativeHudConditionVisible) == 'function' then
+        StatusIconBar.setNativeHudConditionVisible(id, visible)
+    end
+
+    local healthCircle = modules and modules.game_healthcircle
+    if healthCircle and type(healthCircle.setNativeHudConditionVisible) == 'function' then
+        healthCircle.setNativeHudConditionVisible(id, visible)
+    end
+
+    local statusIconBar = modules and modules.game_statusiconbar
+    if statusIconBar and type(statusIconBar.setNativeHudConditionVisible) == 'function' then
+        statusIconBar.setNativeHudConditionVisible(id, visible)
+    end
+end
+
+local function syncStatusIconBarHudMaster(value)
+    if StatusIconBar and type(StatusIconBar.setNativeHudMasterEnabled) == 'function' then
+        StatusIconBar.setNativeHudMasterEnabled(value)
+    end
+
+    local healthCircle = modules and modules.game_healthcircle
+    if healthCircle and type(healthCircle.setNativeHudMasterEnabled) == 'function' then
+        healthCircle.setNativeHudMasterEnabled(value)
+    end
+
+    local statusIconBar = modules and modules.game_statusiconbar
+    if statusIconBar and type(statusIconBar.setNativeHudMasterEnabled) == 'function' then
+        statusIconBar.setNativeHudMasterEnabled(value)
+    end
+end
+
+local emblemIcons = {
+    [EmblemGreen or 1] = '/images/game/emblems/emblem_green',
+    [EmblemRed or 2] = '/images/game/emblems/emblem_red',
+    [EmblemBlue or 3] = '/images/game/emblems/emblem_blue',
+    [EmblemMember or 4] = '/images/game/emblems/emblem_member',
+    [EmblemOther or 5] = '/images/game/emblems/emblem_other'
+}
+
+local emblemTooltips = {
+    [EmblemGreen or 1] = tr('Green Emblem'),
+    [EmblemRed or 2] = tr('Red Emblem'),
+    [EmblemBlue or 3] = tr('Blue Emblem'),
+    [EmblemMember or 4] = tr('Member Emblem'),
+    [EmblemOther or 5] = tr('Other Emblem')
+}
+
+local function getEmblemIconPath(emblem)
+    if type(getEmblemImagePath) == 'function' then
+        local path = getEmblemImagePath(emblem)
+        if path then return path end
+    end
+    return emblemIcons[emblem]
+end
+
+local function getEmblemTooltip(emblem)
+    return emblemTooltips[emblem] or tr('Guild Emblem')
+end
+
+local function isEmblemActive(emblem)
+    return emblem ~= nil and emblem ~= (EmblemNone or 0)
+end
+
+local function applyEmblemStyle(specialCondition, emblem)
+    local iconPath = getEmblemIconPath(emblem)
+    if not specialCondition or not iconPath then
+        return false
+    end
+
+    local tooltip = getEmblemTooltip(emblem)
+    specialCondition:setIcon(iconPath)
+    specialCondition:setPath(EMBLEM_HUD_ICON_PATH)
+    specialCondition:setTooltipBar(tooltip)
+
+    if g_client and type(g_client.updateHudPath) == 'function' then
+        g_client.updateHudPath(specialCondition:getId(), EMBLEM_HUD_ICON_PATH)
+    end
+
+    local inventoryWidget = ConditionsHUD.inventoryBar[specialCondition:getId()]
+    if inventoryWidget then
+        inventoryWidget:setImageSource(iconPath)
+        inventoryWidget:setTooltip(tooltip)
+    end
+
+    local topbarWidget = ConditionsHUD.topbarWidgets[specialCondition:getId()]
+    if topbarWidget then
+        topbarWidget:setImageSource(iconPath)
+        topbarWidget:setTooltip(tooltip)
+    end
+
+    local settingsWidget = ConditionsHUD.widgets[specialCondition:getId()]
+    if settingsWidget and settingsWidget.icon then
+        settingsWidget.icon:setImageSource(EMBLEM_HUD_ICON_PATH)
+    end
+
+    return true
 end
 
 function ConditionsHUD:load()
@@ -644,11 +767,16 @@ function ConditionsHUD:configure()
                 ConditionsHUD:changeVisibilityInHud(condition:getId(), checked)
             end
 
-            widget.showInHudCheckBox:setChecked(ConditionsHUD.settings.visibleHud[condition:getId()] == nil and condition:isVisibleHud() or ConditionsHUD.settings.visibleHud[condition:getId()])
+            local visibleHud = ConditionsHUD.settings.visibleHud[condition:getId()] == nil and condition:isVisibleHud() or ConditionsHUD.settings.visibleHud[condition:getId()]
+            condition:setVisibleHud(visibleHud)
+            syncStatusIconBarHudVisibility(condition:getId(), visibleHud)
+            widget.showInHudCheckBox:setChecked(visibleHud)
             widget.showInBarCheckBox.onCheckChange = function(widget, checked)
                 ConditionsHUD:changeVisibilityInBar(condition:getId(), checked)
             end
-            widget.showInBarCheckBox:setChecked(ConditionsHUD.settings.visibleBar[condition:getId()] == nil and condition:isVisibleBar() or ConditionsHUD.settings.visibleBar[condition:getId()])
+            local visibleBar = ConditionsHUD.settings.visibleBar[condition:getId()] == nil and condition:isVisibleBar() or ConditionsHUD.settings.visibleBar[condition:getId()]
+            condition:setVisibleBar(visibleBar)
+            widget.showInBarCheckBox:setChecked(visibleBar)
 
             widget.bgcolor = i % 2 == 0 and "#414141" or "#484848"
             widget:setBackgroundColor(widget.bgcolor)
@@ -665,6 +793,7 @@ function ConditionsHUD:configure()
         end
     end
 
+    syncStatusIconBarHudMaster(m_settings.getOption('showInHudCheckBox'))
     refreshStatusIconBar()
 end
 
@@ -737,6 +866,7 @@ function ConditionsHUD:changeVisibilityInHud(id, visible)
 
     condition:setVisibleHud(visible)
     ConditionsHUD.settings.visibleHud[id] = visible
+    syncStatusIconBarHudVisibility(id, visible)
     -- notifier
     if visible and ConditionsHUD.actives[condition:getId()] then
         -- if condition is active, add it to the hud
@@ -917,6 +1047,7 @@ end
 
 function ConditionsHUD:setShowInHudEnabled(value)
     local localPlayer = g_game.getLocalPlayer()
+    syncStatusIconBarHudMaster(value)
 
     local removeNormalBattle = false
     for _, condition in pairs(ConditionsHUD.hud) do
@@ -1165,7 +1296,9 @@ function ConditionsHUD:notifierHungryChange(localPlayer, remove)
         -- remove condition
         ConditionsHUD:removeHUDCondition(localPlayer, specialCondition:getId())
         ConditionsHUD.actives[specialCondition:getId()] = nil
-        inventoryWidget:setVisible(false)
+        if inventoryWidget then
+            inventoryWidget:setVisible(false)
+        end
 
         if topbarWidget then
             topbarWidget:setVisible(false)
@@ -1178,15 +1311,21 @@ function ConditionsHUD:notifierHungryChange(localPlayer, remove)
         end
 
         if specialCondition:isVisibleBar() and m_settings.getOption('showInBarCheckBox') then
-            inventoryWidget:setVisible(true)
-            inventoryWidget:setTooltip(specialCondition:getTooltipBar())
+            if inventoryWidget then
+                inventoryWidget:setVisible(true)
+                inventoryWidget:setTooltip(specialCondition:getTooltipBar())
+                inventoryWidget:setImageSource(specialCondition:getIcon())
+            end
 
             if topbarWidget then
                 topbarWidget:setVisible(true)
                 topbarWidget:setTooltip(specialCondition:getTooltipBar())
+                topbarWidget:setImageSource(specialCondition:getIcon())
             end
         end
     end
+
+    refreshStatusIconBar()
 end
 
 function ConditionsHUD:notifierRestingAreaState(zone, state, message)
@@ -1390,32 +1529,41 @@ function ConditionsHUD:notifierEmblemChange(creature, emblem)
     local inventoryWidget = ConditionsHUD.inventoryBar[specialCondition:getId()]
     local topbarWidget = ConditionsHUD.topbarWidgets[specialCondition:getId()]
 
-    if emblem ~= 1 then
+    if not isEmblemActive(emblem) then
         -- remove condition
         if localPlayer.removeHUDCondition then
             ConditionsHUD:removeHUDCondition(localPlayer, specialCondition:getId())
         end
         ConditionsHUD.actives[specialCondition:getId()] = nil
-        inventoryWidget:setVisible(false)
+        if inventoryWidget then
+            inventoryWidget:setVisible(false)
+        end
         if topbarWidget then
             topbarWidget:setVisible(false)
         end
     else
         -- add condition
+        applyEmblemStyle(specialCondition, emblem)
         ConditionsHUD.actives[specialCondition:getId()] = true
         if specialCondition:isVisibleHud() and m_settings.getOption('showInHudCheckBox') then
             ConditionsHUD:addHUDCondition(localPlayer, specialCondition:getId())
         end
 
         if specialCondition:isVisibleBar() and m_settings.getOption('showInBarCheckBox') then
-            inventoryWidget:setVisible(true)
-            inventoryWidget:setTooltip(specialCondition:getTooltipBar())
+            if inventoryWidget then
+                inventoryWidget:setVisible(true)
+                inventoryWidget:setTooltip(specialCondition:getTooltipBar())
+                inventoryWidget:setImageSource(specialCondition:getIcon())
+            end
             if topbarWidget then
                 topbarWidget:setVisible(true)
                 topbarWidget:setTooltip(specialCondition:getTooltipBar())
+                topbarWidget:setImageSource(specialCondition:getIcon())
             end
         end
     end
+
+    refreshStatusIconBar()
 end
 
 function ConditionsHUD:moveItem(tbl, fromIndex, direction)
@@ -1494,6 +1642,7 @@ function ConditionsHUD:onGameStart()
         ConditionsHUD:notifierRestingAreaState(ConditionsHUD.zone, ConditionsHUD.state, ConditionsHUD.message)
         ConditionsHUD:notifierHungryChange(localPlayer, localPlayer:getRegenerationTime() > 0)
         ConditionsHUD:notifierEmblemChange(localPlayer, localPlayer:getEmblem())
+        refreshStatusIconBar()
     end)
 end
 

--- a/mods/client_settings/classes/dataset.lua
+++ b/mods/client_settings/classes/dataset.lua
@@ -1092,7 +1092,7 @@ return {
 	},
 
 	cacheUI = {
-		value = false,
+		value = true,
         apply = function(value)
             g_app.setCacheUI(value)
             return true

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -89,6 +89,18 @@ HotKeys = {}
 local boundCombosCallback = {}
 local boundCombosHelper = {}
 
+local function migrateCacheUIDefaultOn()
+  if g_settings.getBoolean("astraCacheUIDefaultOnV1") then
+    return
+  end
+
+  -- Old defaults were persisted on startup, so a saved false is not a reliable
+  -- manual opt-out. setupStart only writes defaults; loadSettings applies this
+  -- migrated value later in setup().
+  g_settings.set("cacheUI", true)
+  g_settings.set("astraCacheUIDefaultOnV1", true)
+end
+
 function shouldShowLootHighlightEffect()
   return getOption('lootHighlight') ~= false
 end
@@ -118,6 +130,7 @@ function init()
 
   GameOptions:setLoadedWindow(loadedWindows)
   GameOptions:setupStart()
+  migrateCacheUIDefaultOn()
   g_game.shouldShowLootHighlightEffect = shouldShowLootHighlightEffect
 
   for i, file in pairs(importFiles) do
@@ -2322,7 +2335,7 @@ function resetGraphics()
     setTempOption('hdmodeBox', true)
     setTempOption('fullscreen', false)
     setTempOption('dontStretchShrink', false)
-    setTempOption('cacheUI', false)
+    setTempOption('cacheUI', true)
     setTempOption('vsync', false)
     setTempOption('noFrameCheckBox', false)
     setTempOption('backgroundFrameRate', 100)

--- a/mods/game_store/classes/Store.lua
+++ b/mods/game_store/classes/Store.lua
@@ -68,7 +68,9 @@ local function isWidgetAlive(widget)
 end
 
 local localImageAliases = {
-	xp_boost = "/images/game/skills/xp_boost",
+	["13/xp_boost"] = "/images/icons/xp_boost",
+	["64/xp_boost"] = "/images/dailyreward/icon-reward-xpboost",
+	xp_boost = "/images/dailyreward/icon-reward-xpboost",
 	store_premium = "/images/game/battlepass/mainIcon1",
 	prey_wildcard = "/images/game/prey/prey_wildcard"
 }
@@ -89,7 +91,7 @@ function Store:resolveLocalImage(image)
 	end
 
 	local imageName = source:gsub("^%d+/", "")
-	local alias = localImageAliases[imageName]
+	local alias = localImageAliases[source] or localImageAliases[imageName]
 	if alias and resourceImageExists(alias) then
 		return alias
 	end

--- a/mods/game_store/classes/Store.lua
+++ b/mods/game_store/classes/Store.lua
@@ -68,6 +68,7 @@ local function isWidgetAlive(widget)
 end
 
 local localImageAliases = {
+	xp_boost = "/images/game/skills/xp_boost",
 	store_premium = "/images/game/battlepass/mainIcon1",
 	prey_wildcard = "/images/game/prey/prey_wildcard"
 }

--- a/mods/game_store/storeprotocol.lua
+++ b/mods/game_store/storeprotocol.lua
@@ -314,6 +314,16 @@ function StoreProtocol.isCatalogLoaded()
   return catalogLoaded
 end
 
+function StoreProtocol.getOfferBySubtype(subtype)
+  subtype = tostring(subtype or ""):lower()
+  for _, offer in pairs(offersById) do
+    if offer.storeSubtype == subtype then
+      return offer
+    end
+  end
+  return nil
+end
+
 function StoreProtocol.requestStoreOffers(actionOrCategory, valueOrServiceType, serviceType)
   showOffers(actionOrCategory, valueOrServiceType, serviceType)
 end
@@ -360,6 +370,7 @@ function initStoreProtocol()
 
   g_game.openStore = StoreProtocol.openStore
   g_game.forceRefreshStore = StoreProtocol.forceRefresh
+  g_game.getStoreOfferBySubtype = StoreProtocol.getOfferBySubtype
   g_game.requestStoreOffers = StoreProtocol.requestStoreOffers
   g_game.requestOfferDescription = StoreProtocol.requestOfferDescription
   g_game.buyStoreOffer = StoreProtocol.buyStoreOffer

--- a/modules/game_battle/battle.lua
+++ b/modules/game_battle/battle.lua
@@ -9,7 +9,7 @@ mouseWidget = nil
 
 local maxBattleWindow = 21
 local battleUpdateEvent = nil
-local battleUpdateInterval = 300
+local battleUpdateInterval = 100
 local battleAgeNumber = 1
 local battleAges = {}
 local hoveredCreature = nil
@@ -429,7 +429,9 @@ function checkCreatures()
   local spectators = g_map.getSpectatorsInRangeEx(playerPos, false, math.floor(dimension.width / 2), math.floor(dimension.width / 2), math.floor(dimension.height / 2), math.floor(dimension.height / 2))
 
   for _, battle in pairs(battleClasses) do
-    updateBattleCreatures(battle, spectators, player)
+    if not battle.secondary or (battle.window and battle.window:isVisible()) then
+      updateBattleCreatures(battle, spectators, player)
+    end
   end
 
   updateBattleButtons()

--- a/modules/game_healthcircle/game_healthcircle.lua
+++ b/modules/game_healthcircle/game_healthcircle.lua
@@ -98,14 +98,7 @@ local function getBarDistance(mapHeight)
 end
 
 local function hasStableMapGeometry(mapPanel)
-    if not hasValidMapGeometry(mapPanel) then
-        return false
-    end
-
-    local barDistance = getBarDistance(mapPanel:getHeight())
-    local minimumWidth = math.max(480, imageSizeThin * 2 + barDistance * 2 + 64)
-    local minimumHeight = math.max(320, imageSizeBroad + 64)
-    return mapPanel:getWidth() >= minimumWidth and mapPanel:getHeight() >= minimumHeight
+    return hasValidMapGeometry(mapPanel)
 end
 
 local function hideHealthCircleWidgets()
@@ -746,7 +739,19 @@ function handleShowArc(value)
     value = toboolean(value)
     disableMapNativeArcs()
 
+    if value then
+        isHealthCircle = true
+        isManaCircle = true
+        if healthCheckBox then healthCheckBox:setChecked(true) end
+        if manaCheckBox then manaCheckBox:setChecked(true) end
+        g_settings.set('healthcircle_hpcircle', false)
+        g_settings.set('healthcircle_mpcircle', false)
+    end
+
+    whenMapResizeChange(value)
     applyHealthManaCircleVisibility(value)
+    whenHealthChange(value)
+    whenManaChange(value)
     updateManaShieldDisplay(value)
     scheduleMapResizeUpdates(value)
 end

--- a/modules/game_healthcircle/statusiconbar.lua
+++ b/modules/game_healthcircle/statusiconbar.lua
@@ -22,13 +22,109 @@ local config = {
 }
 
 local SETTINGS_FILE = '/settings_conditions_hud.json'
+local NATIVE_SETTINGS_FILE = '/settings.json'
 local DECORATIVE_CHILD_COUNT = 2
+local nativeVisibleHudOverrides = {}
+local nativeHudMasterOverride = nil
+local nativeHudVisibilityLoaded = false
+local EMBLEM_HUD_ICON_PATH = '/images/arcs/conditions/player-state-guildwar-flag'
+local HUNGRY_HUD_ICON_PATH = '/images/arcs/conditions/player-state-flags-client-02'
 
 local function safeCall(obj, method, ...)
     if obj and type(obj[method]) == 'function' then
         return obj[method](obj, ...)
     end
     return nil
+end
+
+local emblemIcons = {
+    [EmblemGreen or 1] = '/images/game/emblems/emblem_green',
+    [EmblemRed or 2] = '/images/game/emblems/emblem_red',
+    [EmblemBlue or 3] = '/images/game/emblems/emblem_blue',
+    [EmblemMember or 4] = '/images/game/emblems/emblem_member',
+    [EmblemOther or 5] = '/images/game/emblems/emblem_other'
+}
+
+local emblemTooltips = {
+    [EmblemGreen or 1] = 'Green Emblem',
+    [EmblemRed or 2] = 'Red Emblem',
+    [EmblemBlue or 3] = 'Blue Emblem',
+    [EmblemMember or 4] = 'Member Emblem',
+    [EmblemOther or 5] = 'Other Emblem'
+}
+
+local function getEmblemIconPath(emblem)
+    if type(getEmblemImagePath) == 'function' then
+        local path = getEmblemImagePath(emblem)
+        if path then return path end
+    end
+    return emblemIcons[emblem]
+end
+
+local function getEmblemTooltip(emblem)
+    return emblemTooltips[emblem] or 'Guild Emblem'
+end
+
+local function getPlayerEmblem(player)
+    return safeCall(player or g_game.getLocalPlayer(), 'getEmblem') or (EmblemNone or 0)
+end
+
+local function isEmblemActive(emblem)
+    return emblem ~= nil and emblem ~= (EmblemNone or 0)
+end
+
+local function loadNativeHudVisibility()
+    table.clear(nativeVisibleHudOverrides)
+    nativeHudVisibilityLoaded = false
+
+    if not g_resources.fileExists(NATIVE_SETTINGS_FILE) then
+        return
+    end
+
+    local status, decoded = pcall(function()
+        return json.decode(g_resources.readFileContents(NATIVE_SETTINGS_FILE))
+    end)
+    if not status or type(decoded) ~= 'table' or type(decoded.visibleHud) ~= 'table' then
+        return
+    end
+
+    nativeHudVisibilityLoaded = true
+    for conditionId, visible in pairs(decoded.visibleHud) do
+        conditionId = tostring(conditionId)
+        visible = visible ~= false
+        nativeVisibleHudOverrides[conditionId] = visible
+    end
+end
+
+local function isNativeHudMasterEnabled()
+    if nativeHudMasterOverride ~= nil then
+        return nativeHudMasterOverride
+    end
+
+    if type(getTmpOption) == 'function' then
+        local tempValue = getTmpOption('showInHudCheckBox')
+        if tempValue ~= nil then
+            return tempValue ~= false
+        end
+    end
+
+    if m_settings and type(m_settings.getOption) == 'function' then
+        local value = m_settings.getOption('showInHudCheckBox')
+        if value ~= nil then
+            return value ~= false
+        end
+    end
+
+    if GameOptions and type(GameOptions.getOption) == 'function' then
+        local ok, value = pcall(function()
+            return GameOptions:getOption('showInHudCheckBox')
+        end)
+        if ok and value ~= nil then
+            return value ~= false
+        end
+    end
+
+    return true
 end
 
 local function isStateActive(states, state)
@@ -69,7 +165,7 @@ local function buildConditionIcons()
                     name = iconData.tooltip or iconData.id,
                     tooltip = iconData.tooltip or '',
                     state = type(state) == 'number' and state ~= -1 and state or nil,
-                    path = iconData.path,
+                    path = iconData.id == 'condition_hungry' and HUNGRY_HUD_ICON_PATH or iconData.path,
                     clip = iconData.clip,
                     visibleHud = true,
                     visibleBar = true,
@@ -81,7 +177,7 @@ local function buildConditionIcons()
     -- Manual additions not in Icons table
     addCond({ id = 'condition_restingarea', name = 'Resting Area', tooltip = 'Resting area protection', state = nil, visibleHud = true, visibleBar = true })
     addCond({ id = 'condition_curse', name = 'Goshnar Curse', tooltip = 'Goshnar Taint', state = nil, visibleHud = true, visibleBar = true })
-    addCond({ id = 'emblem', name = 'Green Emblem', tooltip = 'Green Emblem', state = nil, visibleHud = true, visibleBar = true })
+    addCond({ id = 'emblem', name = 'Guild Emblem', tooltip = 'Guild Emblem', state = nil, path = EMBLEM_HUD_ICON_PATH, visibleHud = false, visibleBar = true })
 
     -- Skull conditions
     addCond({ id = 'skullgreen', name = 'Green Skull', tooltip = 'Green Skull', skull = 2, visibleHud = true, visibleBar = true })
@@ -138,6 +234,7 @@ function ConditionsHUD.loadSettings()
             ConditionsHUD.settings = defaultSettings()
         end
     end
+    loadNativeHudVisibility()
     ConditionsHUD.syncMissingOrderEntries()
 end
 
@@ -164,6 +261,10 @@ function ConditionsHUD.isConditionVisible(conditionId, panel)
     local condition = conditionLookup[conditionId]
     if not condition then return false end
     if panel == 'hud' then
+        if not isNativeHudMasterEnabled() then return false end
+        local nativeValue = nativeVisibleHudOverrides[tostring(conditionId)]
+        if nativeValue ~= nil then return nativeValue end
+        if nativeHudVisibilityLoaded then return condition.visibleHud ~= false end
         if not ConditionsHUD.settings.showInHud then return false end
         local value = ConditionsHUD.settings.visibleHud[conditionId]
         if value == nil then return condition.visibleHud ~= false end
@@ -180,8 +281,7 @@ function StatusIconBar.isConditionActive(player, condition, states)
     end
 
     if condition.id == 'emblem' then
-        local emblem = player:getEmblem()
-        return emblem ~= nil and emblem ~= 0
+        return isEmblemActive(getPlayerEmblem(player))
     end
 
     if condition.id == 'condition_hungry' then
@@ -212,7 +312,9 @@ local function applyIconWidgetStyle(container, condition)
     local icon = container and container:getChildById('icon')
     if not icon then return end
 
-    if condition and condition.path then
+    if condition and condition.id == 'emblem' then
+        icon:setImageSource(EMBLEM_HUD_ICON_PATH)
+    elseif condition and condition.path then
         icon:setImageSource(condition.path)
     elseif condition and condition.clip then
         icon:setImageSource('/images/game/states/player-state-flags')
@@ -390,7 +492,11 @@ function StatusIconBar.refreshIcons()
         else
             container.realHeight = container.realHeight or container:getHeight()
         end
-        container:setTooltip(condition.tooltip or condition.name or '')
+        if condition.id == 'emblem' then
+            container:setTooltip(getEmblemTooltip(getPlayerEmblem(player)))
+        else
+            container:setTooltip(condition.tooltip or condition.name or '')
+        end
         applyIconWidgetStyle(container, condition)
     end
 
@@ -442,6 +548,19 @@ end
 
 function StatusIconBar.onGameEnd()
     StatusIconBar.clearAll()
+end
+
+function StatusIconBar.setNativeHudConditionVisible(conditionId, visible)
+    conditionId = tostring(conditionId)
+    visible = visible ~= false
+    nativeHudVisibilityLoaded = true
+    nativeVisibleHudOverrides[conditionId] = visible
+    StatusIconBar.refreshIcons()
+end
+
+function StatusIconBar.setNativeHudMasterEnabled(visible)
+    nativeHudMasterOverride = visible ~= false
+    StatusIconBar.refreshIcons()
 end
 
 function StatusIconBar.init()
@@ -522,6 +641,18 @@ end
 
 function StatusIconBar.isVisible()
     return statusIconPanel and statusIconPanel:isVisible()
+end
+
+function refreshStatusIcons()
+    StatusIconBar.refreshIcons()
+end
+
+function setNativeHudConditionVisible(conditionId, visible)
+    StatusIconBar.setNativeHudConditionVisible(conditionId, visible)
+end
+
+function setNativeHudMasterEnabled(visible)
+    StatusIconBar.setNativeHudMasterEnabled(visible)
 end
 
 -- ConditionsHUD Options Window

--- a/modules/game_healthcircle/statusiconbar.lua
+++ b/modules/game_healthcircle/statusiconbar.lua
@@ -705,7 +705,7 @@ function ConditionsHUD.createConditionRow(condition)
     check.onCheckChange = function(self, checked)
         ConditionsHUD.settings.visibleHud[self.conditionId] = checked
         ConditionsHUD.saveSettings()
-        StatusIconBar.refreshIcons()
+        StatusIconBar.setNativeHudConditionVisible(self.conditionId, checked)
     end
 
     row.onClick = function(self)
@@ -802,7 +802,7 @@ function ConditionsHUD.setupOptionsWindow()
         masterCheck.onCheckChange = function(_, checked)
             ConditionsHUD.settings.showInHud = checked
             ConditionsHUD.saveSettings()
-            StatusIconBar.refreshIcons()
+            StatusIconBar.setNativeHudMasterEnabled(checked)
         end
     end
 

--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -3,8 +3,6 @@ storeXPButton = nil
 
 local storeBoostTimerEvent = nil
 local storeBoostTime = 0
-local XP_BOOST_OFFER_ID = 65583
-local XP_BOOST_PRICE = 30
 
 local healthUpdateEvent = nil
 local manaUpdateEvent = nil
@@ -1065,6 +1063,22 @@ function onBoostClick()
   instantlyBuyBoost()
 end
 
+local function getXpBoostStoreOffer()
+  if not g_game.getStoreOfferBySubtype then
+    return nil
+  end
+  return g_game.getStoreOfferBySubtype("expboost") or g_game.getStoreOfferBySubtype("xpboost")
+end
+
+local function getXpBoostPurchaseData()
+  local offer = getXpBoostStoreOffer()
+  local selectedOffer = offer and offer.offers and offer.offers[1]
+  if not offer or not offer.id or not selectedOffer or not selectedOffer.price then
+    return nil
+  end
+  return offer.id, selectedOffer.price
+end
+
 function onUpdateGainRate(localPlayer, baseRate, lowLevelBonus, expBoost, staminaMulti)
   if not g_game.isOnline() then
     return
@@ -1124,9 +1138,18 @@ function onUpdateGainRate(localPlayer, baseRate, lowLevelBonus, expBoost, stamin
 end
 
 function instantlyBuyBoost()
+  local offerId, price = getXpBoostPurchaseData()
+  if not offerId then
+    if g_game.openStore then
+      g_game.openStore()
+    end
+    displayErrorBox(tr('Warning'), tr('XP boost offer is not loaded. Open the Store and try again.'))
+    return
+  end
+
   local yesCallback = function()
     if confirmBoostWindow then
-      g_game.buyStoreOffer(XP_BOOST_OFFER_ID, 1, "")
+      g_game.buyStoreOffer(offerId, OFFER_BUY_TYPE_OTHERS or 0, "")
       confirmBoostWindow:destroy()
     end
   end
@@ -1137,7 +1160,7 @@ function instantlyBuyBoost()
     end
   end
 
-  local message = tr("Do you want to buy an XP boost for %s Astra Coins?", XP_BOOST_PRICE)
+  local message = tr("Do you want to buy an XP boost for %s Astra Coins?", price)
   confirmBoostWindow = displayGeneralBox(tr('Warning'), message, {
     { text=tr('Yes'), callback=yesCallback },
     { text=tr('No'), callback=noCallback },

--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -3,6 +3,8 @@ storeXPButton = nil
 
 local storeBoostTimerEvent = nil
 local storeBoostTime = 0
+local XP_BOOST_OFFER_ID = 65583
+local XP_BOOST_PRICE = 30
 
 local healthUpdateEvent = nil
 local manaUpdateEvent = nil
@@ -1060,8 +1062,7 @@ function onTemporaryBonusChange(localPlayer, bonus, endTime)
 end
 
 function onBoostClick()
-	g_game.openStore()
-	g_game.requestStoreOffers(1, "", 1)
+  instantlyBuyBoost()
 end
 
 function onUpdateGainRate(localPlayer, baseRate, lowLevelBonus, expBoost, staminaMulti)
@@ -1123,12 +1124,9 @@ function onUpdateGainRate(localPlayer, baseRate, lowLevelBonus, expBoost, stamin
 end
 
 function instantlyBuyBoost()
-  local xpBoostOfferId = 65583
-  local xpBoostPrice = nil
-
   local yesCallback = function()
     if confirmBoostWindow then
-      g_game.buyStoreOffer(xpBoostOfferId, 1, "")
+      g_game.buyStoreOffer(XP_BOOST_OFFER_ID, 1, "")
       confirmBoostWindow:destroy()
     end
   end
@@ -1139,8 +1137,8 @@ function instantlyBuyBoost()
     end
   end
 
-  local message = tr("Do you want to buy a XP boost for %s Astra Coins?", xpBoostPrice)
-  confirmBoostWindow = displayGeneralBox(tr('Warning'), tr(message), {
+  local message = tr("Do you want to buy an XP boost for %s Astra Coins?", XP_BOOST_PRICE)
+  confirmBoostWindow = displayGeneralBox(tr('Warning'), message, {
     { text=tr('Yes'), callback=yesCallback },
     { text=tr('No'), callback=noCallback },
   }, yesCallback, noCallback)

--- a/modules/game_statusiconbar/statusiconbar.lua
+++ b/modules/game_statusiconbar/statusiconbar.lua
@@ -8,6 +8,10 @@ local refreshEvent
 local initialized = false
 local mapPanel
 local stateByConditionId
+local nativeVisibleHudOverrides = {}
+local nativeHudMasterOverride = nil
+local EMBLEM_HUD_ICON_PATH = '/images/arcs/conditions/player-state-guildwar-flag'
+local HUNGRY_HUD_ICON_PATH = '/images/arcs/conditions/player-state-flags-client-02'
 
 local config = {
     maxIcons = 8,
@@ -29,6 +33,38 @@ local function safeCall(obj, method, ...)
         return obj[method](obj, ...)
     end
     return nil
+end
+
+local emblemIcons = {
+    [EmblemGreen or 1] = '/images/game/emblems/emblem_green',
+    [EmblemRed or 2] = '/images/game/emblems/emblem_red',
+    [EmblemBlue or 3] = '/images/game/emblems/emblem_blue',
+    [EmblemMember or 4] = '/images/game/emblems/emblem_member',
+    [EmblemOther or 5] = '/images/game/emblems/emblem_other'
+}
+
+local emblemTooltips = {
+    [EmblemGreen or 1] = 'Green Emblem',
+    [EmblemRed or 2] = 'Red Emblem',
+    [EmblemBlue or 3] = 'Blue Emblem',
+    [EmblemMember or 4] = 'Member Emblem',
+    [EmblemOther or 5] = 'Other Emblem'
+}
+
+local function getEmblemIconPath(emblem)
+    if type(getEmblemImagePath) == 'function' then
+        local path = getEmblemImagePath(emblem)
+        if path then return path end
+    end
+    return emblemIcons[emblem]
+end
+
+local function getPlayerEmblem()
+    return safeCall(g_game.getLocalPlayer(), 'getEmblem') or (EmblemNone or 0)
+end
+
+local function isEmblemActive(emblem)
+    return emblem ~= nil and emblem ~= (EmblemNone or 0)
 end
 
 local function getMapPanel()
@@ -78,6 +114,14 @@ local function getConditionId(condition)
 end
 
 local function getConditionPath(condition)
+    if getConditionId(condition) == 'emblem' then
+        return EMBLEM_HUD_ICON_PATH
+    end
+
+    if getConditionId(condition) == 'condition_hungry' then
+        return HUNGRY_HUD_ICON_PATH
+    end
+
     if condition and type(condition.getPath) == 'function' then
         return condition:getPath()
     end
@@ -92,6 +136,10 @@ local function getConditionIcon(condition)
 end
 
 local function getConditionTooltip(condition)
+    if getConditionId(condition) == 'emblem' then
+        return emblemTooltips[getPlayerEmblem()] or 'Guild Emblem'
+    end
+
     if condition and type(condition.getTooltipBar) == 'function' then
         local tooltip = condition:getTooltipBar()
         if tooltip and tooltip ~= '' then
@@ -128,6 +176,10 @@ local function isStateActive(states, state)
 end
 
 local function isHudMasterEnabled()
+    if nativeHudMasterOverride ~= nil then
+        return nativeHudMasterOverride
+    end
+
     local tmp = getTmpOption and getTmpOption('showInHudCheckBox')
     if tmp ~= nil then return tmp end
     return getOption('showInHudCheckBox', true) ~= false
@@ -136,6 +188,11 @@ end
 local function isConditionVisibleInHud(condition)
     if not condition then
         return false
+    end
+
+    local id = getConditionId(condition)
+    if id and nativeVisibleHudOverrides[id] ~= nil then
+        return nativeVisibleHudOverrides[id]
     end
 
     if type(condition.isVisibleHud) == 'function' then
@@ -203,7 +260,7 @@ local function isPlayerConditionActive(player, condition, states, hud)
         return isGoshnarCurseActive(states)
     elseif id == 'emblem' then
         local emblem = safeCall(player, 'getEmblem')
-        return emblem ~= nil and emblem == EmblemGreen
+        return isEmblemActive(emblem)
     elseif id == getSkullCondition(safeCall(player, 'getSkull')) then
         return true
     elseif id == 'condition_new_magic_shield' and PlayerStates then
@@ -646,4 +703,28 @@ end
 
 function StatusIconBar.isVisible()
     return statusIconPanel and statusIconPanel:isVisible()
+end
+
+function StatusIconBar.setNativeHudConditionVisible(conditionId, visible)
+    if conditionId ~= nil then
+        nativeVisibleHudOverrides[tostring(conditionId)] = visible ~= false
+    end
+    StatusIconBar.refreshIcons()
+end
+
+function StatusIconBar.setNativeHudMasterEnabled(visible)
+    nativeHudMasterOverride = visible ~= false
+    StatusIconBar.refreshIcons()
+end
+
+function refreshStatusIcons()
+    StatusIconBar.refreshIcons()
+end
+
+function setNativeHudConditionVisible(conditionId, visible)
+    StatusIconBar.setNativeHudConditionVisible(conditionId, visible)
+end
+
+function setNativeHudMasterEnabled(visible)
+    StatusIconBar.setNativeHudMasterEnabled(visible)
 end

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1832,6 +1832,9 @@ void Game::sendQuickLoot(const uint8_t variant, const ItemPtr& item)
     if (!canPerformGameAction())
         return;
 
+    if (getClientVersion() < 1332 && !getFeature(Otc::GameQuickLootFlags))
+        return;
+
     const Position pos = (item && item->getPosition().isValid()) ? item->getPosition() : Position(0, 0, 0);
     const uint16_t itemId = item ? item->getId() : 0;
     const uint8_t stackPos = item ? item->getStackPos() : 0;
@@ -1843,6 +1846,9 @@ void Game::quickLoot(const Position& pos, const uint16_t itemId, const uint8_t s
     if (!canPerformGameAction())
         return;
 
+    if (getClientVersion() < 1332 && !getFeature(Otc::GameQuickLootFlags))
+        return;
+
     m_protocolGame->sendQuickLoot(lootAllCorpses ? 1 : 0, pos, itemId, stackpos);
 }
 
@@ -1851,12 +1857,18 @@ void Game::quickLootArea()
     if (!canPerformGameAction())
         return;
 
+    if (getClientVersion() < 1332 && !getFeature(Otc::GameQuickLootFlags))
+        return;
+
     m_protocolGame->sendQuickLoot(2, Position(0, 0, 0), 0, 0);
 }
 
 void Game::requestQuickLootBlackWhiteList(const uint8_t filter, const uint16_t size, const std::vector<uint16_t>& listedItems)
 {
     if (!canPerformGameAction())
+        return;
+
+    if (getClientVersion() < 1332 && !getFeature(Otc::GameQuickLootFlags))
         return;
 
     m_protocolGame->requestQuickLootBlackWhiteList(filter, size, listedItems);
@@ -1873,6 +1885,9 @@ void Game::updateLootWhiteList(bool useWhitelist, const std::vector<uint16_t>& l
 void Game::openContainerQuickLoot(const uint8_t action, const uint8_t category, const Position& pos, const uint16_t itemId, const uint8_t stackpos, const bool useMainAsFallback)
 {
     if (!canPerformGameAction())
+        return;
+
+    if (getClientVersion() < 1332 && !getFeature(Otc::GameQuickLootFlags))
         return;
 
     m_protocolGame->openContainerQuickLoot(action, category, pos, itemId, stackpos, useMainAsFallback);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3700,7 +3700,17 @@ Imbuement ProtocolGame::getImbuementInfo(const InputMessagePtr& msg)
 
 void ProtocolGame::parseLootContainers(const InputMessagePtr& msg)
 {
+    if (g_game.getClientVersion() < 1332 && !g_game.getFeature(Otc::GameQuickLootFlags)) {
+        const int unreadSize = msg->getUnreadSize();
+        if (unreadSize > 0)
+            msg->skipBytes(static_cast<uint32_t>(unreadSize));
+        return;
+    }
+
     const bool quickLootFallbackToMainContainer = msg->getU8() != 0;
+    if (msg->getUnreadSize() < 1)
+        return;
+
     const uint8_t containersCount = msg->getU8();
     const bool inlineObtainContainers = g_game.getClientVersion() >= 1332 && !g_game.getFeature(Otc::GameQuickLootFlags);
     std::map<uint8_t, uint16_t> lootContainers;
@@ -3708,6 +3718,9 @@ void ProtocolGame::parseLootContainers(const InputMessagePtr& msg)
     std::vector<std::tuple<uint8_t, uint16_t, uint16_t>> lootList;
 
     for (uint8_t i = 0; i < containersCount; ++i) {
+        if (msg->getUnreadSize() < 3)
+            break;
+
         const uint8_t category = msg->getU8();
         const uint16_t lootContainerId = msg->getU16();
         uint16_t obtainContainerId = 0;

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2124,7 +2124,8 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg)
     double levelPercent = msg->getU8();
 
     if (g_game.getFeature(Otc::GameExperienceBonus)) {
-        if (g_game.getProtocolVersion() <= 1096) {
+        bool useModernExperienceBonus = g_game.getProtocolVersion() >= 1097 || g_game.getProtocolVersion() == 860;
+        if (!useModernExperienceBonus) {
             double experienceBonus = msg->getDouble();
             m_localPlayer->setExperienceRate(Otc::EXP_BASE, static_cast<int>(experienceBonus * 100));
         } else {
@@ -2195,7 +2196,7 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg)
     double training = 0;
     if (g_game.getFeature(Otc::GameOfflineTrainingTime)) {
         training = msg->getU16();
-        if (g_game.getProtocolVersion() >= 1097) {
+        if (g_game.getProtocolVersion() >= 1097 || (g_game.getProtocolVersion() == 860 && g_game.getFeature(Otc::GameExperienceBonus))) {
             int remainingStoreXpBoostSeconds = msg->getU16();
             bool canBuyMoreStoreXpBoosts = msg->getU8() != 0;
             m_localPlayer->setStoreExpBoostTime(remainingStoreXpBoostSeconds);

--- a/src/framework/core/graphicalapplication.cpp
+++ b/src/framework/core/graphicalapplication.cpp
@@ -140,6 +140,9 @@ void GraphicalApplication::run()
     m_mapFramebuffer = g_framebuffers.createFrameBuffer();
     m_mapFramebuffer->resize(g_painter->getResolution());
     m_mapFramebuffer->setSmooth(m_mapSmooth.load());
+    m_uiFramebuffer = g_framebuffers.createFrameBuffer();
+    m_uiFramebuffer->resize(g_painter->getResolution());
+    m_uiFramebuffer->setSmooth(false);
 
     ticks_t lastRender = stdext::micros();
 
@@ -325,8 +328,6 @@ void GraphicalApplication::run()
             if (cacheUI) {
                 const Size uiResolution = g_painter->getResolution();
                 const ticks_t uiNow = stdext::micros();
-                if (!m_uiFramebuffer)
-                    m_uiFramebuffer = g_framebuffers.createFrameBuffer();
 
                 if (uiResolution != uiCacheSize || repaintRequested || uiNow - uiCacheLastRender >= 16666) {
                     m_uiFramebuffer->resize(uiResolution);

--- a/src/framework/core/graphicalapplication.h
+++ b/src/framework/core/graphicalapplication.h
@@ -82,7 +82,7 @@ private:
     std::atomic<float> m_lastScaling = 1.0;
     std::atomic_int m_maxFps = 100;
     std::atomic_bool m_mapSmooth = true;
-    std::atomic_bool m_cacheUI = false;
+    std::atomic_bool m_cacheUI = true;
     std::atomic_bool m_mustRepaint = false;
     stdext::boolean<false> m_onInputEvent;
     FrameBufferPtr m_framebuffer, m_mapFramebuffer, m_uiFramebuffer;

--- a/src/framework/graphics/bitmapfont.cpp
+++ b/src/framework/graphics/bitmapfont.cpp
@@ -44,11 +44,17 @@ void BitmapFont::load(const OTMLNodePtr& fontNode)
     m_underlineOffset = fontNode->valueAt("underline-offset", 0);
     int spaceWidth = fontNode->valueAt("space-width", glyphSize.width());
 
+    if(glyphSize.width() <= 0 || glyphSize.height() <= 0) {
+        g_logger.error(stdext::format("font '%s' has invalid glyph size %s", m_name, stdext::to_string(glyphSize)));
+        return;
+    }
+
     if(OTMLNodePtr node = fontNode->get("fixed-glyph-width")) {
         for(int glyph = m_firstGlyph; glyph < 256; ++glyph)
             m_glyphsSize[glyph] = Size(node->value<int>(), m_glyphHeight);
     } else {
-        calculateGlyphsWidthsAutomatically(Image::load(textureFile), glyphSize);
+        if (!calculateGlyphsWidthsAutomatically(Image::load(textureFile), glyphSize))
+            return;
     }
 
     // 32 is space
@@ -75,6 +81,8 @@ void BitmapFont::load(const OTMLNodePtr& fontNode)
     m_texture->update();
 
     int numHorizontalGlyphs = m_texture->getSize().width() / glyphSize.width();
+    if (numHorizontalGlyphs <= 0)
+        return;
 #ifdef DONT_CACHE_FONTS
     Point offset(0, 0);
 #else
@@ -356,27 +364,26 @@ std::string BitmapFont::wrapText(const std::string& text, int maxWidth, std::vec
     return outText;
 }
 
-void BitmapFont::calculateGlyphsWidthsAutomatically(const ImagePtr& image, const Size& glyphSize)
+bool BitmapFont::calculateGlyphsWidthsAutomatically(const ImagePtr& image, const Size& glyphSize)
 {
     if (!image || glyphSize.isEmpty())
-        return;
+        return false;
 
     const Size& imageSize = image->getSize();
     const int imageWidth = imageSize.width();
     const int imageHeight = imageSize.height();
     const int bpp = image->getBpp();
     if (imageWidth <= 0 || imageHeight <= 0 || bpp <= 0)
-        return;
+        return false;
 
     const int numHorizontalGlyphs = imageWidth / glyphSize.width();
     const int numVerticalGlyphs = imageHeight / glyphSize.height();
     const int availableGlyphs = numHorizontalGlyphs * numVerticalGlyphs;
     if (numHorizontalGlyphs <= 0 || numVerticalGlyphs <= 0 || availableGlyphs <= 0)
-        return;
+        return false;
 
     const auto& texturePixels = image->getPixels();
     const size_t pixelBytes = texturePixels.size();
-    const int alphaOffset = bpp >= 4 ? 3 : bpp - 1;
 
     for (int glyph = m_firstGlyph; glyph < 256; ++glyph)
         m_glyphsSize[glyph] = Size(0, m_glyphHeight);
@@ -396,10 +403,22 @@ void BitmapFont::calculateGlyphsWidthsAutomatically(const ImagePtr& image, const
         int width = glyphSize.width();
         for (int x = glyphCoords.left(); x <= scanRight; ++x) {
             int filledPixels = 0;
-            // check if all vertical pixels are alpha
             for (int y = glyphCoords.top(); y <= scanBottom; ++y) {
-                const size_t pixelOffset = (static_cast<size_t>(y) * imageWidth + x) * bpp + alphaOffset;
-                if (pixelOffset < pixelBytes && texturePixels[pixelOffset] != 0)
+                const size_t pixelOffset = (static_cast<size_t>(y) * imageWidth + x) * bpp;
+                bool filled = false;
+                if (bpp >= 4) {
+                    filled = pixelOffset + 3 < pixelBytes && texturePixels[pixelOffset + 3] != 0;
+                } else if (bpp >= 3) {
+                    filled = pixelOffset + 2 < pixelBytes &&
+                             (texturePixels[pixelOffset] != 0 ||
+                              texturePixels[pixelOffset + 1] != 0 ||
+                              texturePixels[pixelOffset + 2] != 0);
+                } else if (bpp == 2) {
+                    filled = pixelOffset + 1 < pixelBytes && texturePixels[pixelOffset + 1] != 0;
+                } else {
+                    filled = pixelOffset < pixelBytes && texturePixels[pixelOffset] != 0;
+                }
+                if (filled)
                     filledPixels++;
             }
             if (filledPixels > 0)
@@ -408,6 +427,7 @@ void BitmapFont::calculateGlyphsWidthsAutomatically(const ImagePtr& image, const
         // store glyph size
         m_glyphsSize[glyph].resize(width, m_glyphHeight);
     }
+    return true;
 }
 
 void BitmapFont::updateColors(std::vector<std::pair<int, Color>>* colors, int pos, int newTextLen)

--- a/src/framework/graphics/bitmapfont.cpp
+++ b/src/framework/graphics/bitmapfont.cpp
@@ -30,6 +30,8 @@
 #include <framework/otml/otml.h>
 #include <framework/util/extras.h>
 
+#include <algorithm>
+
 void BitmapFont::load(const OTMLNodePtr& fontNode)
 {
     OTMLNodePtr textureNode = fontNode->at("texture");
@@ -356,24 +358,48 @@ std::string BitmapFont::wrapText(const std::string& text, int maxWidth, std::vec
 
 void BitmapFont::calculateGlyphsWidthsAutomatically(const ImagePtr& image, const Size& glyphSize)
 {
-    if (!image)
+    if (!image || glyphSize.isEmpty())
         return;
 
-    int numHorizontalGlyphs = image->getSize().width() / glyphSize.width();
-    auto texturePixels = image->getPixels();
+    const Size& imageSize = image->getSize();
+    const int imageWidth = imageSize.width();
+    const int imageHeight = imageSize.height();
+    const int bpp = image->getBpp();
+    if (imageWidth <= 0 || imageHeight <= 0 || bpp <= 0)
+        return;
+
+    const int numHorizontalGlyphs = imageWidth / glyphSize.width();
+    const int numVerticalGlyphs = imageHeight / glyphSize.height();
+    const int availableGlyphs = numHorizontalGlyphs * numVerticalGlyphs;
+    if (numHorizontalGlyphs <= 0 || numVerticalGlyphs <= 0 || availableGlyphs <= 0)
+        return;
+
+    const auto& texturePixels = image->getPixels();
+    const size_t pixelBytes = texturePixels.size();
+    const int alphaOffset = bpp >= 4 ? 3 : bpp - 1;
+
+    for (int glyph = m_firstGlyph; glyph < 256; ++glyph)
+        m_glyphsSize[glyph] = Size(0, m_glyphHeight);
 
     // small AI to auto calculate pixels widths
-    for (int glyph = m_firstGlyph; glyph < 256; ++glyph) {
-        Rect glyphCoords(((glyph - m_firstGlyph) % numHorizontalGlyphs) * glyphSize.width(),
-                         ((glyph - m_firstGlyph) / numHorizontalGlyphs) * glyphSize.height(),
+    for (int glyphOffset = 0; glyphOffset < availableGlyphs; ++glyphOffset) {
+        const int glyph = m_firstGlyph + glyphOffset;
+        if (glyph >= 256)
+            break;
+
+        Rect glyphCoords((glyphOffset % numHorizontalGlyphs) * glyphSize.width(),
+                         (glyphOffset / numHorizontalGlyphs) * glyphSize.height(),
                          glyphSize.width(),
                          m_glyphHeight);
+        const int scanRight = std::min(glyphCoords.right(), imageWidth - 1);
+        const int scanBottom = std::min(glyphCoords.bottom(), imageHeight - 1);
         int width = glyphSize.width();
-        for (int x = glyphCoords.left(); x <= glyphCoords.right(); ++x) {
+        for (int x = glyphCoords.left(); x <= scanRight; ++x) {
             int filledPixels = 0;
             // check if all vertical pixels are alpha
-            for (int y = glyphCoords.top(); y <= glyphCoords.bottom(); ++y) {
-                if (texturePixels[(y * image->getSize().width() * 4) + (x * 4) + 3] != 0)
+            for (int y = glyphCoords.top(); y <= scanBottom; ++y) {
+                const size_t pixelOffset = (static_cast<size_t>(y) * imageWidth + x) * bpp + alphaOffset;
+                if (pixelOffset < pixelBytes && texturePixels[pixelOffset] != 0)
                     filledPixels++;
             }
             if (filledPixels > 0)

--- a/src/framework/graphics/bitmapfont.h
+++ b/src/framework/graphics/bitmapfont.h
@@ -71,7 +71,7 @@ public:
 
 private:
     /// Calculates each font character by inspecting font bitmap
-    void calculateGlyphsWidthsAutomatically(const ImagePtr& image, const Size& glyphSize);
+    bool calculateGlyphsWidthsAutomatically(const ImagePtr& image, const Size& glyphSize);
     void updateColors(std::vector<std::pair<int, Color>>* colors, int pos, int newTextLen);
 
     std::string m_name;
@@ -88,4 +88,3 @@ private:
 
 
 #endif
-

--- a/src/framework/platform/win32window.cpp
+++ b/src/framework/platform/win32window.cpp
@@ -374,9 +374,9 @@ void WIN32Window::internalCreateGLContext()
 
     if (eglGetPlatformDisplayEXT) {
         const std::array<std::pair<const char*, size_t>, 5> rendererOptions = {{
-            {"-vulkan", 0},
             {"-dx11", 1},
             {"-dx9", 2},
+            {"-vulkan", 0},
             {"-warp", 3},
             {"-opengl", 4},
         }};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,12 +55,11 @@ void applyConfiguredRenderer(std::vector<std::string>& args)
 
     Config startupConfig;
     if (!startupConfig.load("/config.otml") || !startupConfig.exists("engine")) {
-        args.emplace_back("-dx11");
         return;
     }
 
     const std::string configuredEngine = startupConfig.getValue("engine");
-    int engine = 2;
+    int engine = 0;
     try {
         size_t parsedCharacters = 0;
         int parsed = std::stoi(configuredEngine, &parsedCharacters);
@@ -68,19 +67,18 @@ void applyConfiguredRenderer(std::vector<std::string>& args)
             throw std::invalid_argument("trailing characters");
         engine = parsed;
     } catch (const std::exception&) {
-        engine = 2;
-        g_logger.warning(stdext::format("Invalid graphics engine value '%s'; using DirectX 11.", configuredEngine));
+        g_logger.warning(stdext::format("Invalid graphics engine value '%s'; using automatic graphics backend.", configuredEngine));
+        return;
     }
 
     switch (engine) {
         case 1: args.emplace_back("-vulkan"); break;
-        case 2: args.emplace_back("-dx11"); break;
+        case 2: break; // automatic fallback starts with DirectX 11.
         case 3: args.emplace_back("-warp"); break;
         case 4: args.emplace_back("-dx9"); break;
         case 5: args.emplace_back("-opengl"); break;
         default:
-            g_logger.warning(stdext::format("Unknown graphics engine id %i; using DirectX 11.", engine));
-            args.emplace_back("-dx11");
+            g_logger.warning(stdext::format("Unknown graphics engine id %i; using automatic graphics backend.", engine));
             break;
     }
 #endif


### PR DESCRIPTION
## What
- Enables the UI framebuffer cache by default in the engine and client settings.
- Initializes the UI framebuffer alongside the existing map/frame framebuffer during startup.
- Keeps the cached UI framebuffer explicitly unsmoothed/pixel-perfect.
- Keeps the graphics reset preset aligned with `cacheUI = true`.
- Updates battle list refreshes so the primary battle window always updates, while hidden secondary battle windows are skipped.
- Restores the battle list interval to 100ms, matching the optimization note that rejected latency-based throttling.
- Fixes `$var-cip-font-wheel` so its `.otfont` points at an existing `Verdana Bold-11px-wheel` texture/metrics instead of a missing PNG that can fatal during `client_styles` font import.
- Bounds automatic bitmap font width scanning to the actual texture grid, preventing the ASAN/Valgrind out-of-bounds read in `BitmapFont::calculateGlyphsWidthsAutomatically`.

## Why
These changes apply the FPS optimizations described in `OTIMIZACOES_FPS.md`: reduce repeated UI rasterization work and avoid rebuilding every secondary battle list window on each battle tick without adding battle-list latency. The font fixes prevent startup/runtime crashes while importing `/fonts/*.otfont`, including the `verdana-8px-rounded_actionbar.png` case that only contains 192 glyph cells.

## Impact
- `g_app.setCacheUI(false)` / `g_app.setCacheUI(true)` still allow runtime A/B toggling.
- Existing configs are migrated once to turn `cacheUI` on, matching the new default; users can still turn it off afterward.
- The migration runs before `GameOptions:loadSettings()`, so the new default is applied in the same startup session.
- Newly opened secondary battle windows refresh on the next normal 100ms battle tick.
- All `.otfont` files under `data/fonts` now reference existing `.png` textures.
- Bitmap fonts with partial texture grids now leave missing glyphs empty instead of reading past the pixel buffer.

## Root Cause
The cache/render support was already mostly present, but `cacheUI` was still off by default in both C++ and settings. `checkCreatures` also rebuilt all battle windows, including hidden secondary windows, and the battle interval still carried an older 300ms throttle. Separately, `data/fonts/var-cip-font-wheel.otfont` referenced a missing `verdana-11px-monochrome_underline_cp1252.png` texture. The memory report was caused by the automatic glyph-width scanner assuming every non-fixed bitmap font had glyph cells through codepoint 255; `verdana-8px-rounded_actionbar.png` has 192 cells, so scanning glyph 224 started at `y = 144`, just past the image height.

## Review Follow-up
- Explicitly disables smoothing on `m_uiFramebuffer`.
- Removed the now-dead lazy `m_uiFramebuffer` creation path from `DrawSecondForeground`.
- Documents why the one-time migration forces `cacheUI = true` before settings are loaded.

## Checks
- `git diff --check`
- Static audit against `OTIMIZACOES_FPS.md`
- Checked every `data/fonts/**/*.otfont` texture reference resolves to an existing `.png`
- Checked non-fixed font texture dimensions against their `glyph-size`; found `verdana-8px-rounded_actionbar.png` has 192 cells, matching the ASAN `110592` byte buffer.
- Reviewed `ASAN verb1 (1).txt` and `valgrind_log (1).txt`; both point at `bitmapfont.cpp:376` / `BitmapFont::calculateGlyphsWidthsAutomatically`.
- Local compile not run by request; Mateus will compile locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Sistema nativo de controle de visibilidade para ícones de status e condições

* **Melhorias de Performance**
  * Cache de interface ativado por padrão para melhor desempenho de renderização
  * Otimização na atualização de criaturas em batalha

* **Correções e Aprimoramentos**
  * Sincronização melhorada da barra de ícones de status
  * Melhor tratamento de emblemas e condições especiais
  * Inicialização mais robusta do renderizador gráfico
  * Aprimoramentos no sistema de compra de impulsos de experiência

<!-- end of auto-generated comment: release notes by coderabbit.ai -->