### PR TITLE
Skills percent bar

### DIFF
--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -994,7 +994,7 @@ end
 function onMagicLevelChange(localPlayer, magiclevel, percent)
   setSkillValue('magiclevel', magiclevel + localPlayer:getMagicLoyalty())
   if percent ~= nil and type(percent) == 'number' then
-    setSkillPercent('magiclevel', (percent / 100))
+    setSkillPercent('magiclevel', percent)
   end
   onBaseMagicLevelChange(localPlayer, localPlayer:getBaseMagicLevel())
 end
@@ -1006,7 +1006,7 @@ end
 function onSkillChange(localPlayer, id, level, percent)
   setSkillValue('skillId' .. id, (level + localPlayer:getSkillLoyalty(id)))
   if percent ~= nil and type(percent) == 'number' then
-    setSkillPercent('skillId' .. id, (percent / 100))
+    setSkillPercent('skillId' .. id, percent)
   end
   onBaseSkillChange(localPlayer, id, localPlayer:getSkillBaseLevel(id))
 end

--- a/modules/game_topbar/topbar.lua
+++ b/modules/game_topbar/topbar.lua
@@ -1013,7 +1013,7 @@ end
 
 function onMagicLevelChange(localPlayer, magiclevel, percent)
     setSkillValue('Magic', magiclevel + localPlayer:getMagicLoyalty())
-    setSkillPercent('Magic', (percent / 100), tr('You have %s percent to go', convertSkillPercent(10000 - percent)))
+    setSkillPercent('Magic', percent, tr('You have %s percent to go', convertSkillPercent(10000 - percent)))
     onBaseMagicLevelChange(localPlayer, localPlayer:getBaseMagicLevel())
 end
 
@@ -1038,7 +1038,7 @@ function onSkillChange(localPlayer, id, level, percent)
     local skillName = skillNames[id]
 
     setSkillValue(skillNames[id], (level + localPlayer:getSkillLoyalty(id - 1)))
-    setSkillPercent(skillNames[id], (percent / 100), tr('You have %s percent to go', convertSkillPercent(10000 - percent)))
+    setSkillPercent(skillNames[id], percent, tr('You have %s percent to go', convertSkillPercent(10000 - percent)))
     setSkillBase(skillNames[id], level, localPlayer:getSkillBaseLevel(id - 1), localPlayer:getSkillLoyalty(id - 1))
 end
 


### PR DESCRIPTION
The skill bar used to display a percentage, but when it reached 99.00, the percentage bar disappeared. Instead of reaching 00.00 to increase a skill, it would automatically increase.

However, after editing skills.lua, it now displays a percentage with no decimals, just a whole number. This issue is also open for anyone who can figure out how to display the percentage bar with both whole numbers and decimals.

before:
<img width="272" height="150" alt="image" src="https://github.com/user-attachments/assets/44bb5076-7fe0-4c9b-9779-335ed15af549" />

after:
<img width="283" height="120" alt="image" src="https://github.com/user-attachments/assets/d9e2d621-d300-44bd-a087-5383dc6d12e6" />
<img width="1037" height="125" alt="{63BFC7F4-105C-497B-AF51-0B4C5B4B6BB4}" src="https://github.com/user-attachments/assets/dfa88adf-339b-480f-8e95-b68fea0384e3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrigido o cálculo de percentuais de habilidades e magia para refletir corretamente os valores sem reescalamento desnecessário.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->