### PR TITLE
feat: tooltip de item dirigido pelo servidor (transporte binário)

### DIFF
--- a/mods/client_settings/classes/dataset.lua
+++ b/mods/client_settings/classes/dataset.lua
@@ -17,6 +17,16 @@ return {
         end,
 	},
 
+	astraItemTooltips = {
+		value = true,
+		apply = function(value)
+            if modules.game_itemtooltip and modules.game_itemtooltip.setEnabled then
+                modules.game_itemtooltip.setEnabled(value)
+            end
+            return true
+        end,
+	},
+
 	showSecondTimestampsInConsole = {
 		value = true,
 		apply = function(value)

--- a/mods/client_settings/options/gameWindow.otui
+++ b/mods/client_settings/options/gameWindow.otui
@@ -47,6 +47,39 @@ GameWindow < Panel
     margin-right: 4
 
     SettingsCheckBox
+      id: astraItemTooltips
+      size: 12 12
+      !text: tr('Show Item Tooltips')
+      font: $var-cip-font
+      text-auto-resize: true
+      color: $var-text-cip-color
+      text-offset: 14 -2
+      anchors.left: parent.left
+      anchors.top: parent.top
+      margin-top: 5
+      margin-left: 4
+      image-source: /images/ui/checkbox
+      image-clip: 0 0 12 12
+
+    UIWidget
+      size: 12 12
+      anchors.top: parent.top
+      anchors.right: parent.right
+      margin-right: 5
+      margin-top: 5
+      image-source: /images/skin/show-gui-help-grey
+      !tooltip: tr('Show a detailed tooltip with server-provided item data when you\nhover items in your inventory, containers or action bars.')
+
+  FlatPanel
+    size: 505 22
+    anchors.top: prev.bottom
+    anchors.right: parent.right
+    anchors.left: parent.left
+    margin-top: 5
+    margin-left: 4
+    margin-right: 4
+
+    SettingsCheckBox
       id: showMessages
       size: 12 12
       !text: tr('Show Messages')

--- a/mods/game_tooltips/item_tooltip.lua
+++ b/mods/game_tooltips/item_tooltip.lua
@@ -35,15 +35,25 @@ local tooltipHeight = BASE_HEIGHT
 local longestString = 0
 
 local Colors = {
-  Default = "#ffffff",
-  Title = "#ffffff",
-  Requirement = "#abface",
-  Description = "#8080ff",
-  Implicit = "#ffbb22",
-  Imbuement = "#44ccff",
-  Augment = "#d7a0ff",
-  Charges = "#cccccc",
-  Tier = "#dca01e"
+  Default = "#dfe6f0",     -- stats: cool light steel
+  Title = "#f4e9c8",       -- item name: warm ivory
+  Requirement = "#e0a050", -- required level / vocation: amber
+  Description = "#8a93c4", -- flavor text: soft periwinkle
+  Implicit = "#79d68a",    -- ability bonuses: soft green
+  Imbuement = "#5fc8e8",   -- imbuements: cyan
+  Augment = "#c79bf0",     -- augments: lavender
+  Charges = "#9aa6b2",     -- charges / duration / empty slots: muted slate
+  Weight = "#7e8794"       -- weight footer: dim grey
+}
+
+-- Forge tier warms up from gold to red as the tier climbs.
+local tierColors = {
+  "#e8b54a", -- 1
+  "#e8b54a", -- 2
+  "#eaa63f", -- 3
+  "#f0913a", -- 4
+  "#f37b35", -- 5
+  "#f5642f"  -- 6+
 }
 
 -- ─── helpers ────────────────────────────────────────────────────────────────
@@ -217,7 +227,10 @@ end
 -- ─── rendering ──────────────────────────────────────────────────────────────
 
 local function tierColor(tier)
-  return Colors.Tier
+  if tier and tier >= 1 then
+    return tierColors[math.min(tier, #tierColors)]
+  end
+  return tierColors[1]
 end
 
 local function formatDuration(seconds)
@@ -240,6 +253,7 @@ function buildItemTooltip(data)
   labels:destroyChildren()
 
   itemWeightLabel:setText(formatWeight(data.weight or 0))
+  itemWeightLabel:setColor(Colors.Weight)
   itemSprite:setItemId(data.clientId)
   itemSprite:setItemCount(currentItem and currentItem:getCount() or 1)
 

--- a/mods/game_tooltips/item_tooltip.lua
+++ b/mods/game_tooltips/item_tooltip.lua
@@ -1,0 +1,477 @@
+-- Astra server-authoritative item tooltip (binary ProtocolGame transport).
+--
+-- This module ONLY: detects hover, asks C++ for the tooltip, receives an already
+-- parsed data table, and draws the window. There is NO JSON and NO binary parsing
+-- in Lua — g_game.requestAstraItemTooltip() sends the request and the C++ layer
+-- raises g_game.onAstraItemTooltip(data) with the decoded payload.
+
+-- Request source types — must match AstraItemTooltip::SourceType on the server.
+local SOURCE_INVENTORY = 1
+local SOURCE_CONTAINER = 2
+local SOURCE_ACTIONBAR = 3
+local SOURCE_GENERIC = 4
+
+-- Hover dwell before we bother the server (also throttles flicking across slots).
+local HOVER_DELAY = 90
+
+local tooltipWindow = nil
+local itemSprite = nil
+local itemWeightLabel = nil
+local labels = nil
+
+local optionEnabled = true
+local currentWidget = nil
+local currentItem = nil
+local pendingRequestId = nil
+local requestCounter = 0
+local tooltipDelayEvent = nil
+
+local BASE_WIDTH = 170
+local BASE_HEIGHT = 0
+
+local tooltipWidth = 0
+local tooltipWidthBase = BASE_WIDTH
+local tooltipHeight = BASE_HEIGHT
+local longestString = 0
+
+local Colors = {
+  Default = "#ffffff",
+  Title = "#ffffff",
+  Requirement = "#abface",
+  Description = "#8080ff",
+  Implicit = "#ffbb22",
+  Imbuement = "#44ccff",
+  Augment = "#d7a0ff",
+  Charges = "#cccccc",
+  Tier = "#dca01e"
+}
+
+-- ─── helpers ────────────────────────────────────────────────────────────────
+
+local function isEnabled()
+  return optionEnabled and g_game.isOnline() and g_game.getFeature(GameAstraItemTooltip)
+end
+
+local function getTier(item)
+  if item and item.getTier then
+    return item:getTier() or 0
+  end
+  return 0
+end
+
+local function cancelDelay()
+  if tooltipDelayEvent then
+    removeEvent(tooltipDelayEvent)
+    tooltipDelayEvent = nil
+  end
+end
+
+local function hideTooltip()
+  if tooltipWindow then
+    tooltipWindow:hide()
+  end
+end
+
+-- Map a hovered widget back to (sourceType + ids). The server re-validates and
+-- cross-checks the client id, so a misclassified source is harmless (denied).
+local function resolveSource(widget, item)
+  local id = widget:getId()
+
+  -- inventory equipment slot: ids 'slot1'..'slot10' map 1:1 to CONST_SLOT_*.
+  if id then
+    local invSlot = id:match("^slot(%d+)$")
+    if invSlot then
+      invSlot = tonumber(invSlot)
+      if invSlot >= 1 and invSlot <= 10 then
+        return { type = SOURCE_INVENTORY, clientId = item:getId(), arg0 = invSlot, tier = getTier(item) }
+      end
+    end
+
+    -- container slot: ids 'item0'..'itemN' under a 'containerN' window (.instance).
+    local containerSlot = id:match("^item(%d+)$")
+    if containerSlot then
+      local parent = widget:getParent()
+      local depth = 0
+      while parent and depth < 6 do
+        if parent.instance ~= nil then
+          return { type = SOURCE_CONTAINER, clientId = item:getId(),
+                   arg0 = tonumber(parent.instance), arg1 = tonumber(containerSlot), tier = getTier(item) }
+        end
+        local pid = parent:getId()
+        if pid then
+          local cid = pid:match("^container(%d+)$")
+          if cid then
+            return { type = SOURCE_CONTAINER, clientId = item:getId(),
+                     arg0 = tonumber(cid), arg1 = tonumber(containerSlot), tier = getTier(item) }
+          end
+        end
+        parent = parent:getParent()
+        depth = depth + 1
+      end
+    end
+  end
+
+  -- everything else (actionbar buttons, market/forge previews, npc/trade slots):
+  -- static ItemType data only, keyed by the client id the widget is showing.
+  return { type = SOURCE_GENERIC, clientId = item:getId(), tier = getTier(item) }
+end
+
+-- ─── transport ──────────────────────────────────────────────────────────────
+
+local function onItemHover(widget)
+  if not isEnabled() or not widget then
+    return
+  end
+
+  local item = widget:getItem()
+  if not item then
+    return
+  end
+
+  currentWidget = widget
+  currentItem = item
+
+  cancelDelay()
+  requestCounter = (requestCounter % 250) + 1
+  local reqId = requestCounter
+  pendingRequestId = reqId
+  local capturedWidget = widget
+
+  tooltipDelayEvent = scheduleEvent(function()
+    tooltipDelayEvent = nil
+    if not isEnabled() then return end
+    if currentWidget ~= capturedWidget then return end
+    if capturedWidget:isDestroyed() then return end
+    if not g_game.isOnline() then return end
+
+    local liveItem = capturedWidget:getItem()
+    if not liveItem then return end
+
+    local source = resolveSource(capturedWidget, liveItem)
+    g_game.requestAstraItemTooltip(reqId, source.type, source.clientId,
+      source.arg0 or 0, source.arg1 or 0, source.fallbackClientId or 0, source.tier or 0)
+  end, HOVER_DELAY)
+end
+
+local function onItemUnhover(widget)
+  if currentWidget == widget then
+    currentWidget = nil
+    currentItem = nil
+    pendingRequestId = nil
+    cancelDelay()
+    hideTooltip()
+  end
+end
+
+function onHoverChange(widget, hovered)
+  if hovered then
+    onItemHover(widget)
+  else
+    onItemUnhover(widget)
+  end
+end
+
+-- C++ raises this with the fully parsed payload (see ProtocolGame::parseAstraItemTooltip).
+function onAstraItemTooltip(data)
+  if not data or data.requestId ~= pendingRequestId then
+    return -- stale / belongs to an item the mouse already left
+  end
+  if data.status ~= 0 then
+    hideTooltip()
+    return
+  end
+  if not currentWidget or currentWidget:isDestroyed() then
+    return
+  end
+
+  local liveItem = currentWidget:getItem()
+  if not liveItem or liveItem:getId() ~= data.clientId then
+    return -- the item under the mouse changed since the request
+  end
+
+  buildItemTooltip(data)
+end
+
+function onGameEnd()
+  cancelDelay()
+  currentWidget = nil
+  currentItem = nil
+  pendingRequestId = nil
+  hideTooltip()
+end
+
+-- ─── option (game options checkbox) ─────────────────────────────────────────
+
+function setEnabled(value)
+  optionEnabled = value
+  if not value then
+    cancelDelay()
+    hideTooltip()
+  end
+end
+
+function isOptionEnabled()
+  return optionEnabled
+end
+
+-- ─── rendering ──────────────────────────────────────────────────────────────
+
+local function tierColor(tier)
+  return Colors.Tier
+end
+
+local function formatDuration(seconds)
+  local h = math.floor(seconds / 3600)
+  local m = math.floor((seconds % 3600) / 60)
+  local s = seconds % 60
+  if h > 0 then return string.format("%dh %02dm", h, m) end
+  if m > 0 then return string.format("%dm %02ds", m, s) end
+  return string.format("%ds", s)
+end
+
+function buildItemTooltip(data)
+  tooltipWidth = 0
+  longestString = 0
+  tooltipWidthBase = BASE_WIDTH
+  tooltipHeight = BASE_HEIGHT
+  tooltipWindow:setWidth(tooltipWidth)
+  tooltipWindow:setHeight(tooltipHeight)
+
+  labels:destroyChildren()
+
+  itemWeightLabel:setText(formatWeight(data.weight or 0))
+  itemSprite:setItemId(data.clientId)
+  itemSprite:setItemCount(currentItem and currentItem:getCount() or 1)
+
+  -- Title (+ forge tier).
+  local title = data.name or ""
+  if data.tier and data.tier > 0 then
+    title = title .. " (Tier " .. data.tier .. ")"
+    addString(title, tierColor(data.tier))
+  else
+    addString(title, Colors.Title)
+  end
+
+  -- Requirements.
+  if data.requiredLevel and data.requiredLevel > 0 then
+    addString("Required Level " .. data.requiredLevel, Colors.Requirement)
+  end
+  if data.requiredMagicLevel and data.requiredMagicLevel > 0 then
+    addString("Required Magic Level " .. data.requiredMagicLevel, Colors.Requirement)
+  end
+  if data.vocation and #data.vocation > 0 then
+    addString(data.vocation, Colors.Requirement)
+  end
+
+  -- Combat / defensive stats.
+  local statLines = {}
+  local function stat(label, value, suffix)
+    if value and value ~= 0 then
+      table.insert(statLines, label .. ": " .. (value > 0 and "" or "") .. value .. (suffix or ""))
+    end
+  end
+  if data.isWeapon then
+    stat("Attack", data.attack)
+    stat("Defense", data.defense)
+    stat("Extra Defense", data.extraDefense)
+    stat("Hit Chance", data.hitChance, "%")
+    if data.shootRange and data.shootRange > 1 then
+      stat("Range", data.shootRange)
+    end
+  else
+    stat("Armor", data.armor)
+    stat("Defense", data.defense)
+    stat("Extra Defense", data.extraDefense)
+  end
+  if #statLines > 0 then
+    addSeparator()
+    addEmpty(5)
+    for _, line in ipairs(statLines) do
+      addString(line, Colors.Default)
+    end
+  end
+
+  -- Implicit ability lines (pre-formatted by the server).
+  if data.implicits and #data.implicits > 0 then
+    addSeparator()
+    addEmpty(5)
+    for _, line in ipairs(data.implicits) do
+      addString(line, Colors.Implicit)
+    end
+  end
+
+  -- Imbuements.
+  if data.imbuementSlots and data.imbuementSlots > 0 then
+    addSeparator()
+    addEmpty(5)
+    local applied = data.imbuements or {}
+    addString("Imbuements (" .. #applied .. "/" .. data.imbuementSlots .. ")", Colors.Imbuement)
+    for _, imb in ipairs(applied) do
+      local line = "- " .. imb.name
+      if imb.duration and imb.duration > 0 then
+        line = line .. " (" .. formatDuration(imb.duration) .. ")"
+      end
+      addString(line, Colors.Imbuement)
+    end
+    for _ = #applied + 1, data.imbuementSlots do
+      addString("- Empty Slot", Colors.Charges)
+    end
+  end
+
+  -- Augments.
+  if data.augments and #data.augments > 0 then
+    addSeparator()
+    addEmpty(5)
+    addString("Augments", Colors.Augment)
+    for _, line in ipairs(data.augments) do
+      addString(line, Colors.Augment)
+    end
+  end
+
+  -- Charges / duration / container capacity.
+  local extra = {}
+  if data.charges then
+    table.insert(extra, { "Charges: " .. data.charges, Colors.Charges })
+  end
+  if data.duration then
+    local text = "Duration: " .. formatDuration(data.duration)
+    if data.durationPaused then
+      text = text .. " (paused)"
+    end
+    table.insert(extra, { text, Colors.Charges })
+  end
+  if data.isContainer and data.containerCapacity then
+    table.insert(extra, { "Capacity: " .. data.containerCapacity, Colors.Charges })
+  end
+  if #extra > 0 then
+    addSeparator()
+    addEmpty(5)
+    for _, e in ipairs(extra) do
+      addString(e[1], e[2])
+    end
+  end
+
+  -- Flavor description.
+  if data.description and #data.description > 0 then
+    addEmpty(5)
+    addString(data.description, Colors.Description, true)
+  end
+
+  shrinkSeparators()
+  showItemTooltip()
+end
+
+function addString(text, color, resize)
+  local label = g_ui.createWidget("TooltipLabel", labels)
+  label:setColor(color)
+
+  if resize then
+    tooltipWindow:setWidth(tooltipWidth)
+    label:setTextWrap(true)
+    label:setTextAutoResize(true)
+    label:setText(text)
+    tooltipHeight = tooltipHeight + label:getTextSize().height + 4
+  else
+    label:setText(text)
+    local textSize = label:getTextSize()
+    if longestString == 0 then
+      longestString = textSize.width + itemWeightLabel:getWidth()
+      tooltipWidth = tooltipWidthBase + longestString
+      label:addAnchor(AnchorTop, "parent", AnchorTop)
+    elseif textSize.width > longestString then
+      longestString = textSize.width
+      tooltipWidth = tooltipWidthBase + longestString
+    end
+    tooltipHeight = tooltipHeight + textSize.height
+  end
+end
+
+function shrinkSeparators()
+  local children = labels:getChildren()
+  local m = math.max(60, math.floor(tooltipWidth / 4))
+  for _, child in ipairs(children) do
+    if child:getStyleName() == "TooltipSeparator" then
+      child:setMarginLeft(m)
+      child:setMarginRight(m)
+    end
+  end
+end
+
+function addSeparator()
+  local sep = g_ui.createWidget("TooltipSeparator", labels)
+  tooltipHeight = tooltipHeight + sep:getHeight() + sep:getMarginTop() + sep:getMarginBottom()
+end
+
+function addEmpty(height)
+  local empty = g_ui.createWidget("TooltipEmpty", labels)
+  empty:setHeight(height)
+  tooltipHeight = tooltipHeight + height
+end
+
+function showItemTooltip()
+  local mousePos = g_window.getMousePosition()
+  tooltipHeight = math.max(tooltipHeight, 40)
+  tooltipWindow:setWidth(tooltipWidth)
+  tooltipWindow:setHeight(tooltipHeight)
+
+  local windowSize = g_window.getSize()
+  if mousePos.x > windowSize.width / 2 then
+    tooltipWindow:move(mousePos.x - (tooltipWidth + 2), math.min(windowSize.height - tooltipHeight, mousePos.y + 5))
+  else
+    tooltipWindow:move(mousePos.x + 5, mousePos.y + 10)
+  end
+  tooltipWindow:raise()
+  tooltipWindow:show()
+  g_effects.fadeIn(tooltipWindow, 100)
+end
+
+function formatWeight(weight)
+  local ss
+  if weight < 10 then
+    ss = "0.0" .. weight
+  elseif weight < 100 then
+    ss = "0." .. weight
+  else
+    local weightString = tostring(weight)
+    local len = weightString:len()
+    ss = weightString:sub(1, len - 2) .. "." .. weightString:sub(len - 1, len)
+  end
+  return ss .. " oz."
+end
+
+-- ─── lifecycle ──────────────────────────────────────────────────────────────
+
+function init()
+  -- Register the default so the value is correct regardless of module load order.
+  g_settings.setDefault("astraItemTooltips", true)
+  optionEnabled = g_settings.getBoolean("astraItemTooltips")
+
+  connect(UIItem, { onHoverChange = onHoverChange })
+  connect(g_game, { onGameEnd = onGameEnd, onAstraItemTooltip = onAstraItemTooltip })
+
+  tooltipWindow = g_ui.displayUI("item_tooltip")
+  tooltipWindow:hide()
+
+  labels = tooltipWindow:getChildById("labels")
+  itemWeightLabel = tooltipWindow:getChildById("itemWeightLabel")
+  itemSprite = tooltipWindow:getChildById("itemSprite")
+end
+
+function terminate()
+  disconnect(UIItem, { onHoverChange = onHoverChange })
+  disconnect(g_game, { onGameEnd = onGameEnd, onAstraItemTooltip = onAstraItemTooltip })
+
+  cancelDelay()
+
+  currentWidget = nil
+  currentItem = nil
+  pendingRequestId = nil
+
+  if tooltipWindow then
+    itemWeightLabel = nil
+    itemSprite = nil
+    labels = nil
+    tooltipWindow:destroy()
+    tooltipWindow = nil
+  end
+end

--- a/mods/game_tooltips/item_tooltip.lua
+++ b/mods/game_tooltips/item_tooltip.lua
@@ -284,25 +284,21 @@ function buildItemTooltip(data)
     addString(data.vocation, Colors.Requirement)
   end
 
-  -- Combat / defensive stats.
+  -- Combat / defensive stats — show whatever the server marked non-zero, so an
+  -- item is never hidden just because it is neither flagged weapon nor armor.
   local statLines = {}
   local function stat(label, value, suffix)
     if value and value ~= 0 then
-      table.insert(statLines, label .. ": " .. (value > 0 and "" or "") .. value .. (suffix or ""))
+      table.insert(statLines, label .. ": " .. value .. (suffix or ""))
     end
   end
-  if data.isWeapon then
-    stat("Attack", data.attack)
-    stat("Defense", data.defense)
-    stat("Extra Defense", data.extraDefense)
-    stat("Hit Chance", data.hitChance, "%")
-    if data.shootRange and data.shootRange > 1 then
-      stat("Range", data.shootRange)
-    end
-  else
-    stat("Armor", data.armor)
-    stat("Defense", data.defense)
-    stat("Extra Defense", data.extraDefense)
+  stat("Attack", data.attack)
+  stat("Defense", data.defense)
+  stat("Extra Defense", data.extraDefense)
+  stat("Armor", data.armor)
+  stat("Hit Chance", data.hitChance, "%")
+  if data.shootRange and data.shootRange > 1 then
+    stat("Range", data.shootRange)
   end
   if #statLines > 0 then
     addSeparator()
@@ -432,6 +428,7 @@ end
 function showItemTooltip()
   local mousePos = g_window.getMousePosition()
   tooltipHeight = math.max(tooltipHeight, 40)
+  tooltipWidth = math.max(tooltipWidth, BASE_WIDTH)
   tooltipWindow:setWidth(tooltipWidth)
   tooltipWindow:setHeight(tooltipHeight)
 

--- a/mods/game_tooltips/item_tooltip.lua
+++ b/mods/game_tooltips/item_tooltip.lua
@@ -6,9 +6,10 @@
 -- raises g_game.onAstraItemTooltip(data) with the decoded payload.
 
 -- Request source types — must match AstraItemTooltip::SourceType on the server.
+-- Action bar buttons and other virtual item widgets resolve through SOURCE_GENERIC
+-- (static ItemType data), so the dedicated SOURCE_ACTIONBAR (3) is not sent here.
 local SOURCE_INVENTORY = 1
 local SOURCE_CONTAINER = 2
-local SOURCE_ACTIONBAR = 3
 local SOURCE_GENERIC = 4
 
 -- Hover dwell before we bother the server (also throttles flicking across slots).
@@ -55,6 +56,12 @@ local tierColors = {
   "#f37b35", -- 5
   "#f5642f"  -- 6+
 }
+
+-- Internal functions stay local (sandboxed module — only init/terminate/setEnabled
+-- need to be reachable by name). Forward-declared so they can reference each other
+-- regardless of definition order.
+local onHoverChange, onAstraItemTooltip, onGameEnd
+local buildItemTooltip, addString, addSeparator, addEmpty, shrinkSeparators, showItemTooltip, formatWeight
 
 -- ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -384,7 +391,7 @@ function addString(text, color, resize)
     label:setTextWrap(true)
     label:setTextAutoResize(true)
     label:setText(text)
-    tooltipHeight = tooltipHeight + label:getTextSize().height + 4
+    tooltipHeight = tooltipHeight + label:getHeight() + 4
   else
     label:setText(text)
     local textSize = label:getTextSize()
@@ -432,7 +439,7 @@ function showItemTooltip()
   if mousePos.x > windowSize.width / 2 then
     tooltipWindow:move(mousePos.x - (tooltipWidth + 2), math.min(windowSize.height - tooltipHeight, mousePos.y + 5))
   else
-    tooltipWindow:move(mousePos.x + 5, mousePos.y + 10)
+    tooltipWindow:move(mousePos.x + 5, math.min(windowSize.height - tooltipHeight, mousePos.y + 10))
   end
   tooltipWindow:raise()
   tooltipWindow:show()
@@ -440,17 +447,7 @@ function showItemTooltip()
 end
 
 function formatWeight(weight)
-  local ss
-  if weight < 10 then
-    ss = "0.0" .. weight
-  elseif weight < 100 then
-    ss = "0." .. weight
-  else
-    local weightString = tostring(weight)
-    local len = weightString:len()
-    ss = weightString:sub(1, len - 2) .. "." .. weightString:sub(len - 1, len)
-  end
-  return ss .. " oz."
+  return string.format("%.2f oz.", (weight or 0) / 100)
 end
 
 -- ─── lifecycle ──────────────────────────────────────────────────────────────

--- a/mods/game_tooltips/item_tooltip.otmod
+++ b/mods/game_tooltips/item_tooltip.otmod
@@ -1,0 +1,10 @@
+Module
+  name: game_itemtooltip
+  description: Show item info on hover
+  author: Oen
+  website: None
+  sandboxed: true
+  autoload: true
+  scripts: [ item_tooltip ]
+  @onLoad: init()
+  @onUnload: terminate()

--- a/mods/game_tooltips/item_tooltip.otui
+++ b/mods/game_tooltips/item_tooltip.otui
@@ -1,0 +1,45 @@
+TooltipLabel < Label
+  anchors.top: prev.bottom
+  anchors.left: parent.left
+  anchors.right: parent.right
+  font: verdana-11px-rounded
+  text-align: center
+
+TooltipSeparator < HorizontalSeparator
+  anchors.top: prev.bottom
+  anchors.left: parent.left
+  anchors.right: parent.right
+  margin-top: 3
+
+TooltipEmpty < UIWidget
+  anchors.top: prev.bottom
+  anchors.left: parent.left
+  anchors.right: parent.right
+
+FlatPanel
+  Label
+    id: itemWeightLabel
+    font: verdana-11px-rounded
+    anchors.top: parent.top
+    anchors.left: parent.left
+    text-auto-resize: true
+    margin-top: 5
+    margin-left: 5
+    
+  UIItem
+    id: itemSprite
+    font: verdana-11px-rounded
+    virtual: true
+    anchors.top: parent.top
+    anchors.right: parent.right
+    size: 32 32
+    margin-top: 5
+    margin-right: 5
+
+  Panel
+    id: labels
+    anchors.fill: parent
+    margin-top: 5
+    margin-bottom: 5
+    margin-left: 37
+    margin-right: 37

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -501,8 +501,9 @@ namespace Otc
         GamePlayerFamiliars = 138,
         GameDisplayItemCharges = 139,
         GamePackedPlayerInventory = 140,
+        GameAstraItemTooltip = 141,
 
-        LastGameFeature = 141
+        LastGameFeature = 142
     };
 
     enum PathFindResult {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1585,6 +1585,16 @@ void Game::requestItemInfo(const ItemPtr& item, int index)
     m_protocolGame->sendRequestItemInfo(item->getId(), item->getSubType(), index);
 }
 
+void Game::requestAstraItemTooltip(int requestId, int sourceType, int clientId, int arg0, int arg1, int fallbackClientId, int tier)
+{
+    if(!canPerformGameAction())
+        return;
+    // Hard gate: never speak the protocol unless the server announced the feature.
+    if(!getFeature(Otc::GameAstraItemTooltip))
+        return;
+    m_protocolGame->sendAstraItemTooltipRequest(requestId, sourceType, clientId, arg0, arg1, fallbackClientId, tier);
+}
+
 void Game::answerModalDialog(uint32 dialog, int button, int choice)
 {
     if(!canPerformGameAction())

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -304,6 +304,10 @@ public:
     // 910 only
     void requestItemInfo(const ItemPtr& item, int index);
 
+    // Astra server-authoritative item tooltip. Only sent when the server
+    // announced GameAstraItemTooltip; otherwise this is a no-op.
+    void requestAstraItemTooltip(int requestId, int sourceType, int clientId, int arg0, int arg1, int fallbackClientId, int tier);
+
     // >= 970 modal dialog
     void answerModalDialog(uint32 dialog, int button, int choice);
 

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -303,6 +303,7 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_game", "mount", &Game::mount, &g_game);
     g_lua.bindSingletonFunction("g_game", "setOutfitExtensions", &Game::setOutfitExtensions, &g_game);
     g_lua.bindSingletonFunction("g_game", "requestItemInfo", &Game::requestItemInfo, &g_game);
+    g_lua.bindSingletonFunction("g_game", "requestAstraItemTooltip", &Game::requestAstraItemTooltip, &g_game);
     g_lua.bindSingletonFunction("g_game", "ping", &Game::ping, &g_game);
     g_lua.bindSingletonFunction("g_game", "setPingDelay", &Game::setPingDelay, &g_game);
     g_lua.bindSingletonFunction("g_game", "enableTimerInventory", &Game::enableTimerInventory, &g_game);

--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -68,6 +68,9 @@ namespace Proto {
 
         // otclient ONLY
         GameServerExtendedOpcode            = 50,
+        // Astra binary item tooltip response (0x36). Keep in sync with the server's
+        // AstraItemTooltip::ServerOpcodeResponse.
+        GameServerAstraItemTooltipResponse  = 54,
         GameServerProgressBar               = 59,
 
         // NOTE: add any custom opcodes in this range
@@ -248,6 +251,10 @@ namespace Proto {
 
         // otclient ONLY
         ClientExtendedOpcode                = 50,
+
+        // Astra binary item tooltip request (0x35). Keep in sync with the server's
+        // AstraItemTooltip::ClientOpcodeRequest.
+        ClientAstraItemTooltipRequest       = 53,
 
         // NOTE: add any custom opcodes in this range
 

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -126,6 +126,9 @@ public:
     void sendRequestQuestLine(int questId);
     void sendNewNewRuleViolation(int reason, int action, const std::string& characterName, const std::string& comment, const std::string& translation);
     void sendRequestItemInfo(int itemId, int subType, int index);
+    // Astra binary item tooltip request. Fields are interpreted per sourceType
+    // (see astraitemtooltip.h on the server); arg0/arg1 carry the source-specific ids.
+    void sendAstraItemTooltipRequest(int requestId, int sourceType, int clientId, int arg0, int arg1, int fallbackClientId, int tier);
     void sendAnswerModalDialog(uint32 dialog, int button, int choice);
     void sendBrowseField(const Position& position);
     void sendSeekInContainer(int cid, int index);
@@ -337,6 +340,7 @@ private:
     void parseChangeMapAwareRange(const InputMessagePtr& msg);
     void parseProgressBar(const InputMessagePtr& msg);
     void parseFeatures(const InputMessagePtr& msg);
+    void parseAstraItemTooltip(const InputMessagePtr& msg);
     void parseCreaturesMark(const InputMessagePtr& msg);
     void parseNewCancelWalk(const InputMessagePtr& msg);
     void parsePredictiveCancelWalk(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4296,6 +4296,9 @@ void ProtocolGame::parseAstraItemTooltip(const InputMessagePtr& msg)
     // mismatch can never unbalance the Lua stack. The u16 length prefix then lets
     // us re-align the stream unconditionally — this is the anti-desync guarantee.
     const uint16 payloadSize = msg->getU16();
+    if (payloadSize > msg->getUnreadSize()) {
+        stdext::throw_exception("AstraItemTooltip payload size exceeds packet size");
+    }
     const int payloadStart = msg->getReadPos();
 
     const uint16 clientId = msg->getU16();
@@ -4381,8 +4384,15 @@ void ProtocolGame::parseAstraItemTooltip(const InputMessagePtr& msg)
         containerCapacity = msg->getU16();
     }
 
-    // Re-align to the declared payload end no matter what we parsed above.
+    // Sections must fit inside the declared payload. If the flags claimed more
+    // than payloadSize covers, we may have read into following packets, so drop
+    // this tooltip. We re-align to the declared end first either way, so later
+    // packets stay intact — no desync.
+    const bool overran = (msg->getReadPos() - payloadStart) > static_cast<int>(payloadSize);
     msg->setReadPos(payloadStart + payloadSize);
+    if (overran) {
+        return;
+    }
 
     g_lua.getGlobalField("g_game", "onAstraItemTooltip");
     if (g_lua.isNil()) {

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -668,6 +668,9 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
             case Proto::GameServerFeatures:
                 parseFeatures(msg);
                 break;
+            case Proto::GameServerAstraItemTooltipResponse:
+                parseAstraItemTooltip(msg);
+                break;
             case Proto::GameServerNewCancelWalk:
                 if (g_game.getFeature(Otc::GameNewWalking))
                     parseNewCancelWalk(msg);
@@ -4251,6 +4254,216 @@ void ProtocolGame::parseFeatures(const InputMessagePtr& msg)
         } else {
             g_game.disableFeature(feature);
         }
+    }
+}
+
+void ProtocolGame::parseAstraItemTooltip(const InputMessagePtr& msg)
+{
+    // Section flags — must mirror AstraItemTooltip::Flags on the server.
+    static const uint32 FLAG_HAS_INSTANCE_DATA = 1u << 0;
+    static const uint32 FLAG_HAS_STATS = 1u << 1;
+    static const uint32 FLAG_HAS_REQUIREMENTS = 1u << 2;
+    static const uint32 FLAG_HAS_IMBUEMENTS = 1u << 3;
+    static const uint32 FLAG_HAS_AUGMENTS = 1u << 4;
+    static const uint32 FLAG_HAS_IMPLICITS = 1u << 5;
+    static const uint32 FLAG_HAS_CHARGES = 1u << 6;
+    static const uint32 FLAG_HAS_DURATION = 1u << 7;
+    static const uint32 FLAG_IS_CONTAINER = 1u << 8;
+    static const uint32 FLAG_IS_WEAPON = 1u << 9;
+    static const uint32 FLAG_IS_ARMOR = 1u << 10;
+
+    const uint8 requestId = msg->getU8();
+    const uint8 status = msg->getU8();
+
+    // Error / no-payload response: tell Lua so it can clear its pending state.
+    if (status != 0) {
+        g_lua.getGlobalField("g_game", "onAstraItemTooltip");
+        if (g_lua.isNil()) {
+            g_lua.pop(1);
+            return;
+        }
+        g_lua.createTable(0, 2);
+        g_lua.pushInteger(requestId); g_lua.setField("requestId");
+        g_lua.pushInteger(status);    g_lua.setField("status");
+        const int rets = g_lua.signalCall(1);
+        if (rets > 0) {
+            g_lua.pop(rets);
+        }
+        return;
+    }
+
+    // Read the ENTIRE payload into locals first (no Lua stack ops yet) so a parse
+    // mismatch can never unbalance the Lua stack. The u16 length prefix then lets
+    // us re-align the stream unconditionally — this is the anti-desync guarantee.
+    const uint16 payloadSize = msg->getU16();
+    const int payloadStart = msg->getReadPos();
+
+    const uint16 clientId = msg->getU16();
+    const uint16 serverId = msg->getU16();
+    const uint8 sourceType = msg->getU8();
+    const uint32 flags = msg->getU32();
+    const std::string itemName = msg->getString();
+    const std::string description = msg->getString();
+    const uint32 weight = msg->getU32();
+    const uint8 category = msg->getU8();
+    const uint8 weaponType = msg->getU8();
+    const uint8 classification = msg->getU8();
+    const uint8 tier = msg->getU8();
+
+    int32 attack = 0, defense = 0, extraDefense = 0, armor = 0, hitChance = 0, shootRange = 0;
+    if (flags & FLAG_HAS_STATS) {
+        attack = static_cast<int32>(msg->getU32());
+        defense = static_cast<int32>(msg->getU32());
+        extraDefense = static_cast<int32>(msg->getU32());
+        armor = static_cast<int32>(msg->getU32());
+        hitChance = static_cast<int32>(msg->getU32());
+        shootRange = static_cast<int32>(msg->getU32());
+    }
+
+    uint16 requiredLevel = 0, requiredMagicLevel = 0;
+    std::string vocation;
+    if (flags & FLAG_HAS_REQUIREMENTS) {
+        requiredLevel = msg->getU16();
+        requiredMagicLevel = msg->getU16();
+        vocation = msg->getString();
+    }
+
+    uint8 imbuementSlots = 0;
+    std::vector<std::tuple<std::string, uint32, uint8>> imbuements;
+    if (flags & FLAG_HAS_IMBUEMENTS) {
+        imbuementSlots = msg->getU8();
+        const uint8 appliedCount = msg->getU8();
+        imbuements.reserve(appliedCount);
+        for (uint8 i = 0; i < appliedCount; ++i) {
+            const std::string name = msg->getString();
+            const uint32 imbDuration = msg->getU32();
+            const uint8 imbuementTier = msg->getU8();
+            imbuements.emplace_back(name, imbDuration, imbuementTier);
+        }
+    }
+
+    std::vector<std::string> augments;
+    if (flags & FLAG_HAS_AUGMENTS) {
+        const uint8 count = msg->getU8();
+        augments.reserve(count);
+        for (uint8 i = 0; i < count; ++i) {
+            augments.push_back(msg->getString());
+        }
+    }
+
+    std::vector<std::string> implicits;
+    if (flags & FLAG_HAS_IMPLICITS) {
+        const uint8 count = msg->getU8();
+        implicits.reserve(count);
+        for (uint8 i = 0; i < count; ++i) {
+            implicits.push_back(msg->getString());
+        }
+    }
+
+    uint32 charges = 0;
+    bool hasCharges = false;
+    if (flags & FLAG_HAS_CHARGES) {
+        charges = msg->getU32();
+        hasCharges = true;
+    }
+
+    uint32 duration = 0;
+    bool durationPaused = false;
+    bool hasDuration = false;
+    if (flags & FLAG_HAS_DURATION) {
+        duration = msg->getU32();
+        durationPaused = msg->getU8() != 0;
+        hasDuration = true;
+    }
+
+    uint16 containerCapacity = 0;
+    if (flags & FLAG_IS_CONTAINER) {
+        containerCapacity = msg->getU16();
+    }
+
+    // Re-align to the declared payload end no matter what we parsed above.
+    msg->setReadPos(payloadStart + payloadSize);
+
+    g_lua.getGlobalField("g_game", "onAstraItemTooltip");
+    if (g_lua.isNil()) {
+        g_lua.pop(1);
+        return;
+    }
+
+    g_lua.createTable(0, 28);
+    g_lua.pushInteger(requestId);       g_lua.setField("requestId");
+    g_lua.pushInteger(status);          g_lua.setField("status");
+    g_lua.pushInteger(clientId);        g_lua.setField("clientId");
+    g_lua.pushInteger(serverId);        g_lua.setField("serverId");
+    g_lua.pushInteger(sourceType);      g_lua.setField("sourceType");
+    g_lua.pushInteger(flags);           g_lua.setField("flags");
+    g_lua.pushString(itemName);         g_lua.setField("name");
+    g_lua.pushString(description);      g_lua.setField("description");
+    g_lua.pushInteger(weight);          g_lua.setField("weight");
+    g_lua.pushInteger(category);        g_lua.setField("category");
+    g_lua.pushInteger(weaponType);      g_lua.setField("weaponType");
+    g_lua.pushInteger(classification);  g_lua.setField("classification");
+    g_lua.pushInteger(tier);            g_lua.setField("tier");
+    g_lua.pushBoolean((flags & FLAG_HAS_INSTANCE_DATA) != 0); g_lua.setField("hasInstanceData");
+    g_lua.pushBoolean((flags & FLAG_IS_CONTAINER) != 0);      g_lua.setField("isContainer");
+    g_lua.pushBoolean((flags & FLAG_IS_WEAPON) != 0);         g_lua.setField("isWeapon");
+    g_lua.pushBoolean((flags & FLAG_IS_ARMOR) != 0);          g_lua.setField("isArmor");
+
+    if (flags & FLAG_HAS_STATS) {
+        g_lua.pushInteger(attack);       g_lua.setField("attack");
+        g_lua.pushInteger(defense);      g_lua.setField("defense");
+        g_lua.pushInteger(extraDefense); g_lua.setField("extraDefense");
+        g_lua.pushInteger(armor);        g_lua.setField("armor");
+        g_lua.pushInteger(hitChance);    g_lua.setField("hitChance");
+        g_lua.pushInteger(shootRange);   g_lua.setField("shootRange");
+    }
+    if (flags & FLAG_HAS_REQUIREMENTS) {
+        g_lua.pushInteger(requiredLevel);      g_lua.setField("requiredLevel");
+        g_lua.pushInteger(requiredMagicLevel); g_lua.setField("requiredMagicLevel");
+        g_lua.pushString(vocation);            g_lua.setField("vocation");
+    }
+    if (flags & FLAG_HAS_IMBUEMENTS) {
+        g_lua.pushInteger(imbuementSlots); g_lua.setField("imbuementSlots");
+        g_lua.createTable(static_cast<int>(imbuements.size()), 0);
+        for (size_t i = 0; i < imbuements.size(); ++i) {
+            g_lua.createTable(0, 3);
+            g_lua.pushString(std::get<0>(imbuements[i]));  g_lua.setField("name");
+            g_lua.pushInteger(std::get<1>(imbuements[i])); g_lua.setField("duration");
+            g_lua.pushInteger(std::get<2>(imbuements[i])); g_lua.setField("tier");
+            g_lua.rawSeti(static_cast<int>(i + 1));
+        }
+        g_lua.setField("imbuements");
+    }
+    if (!augments.empty()) {
+        g_lua.createTable(static_cast<int>(augments.size()), 0);
+        for (size_t i = 0; i < augments.size(); ++i) {
+            g_lua.pushString(augments[i]);
+            g_lua.rawSeti(static_cast<int>(i + 1));
+        }
+        g_lua.setField("augments");
+    }
+    if (!implicits.empty()) {
+        g_lua.createTable(static_cast<int>(implicits.size()), 0);
+        for (size_t i = 0; i < implicits.size(); ++i) {
+            g_lua.pushString(implicits[i]);
+            g_lua.rawSeti(static_cast<int>(i + 1));
+        }
+        g_lua.setField("implicits");
+    }
+    if (hasCharges) {
+        g_lua.pushInteger(charges); g_lua.setField("charges");
+    }
+    if (hasDuration) {
+        g_lua.pushInteger(duration);       g_lua.setField("duration");
+        g_lua.pushBoolean(durationPaused); g_lua.setField("durationPaused");
+    }
+    if (flags & FLAG_IS_CONTAINER) {
+        g_lua.pushInteger(containerCapacity); g_lua.setField("containerCapacity");
+    }
+
+    const int rets = g_lua.signalCall(1);
+    if (rets > 0) {
+        g_lua.pop(rets);
     }
 }
 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4292,106 +4292,97 @@ void ProtocolGame::parseAstraItemTooltip(const InputMessagePtr& msg)
         return;
     }
 
-    // Read the ENTIRE payload into locals first (no Lua stack ops yet) so a parse
-    // mismatch can never unbalance the Lua stack. The u16 length prefix then lets
-    // us re-align the stream unconditionally — this is the anti-desync guarantee.
+    // Copy the declared payload out of the main stream into a private message.
+    // Reading exactly payloadSize bytes here advances the main stream by that
+    // amount (so the rest of the packet always stays aligned), and every field
+    // is then read from the private buffer — a malformed payload throws only on
+    // that buffer, never desyncing the connection. No throw on the main stream.
     const uint16 payloadSize = msg->getU16();
-    if (payloadSize > msg->getUnreadSize()) {
-        stdext::throw_exception("AstraItemTooltip payload size exceeds packet size");
+    if (payloadSize > static_cast<uint32>(msg->getUnreadSize())) {
+        return; // corrupt length prefix: cannot realign safely, drop gracefully
     }
-    const int payloadStart = msg->getReadPos();
 
-    const uint16 clientId = msg->getU16();
-    const uint16 serverId = msg->getU16();
-    const uint8 sourceType = msg->getU8();
-    const uint32 flags = msg->getU32();
-    const std::string itemName = msg->getString();
-    const std::string description = msg->getString();
-    const uint32 weight = msg->getU32();
-    const uint8 category = msg->getU8();
-    const uint8 weaponType = msg->getU8();
-    const uint8 classification = msg->getU8();
-    const uint8 tier = msg->getU8();
+    std::string payloadBytes(payloadSize, '\0');
+    for (uint16 i = 0; i < payloadSize; ++i) {
+        payloadBytes[i] = static_cast<char>(msg->getU8());
+    }
+    const auto payload = std::make_shared<InputMessage>();
+    payload->setBuffer(payloadBytes);
 
+    uint16 clientId = 0, serverId = 0, requiredLevel = 0, requiredMagicLevel = 0, containerCapacity = 0;
+    uint8 sourceType = 0, category = 0, weaponType = 0, classification = 0, tier = 0, imbuementSlots = 0;
+    uint32 flags = 0, weight = 0, charges = 0, duration = 0;
+    bool hasCharges = false, hasDuration = false, durationPaused = false;
     int32 attack = 0, defense = 0, extraDefense = 0, armor = 0, hitChance = 0, shootRange = 0;
-    if (flags & FLAG_HAS_STATS) {
-        attack = static_cast<int32>(msg->getU32());
-        defense = static_cast<int32>(msg->getU32());
-        extraDefense = static_cast<int32>(msg->getU32());
-        armor = static_cast<int32>(msg->getU32());
-        hitChance = static_cast<int32>(msg->getU32());
-        shootRange = static_cast<int32>(msg->getU32());
-    }
-
-    uint16 requiredLevel = 0, requiredMagicLevel = 0;
-    std::string vocation;
-    if (flags & FLAG_HAS_REQUIREMENTS) {
-        requiredLevel = msg->getU16();
-        requiredMagicLevel = msg->getU16();
-        vocation = msg->getString();
-    }
-
-    uint8 imbuementSlots = 0;
+    std::string itemName, description, vocation;
     std::vector<std::tuple<std::string, uint32, uint8>> imbuements;
-    if (flags & FLAG_HAS_IMBUEMENTS) {
-        imbuementSlots = msg->getU8();
-        const uint8 appliedCount = msg->getU8();
-        imbuements.reserve(appliedCount);
-        for (uint8 i = 0; i < appliedCount; ++i) {
-            const std::string name = msg->getString();
-            const uint32 imbDuration = msg->getU32();
-            const uint8 imbuementTier = msg->getU8();
-            imbuements.emplace_back(name, imbDuration, imbuementTier);
+    std::vector<std::string> augments, implicits;
+
+    try {
+        clientId = payload->getU16();
+        serverId = payload->getU16();
+        sourceType = payload->getU8();
+        flags = payload->getU32();
+        itemName = payload->getString();
+        description = payload->getString();
+        weight = payload->getU32();
+        category = payload->getU8();
+        weaponType = payload->getU8();
+        classification = payload->getU8();
+        tier = payload->getU8();
+
+        if (flags & FLAG_HAS_STATS) {
+            attack = static_cast<int32>(payload->getU32());
+            defense = static_cast<int32>(payload->getU32());
+            extraDefense = static_cast<int32>(payload->getU32());
+            armor = static_cast<int32>(payload->getU32());
+            hitChance = static_cast<int32>(payload->getU32());
+            shootRange = static_cast<int32>(payload->getU32());
         }
-    }
-
-    std::vector<std::string> augments;
-    if (flags & FLAG_HAS_AUGMENTS) {
-        const uint8 count = msg->getU8();
-        augments.reserve(count);
-        for (uint8 i = 0; i < count; ++i) {
-            augments.push_back(msg->getString());
+        if (flags & FLAG_HAS_REQUIREMENTS) {
+            requiredLevel = payload->getU16();
+            requiredMagicLevel = payload->getU16();
+            vocation = payload->getString();
         }
-    }
-
-    std::vector<std::string> implicits;
-    if (flags & FLAG_HAS_IMPLICITS) {
-        const uint8 count = msg->getU8();
-        implicits.reserve(count);
-        for (uint8 i = 0; i < count; ++i) {
-            implicits.push_back(msg->getString());
+        if (flags & FLAG_HAS_IMBUEMENTS) {
+            imbuementSlots = payload->getU8();
+            const uint8 appliedCount = payload->getU8();
+            imbuements.reserve(appliedCount);
+            for (uint8 i = 0; i < appliedCount; ++i) {
+                const std::string name = payload->getString();
+                const uint32 imbDuration = payload->getU32();
+                const uint8 imbuementTier = payload->getU8();
+                imbuements.emplace_back(name, imbDuration, imbuementTier);
+            }
         }
-    }
-
-    uint32 charges = 0;
-    bool hasCharges = false;
-    if (flags & FLAG_HAS_CHARGES) {
-        charges = msg->getU32();
-        hasCharges = true;
-    }
-
-    uint32 duration = 0;
-    bool durationPaused = false;
-    bool hasDuration = false;
-    if (flags & FLAG_HAS_DURATION) {
-        duration = msg->getU32();
-        durationPaused = msg->getU8() != 0;
-        hasDuration = true;
-    }
-
-    uint16 containerCapacity = 0;
-    if (flags & FLAG_IS_CONTAINER) {
-        containerCapacity = msg->getU16();
-    }
-
-    // Sections must fit inside the declared payload. If the flags claimed more
-    // than payloadSize covers, we may have read into following packets, so drop
-    // this tooltip. We re-align to the declared end first either way, so later
-    // packets stay intact — no desync.
-    const bool overran = (msg->getReadPos() - payloadStart) > static_cast<int>(payloadSize);
-    msg->setReadPos(payloadStart + payloadSize);
-    if (overran) {
-        return;
+        if (flags & FLAG_HAS_AUGMENTS) {
+            const uint8 count = payload->getU8();
+            augments.reserve(count);
+            for (uint8 i = 0; i < count; ++i) {
+                augments.push_back(payload->getString());
+            }
+        }
+        if (flags & FLAG_HAS_IMPLICITS) {
+            const uint8 count = payload->getU8();
+            implicits.reserve(count);
+            for (uint8 i = 0; i < count; ++i) {
+                implicits.push_back(payload->getString());
+            }
+        }
+        if (flags & FLAG_HAS_CHARGES) {
+            charges = payload->getU32();
+            hasCharges = true;
+        }
+        if (flags & FLAG_HAS_DURATION) {
+            duration = payload->getU32();
+            durationPaused = payload->getU8() != 0;
+            hasDuration = true;
+        }
+        if (flags & FLAG_IS_CONTAINER) {
+            containerCapacity = payload->getU16();
+        }
+    } catch (const stdext::exception&) {
+        return; // malformed payload; main stream already aligned, so just drop it
     }
 
     g_lua.getGlobalField("g_game", "onAstraItemTooltip");

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -1196,6 +1196,39 @@ void ProtocolGame::sendRequestItemInfo(int itemId, int subType, int index)
     send(msg);
 }
 
+void ProtocolGame::sendAstraItemTooltipRequest(int requestId, int sourceType, int clientId, int arg0, int arg1, int fallbackClientId, int tier)
+{
+    auto msg = std::make_shared<OutputMessage>();
+    msg->addU8(Proto::ClientAstraItemTooltipRequest);
+    msg->addU8(requestId & 0xFF);
+    msg->addU8(sourceType & 0xFF);
+    msg->addU16(clientId & 0xFFFF);
+
+    // The trailing fields are source-specific and must mirror the server's
+    // ProtocolGame::parseAstraItemTooltipRequest byte-for-byte.
+    switch (sourceType) {
+        case 1: // inventory: inventorySlot
+            msg->addU8(arg0 & 0xFF);
+            break;
+        case 2: // container: containerId, slotIndex
+            msg->addU8(arg0 & 0xFF);
+            msg->addU16(arg1 & 0xFFFF);
+            break;
+        case 3: // actionbar: actionbarId, actionbarSlot, fallbackClientId, fallbackTier
+            msg->addU8(arg0 & 0xFF);
+            msg->addU8(arg1 & 0xFF);
+            msg->addU16(fallbackClientId & 0xFFFF);
+            msg->addU8(tier & 0xFF);
+            break;
+        case 4: // generic: visual tier
+            msg->addU8(tier & 0xFF);
+            break;
+        default:
+            break;
+    }
+    send(msg);
+}
+
 void ProtocolGame::sendAnswerModalDialog(uint32 dialog, int button, int choice)
 {
     auto msg = std::make_shared<OutputMessage>();


### PR DESCRIPTION
Consome o pacote binário do ProtocolGame do servidor. Sem Extended Opcode, sem JSON, sem parse binário em Lua: o C++ lê os bytes e entrega ao Lua uma tabela pronta.

## Bytes / constantes
- `ClientAstraItemTooltipRequest` (0x35) e `GameServerAstraItemTooltipResponse` (0x36) em `src/client/protocolcodes.h`
- Feature `GameAstraItemTooltip = 141` (`src/client/const.h`, `LastGameFeature`→142)

## Fluxo
- `Game::requestAstraItemTooltip` só envia se a feature foi anunciada → `ProtocolGame::sendAstraItemTooltipRequest` (request binário por sourceType).
- `ProtocolGame::parseAstraItemTooltip` lê o payload (com prefixo de tamanho) para variáveis locais, re-alinha o stream (à prova de desync) e dispara `g_game.onAstraItemTooltip(data)`.

## UI (`mods/game_tooltips`)
- Hover com `requestId` + delay de 90 ms; resolução de fonte (inventory/container/actionbar/generic); descarte de resposta atrasada (requestId/widget/clientId); montagem e posicionamento da janela; limpeza completa em unhover/onGameEnd/terminate (sem leak).
- Opção em game options: checkbox "Show Item Tooltips" (`astraItemTooltips`).
- Paleta de cores refinada + gradiente de tier (dourado→laranja→vermelho).

> Não compilado localmente (toolchain vcpkg pesado). Revisado manualmente — compilar antes do merge.