### PR TITLE
Fix Task Hunt and Bounty live tracker sync

### DIFF
--- a/mods/game_prey_hunting/hunting.lua
+++ b/mods/game_prey_hunting/hunting.lua
@@ -46,7 +46,6 @@ local PREY_HUNTING_STATE_ACTIVE = 4
 local PREY_HUNTING_STATE_REDEEM = 5
 local PREY_HUNTING_BASE_OPCODE = 0xBA
 local PREY_HUNTING_DATA_OPCODE = 0xBB
-local huntingProtocolRegistered = false
 
 local DESC_TYPE = {
 	TYPE_MONSTER_LIST = 1,
@@ -63,92 +62,9 @@ local DESC_TYPE = {
 	TYPE_SLOT_REROLL = 14
 }
 
-local function parseHuntingBaseData(_, msg)
-	local monsterInfo = {}
-	local rewardData = {}
-	local monsterCount = msg:getU16()
-	for _ = 1, monsterCount do
-		monsterInfo[msg:getU16()] = msg:getU8()
-	end
-
-	local optionCount = msg:getU8()
-	for index = 1, optionCount do
-		rewardData[index] = {
-			difficulty = msg:getU8(),
-			grade = msg:getU8(),
-			nonBestiaryKills = msg:getU16(),
-			nonBestiaryReward = msg:getU16(),
-			fullBestiaryKills = msg:getU16(),
-			fullBestiaryReward = msg:getU16()
-		}
-	end
-
-	onPreyHuntingBaseData(monsterInfo, rewardData)
-	onPreyHuntingPrice(msg:getU32(), msg:getU32(), msg:getU8(), msg:getU8())
-	return true
-end
-
-local function parseHuntingData(_, msg)
-	local slot = msg:getU8()
-	local state = msg:getU8()
-	local lockType
-	local creatureList
-	local currentMonster
-	local unlocked
-	local toKill
-	local killed
-	local stars
-
-	if state == PREY_HUNTING_STATE_LOCKED then
-		lockType = msg:getU8()
-	elseif state == PREY_HUNTING_STATE_SELECT or state == PREY_HUNTING_STATE_WILDCARD then
-		creatureList = {}
-		local creatureCount = msg:getU16()
-		for _ = 1, creatureCount do
-			creatureList[msg:getU16()] = msg:getU8() ~= 0
-		end
-	elseif state == PREY_HUNTING_STATE_ACTIVE or state == PREY_HUNTING_STATE_REDEEM then
-		currentMonster = msg:getU16()
-		unlocked = msg:getU8() ~= 0
-		toKill = msg:getU16()
-		killed = msg:getU16()
-		stars = msg:getU8()
-	end
-
-	onUpdateRerrolTime(slot, msg:getU32())
-	if state == PREY_HUNTING_STATE_LOCKED then
-		onHuntingLockedState(slot, lockType, state)
-	elseif state == PREY_HUNTING_STATE_EXHAUSTED then
-		onHuntingExhaustedState(slot, state)
-	elseif state == PREY_HUNTING_STATE_SELECT then
-		onHuntingSelectState(slot, creatureList, state)
-	elseif state == PREY_HUNTING_STATE_WILDCARD then
-		onHuntingWildcardState(slot, creatureList, state)
-	elseif state == PREY_HUNTING_STATE_ACTIVE or state == PREY_HUNTING_STATE_REDEEM then
-		onHuntingActiveState(slot, currentMonster, unlocked, toKill, killed, stars, state)
-	end
-	return true
-end
-
-local function registerHuntingBaseProtocol()
-	if huntingProtocolRegistered then
-		return
-	end
-	ProtocolGame.unregisterOpcode(PREY_HUNTING_BASE_OPCODE)
-	ProtocolGame.unregisterOpcode(PREY_HUNTING_DATA_OPCODE)
-	ProtocolGame.registerOpcode(PREY_HUNTING_BASE_OPCODE, parseHuntingBaseData)
-	ProtocolGame.registerOpcode(PREY_HUNTING_DATA_OPCODE, parseHuntingData)
-	huntingProtocolRegistered = true
-end
-
-local function unregisterHuntingBaseProtocol()
-	if not huntingProtocolRegistered then
-		return
-	end
-	ProtocolGame.unregisterOpcode(PREY_HUNTING_BASE_OPCODE)
-	ProtocolGame.unregisterOpcode(PREY_HUNTING_DATA_OPCODE)
-	huntingProtocolRegistered = false
-end
+-- 0xBA/0xBB are parsed exactly once in ProtocolGame C++. Registering Lua
+-- handlers here would consume the packet before that parser and create a
+-- second source of truth for the wire format.
 
 function init()
   huntingWindow = g_ui.displayUI('hunting')
@@ -180,7 +96,6 @@ function init()
   end
 
   huntingWindow:hide()
-  registerHuntingBaseProtocol()
 end
 
 function terminate()
@@ -198,7 +113,6 @@ function terminate()
 	onHuntingExhaustedState = onHuntingExhaustedState
   })
 
-  unregisterHuntingBaseProtocol()
   g_keyboard.unbindKeyPress('Tab', onSelectPrey, huntingWindow)
 end
 

--- a/modules/game_task_hunt/classes/bounty-tasks.lua
+++ b/modules/game_task_hunt/classes/bounty-tasks.lua
@@ -205,19 +205,6 @@ function TaskBounty.onServerData(header, monsters, talisman, preferreds, availab
     -- Always update the kill tracker
     TaskBounty.updateTracker(header, monsters)
 
-    if taskHuntWindow and ResourceTypes then
-        local player = g_game.getLocalPlayer()
-        if player then
-            local bountyPanel = taskHuntWindow:recursiveGetChildById('bountyPoints')
-            if bountyPanel then
-                local label = bountyPanel:recursiveGetChildById('panelLabel')
-                if label then
-                    label:setText(comma_value(player:getResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS)))
-                end
-            end
-        end
-    end
-
     if not taskHuntWindow then return end
 
     -- Header data

--- a/modules/game_task_hunt/classes/bounty-tasks.lua
+++ b/modules/game_task_hunt/classes/bounty-tasks.lua
@@ -56,6 +56,23 @@ end
 
 local ACTION_REQUEST = 4
 
+local function syncBountyResourceLabelsFromCache()
+    if not ResourceTypes or not onResourceBalance then return end
+
+    local player = g_game.getLocalPlayer()
+    if not player then return end
+
+    onResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS,
+        player:getResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS))
+    onResourceBalance(ResourceTypes.BOUNTY_REROLL_POINTS,
+        player:getResourceBalance(ResourceTypes.BOUNTY_REROLL_POINTS))
+end
+
+function TaskBounty.syncResourceLabels()
+    syncBountyResourceLabelsFromCache()
+    scheduleEvent(syncBountyResourceLabelsFromCache, 50)
+end
+
 function TaskBounty.requestRefresh()
     g_game.bountyTaskAction(ACTION_REQUEST, 0)
 end
@@ -204,6 +221,7 @@ function TaskBounty.onServerData(header, monsters, talisman, preferreds, availab
 
     -- Always update the kill tracker
     TaskBounty.updateTracker(header, monsters)
+    TaskBounty.syncResourceLabels()
 
     if not taskHuntWindow then return end
 

--- a/modules/game_task_hunt/classes/bounty-tasks.lua
+++ b/modules/game_task_hunt/classes/bounty-tasks.lua
@@ -205,6 +205,19 @@ function TaskBounty.onServerData(header, monsters, talisman, preferreds, availab
     -- Always update the kill tracker
     TaskBounty.updateTracker(header, monsters)
 
+    if taskHuntWindow and ResourceTypes then
+        local player = g_game.getLocalPlayer()
+        if player then
+            local bountyPanel = taskHuntWindow:recursiveGetChildById('bountyPoints')
+            if bountyPanel then
+                local label = bountyPanel:recursiveGetChildById('panelLabel')
+                if label then
+                    label:setText(comma_value(player:getResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS)))
+                end
+            end
+        end
+    end
+
     if not taskHuntWindow then return end
 
     -- Header data

--- a/modules/game_task_hunt/classes/bounty-tasks.lua
+++ b/modules/game_task_hunt/classes/bounty-tasks.lua
@@ -68,17 +68,10 @@ local function syncBountyResourceLabelsFromCache()
         player:getResourceBalance(ResourceTypes.BOUNTY_REROLL_POINTS))
 end
 
-local pendingResourceSync = nil
-
 function TaskBounty.syncResourceLabels()
     syncBountyResourceLabelsFromCache()
-    if pendingResourceSync then
-        pendingResourceSync:cancel()
-    end
-    pendingResourceSync = scheduleEvent(function()
-        pendingResourceSync = nil
-        syncBountyResourceLabelsFromCache()
-    end, 50)
+    scheduleEvent(syncBountyResourceLabelsFromCache, 50)
+    scheduleEvent(syncBountyResourceLabelsFromCache, 150)
 end
 
 function TaskBounty.requestRefresh()

--- a/modules/game_task_hunt/classes/bounty-tasks.lua
+++ b/modules/game_task_hunt/classes/bounty-tasks.lua
@@ -68,9 +68,17 @@ local function syncBountyResourceLabelsFromCache()
         player:getResourceBalance(ResourceTypes.BOUNTY_REROLL_POINTS))
 end
 
+local pendingResourceSync = nil
+
 function TaskBounty.syncResourceLabels()
     syncBountyResourceLabelsFromCache()
-    scheduleEvent(syncBountyResourceLabelsFromCache, 50)
+    if pendingResourceSync then
+        pendingResourceSync:cancel()
+    end
+    pendingResourceSync = scheduleEvent(function()
+        pendingResourceSync = nil
+        syncBountyResourceLabelsFromCache()
+    end, 50)
 end
 
 function TaskBounty.requestRefresh()

--- a/modules/game_task_hunt/tasks.lua
+++ b/modules/game_task_hunt/tasks.lua
@@ -250,7 +250,7 @@ function onResourceBalance(resourceType, balance)
     end
 
     if resourceType == ResourceTypes.TASK_HUNTING then
-        local panel = taskHuntWindow:recursiveGetChildById('taskShopPoints')
+        local panel = taskHuntWindow and taskHuntWindow:recursiveGetChildById('taskShopPoints')
         if panel then
             local label = panel:recursiveGetChildById('panelLabel')
             if label then label:setText(comma_value(balance)) end
@@ -259,7 +259,7 @@ function onResourceBalance(resourceType, balance)
     end
 
     if resourceType == ResourceTypes.SOULSEAL_POINTS then
-        local panel = taskHuntWindow:recursiveGetChildById('soulpitPoints')
+        local panel = taskHuntWindow and taskHuntWindow:recursiveGetChildById('soulpitPoints')
         if panel then
             local label = panel:recursiveGetChildById('panelLabel')
             if label then label:setText(comma_value(balance)) end
@@ -267,7 +267,7 @@ function onResourceBalance(resourceType, balance)
     end
 
     if resourceType == ResourceTypes.BOUNTY_TASK_POINTS then
-        local panel = taskHuntWindow:recursiveGetChildById('bountyPoints')
+        local panel = taskHuntWindow and taskHuntWindow:recursiveGetChildById('bountyPoints')
         if panel then
             local label = panel:recursiveGetChildById('panelLabel')
             if label then label:setText(comma_value(balance)) end
@@ -276,7 +276,7 @@ function onResourceBalance(resourceType, balance)
     end
 
     if resourceType == ResourceTypes.BOUNTY_REROLL_POINTS then
-        local rerollLabel = taskHuntWindow:recursiveGetChildById('rerollPointsLabel')
+        local rerollLabel = taskHuntWindow and taskHuntWindow:recursiveGetChildById('rerollPointsLabel')
         if rerollLabel then rerollLabel:setText(tostring(balance)) end
 
         local claimLabel = taskHuntWindow:recursiveGetChildById('claimDailyLabel')

--- a/modules/game_task_hunt/tasks.lua
+++ b/modules/game_task_hunt/tasks.lua
@@ -279,7 +279,7 @@ function onResourceBalance(resourceType, balance)
         local rerollLabel = taskHuntWindow and taskHuntWindow:recursiveGetChildById('rerollPointsLabel')
         if rerollLabel then rerollLabel:setText(tostring(balance)) end
 
-        local claimLabel = taskHuntWindow:recursiveGetChildById('claimDailyLabel')
+        local claimLabel = taskHuntWindow and taskHuntWindow:recursiveGetChildById('claimDailyLabel')
         if claimLabel then claimLabel:setText(tostring(balance)) end
     end
 end

--- a/modules/game_task_hunt/tasks.lua
+++ b/modules/game_task_hunt/tasks.lua
@@ -36,6 +36,8 @@ local function syncResourceBalances()
         player:getResourceBalance(ResourceTypes.TASK_HUNTING))
     onResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS,
         player:getResourceBalance(ResourceTypes.BOUNTY_TASK_POINTS))
+    onResourceBalance(ResourceTypes.BOUNTY_REROLL_POINTS,
+        player:getResourceBalance(ResourceTypes.BOUNTY_REROLL_POINTS))
     onResourceBalance(ResourceTypes.SOULSEAL_POINTS,
         player:getResourceBalance(ResourceTypes.SOULSEAL_POINTS))
 end

--- a/modules/game_trackers/classes/kill_tracker.lua
+++ b/modules/game_trackers/classes/kill_tracker.lua
@@ -19,6 +19,7 @@ local SLOT_STATE_WILDCARD = 4
 
 local preySlots = {}
 local lastPreyRequest = 0
+local lastBountyRequest = 0
 
 local function attachTrackerWindow()
     if preyTracker:getParent() then
@@ -175,6 +176,20 @@ local function requestPreyData(force)
     if force or now - lastPreyRequest > 1000 then
         lastPreyRequest = now
         g_game.preyRequest()
+    end
+end
+
+local function requestBountyData(force)
+    if not g_game.isOnline() or not g_game.bountyTaskAction then
+        return
+    end
+
+    local now = g_clock.millis()
+    if force or now - lastBountyRequest > 1000 then
+        lastBountyRequest = now
+        -- ACTION_REQUEST from game_task_hunt/classes/bounty-tasks.lua.
+        -- C++ maps it to TaskBoard OPEN_BOUNTY (0x5F option 0).
+        g_game.bountyTaskAction(4, 0)
     end
 end
 
@@ -365,7 +380,9 @@ function Tracker.Prey.init()
         onPreyActive = Tracker.Prey.onPreyActive,
         onPreySelection = Tracker.Prey.onPreySelection,
         onPreyWildcard = Tracker.Prey.onPreyWildcard,
-        onPreyTimeLeft = Tracker.Prey.onPreyTimeLeft
+        onPreyTimeLeft = Tracker.Prey.onPreyTimeLeft,
+        onBountyTaskData = Tracker.Bounty.onTaskData,
+        onBountyKillUpdate = Tracker.Bounty.onKillUpdate
     })
 
     preyTracker.onOpen = function()
@@ -373,6 +390,7 @@ function Tracker.Prey.init()
             preyTrackerButton:setOn(true)
         end
         requestPreyData()
+        requestBountyData()
     end
 
     preyTracker.onClose = function()
@@ -408,7 +426,9 @@ function Tracker.Prey.terminate()
         onPreyActive = Tracker.Prey.onPreyActive,
         onPreySelection = Tracker.Prey.onPreySelection,
         onPreyWildcard = Tracker.Prey.onPreyWildcard,
-        onPreyTimeLeft = Tracker.Prey.onPreyTimeLeft
+        onPreyTimeLeft = Tracker.Prey.onPreyTimeLeft,
+        onBountyTaskData = Tracker.Bounty.onTaskData,
+        onBountyKillUpdate = Tracker.Bounty.onKillUpdate
     })
 
     if preyTrackerButton then
@@ -462,6 +482,7 @@ function Tracker.Prey.toggle()
         end
         preyTracker:open()
         requestPreyData()
+        requestBountyData()
         preyTracker:getParent():moveChildToIndex(preyTracker, #preyTracker:getParent():getChildren())
     end
 end
@@ -481,6 +502,7 @@ function Tracker.Prey.ensureVisible()
 
     preyTracker:open()
     requestPreyData()
+    requestBountyData()
     preyTracker:getParent():moveChildToIndex(preyTracker, #preyTracker:getParent():getChildren())
     return true
 end
@@ -561,6 +583,9 @@ end
 Tracker.Bounty = {}
 
 function Tracker.Bounty.getSlot()
+    if not preyTracker or not preyTracker.contentsPanel then
+        return nil
+    end
     return preyTracker.contentsPanel["bslot1"]
 end
 
@@ -629,10 +654,89 @@ function Tracker.Bounty.setCompleted(name, outfit, killCount, killTarget)
     end
 end
 
+local function getBountyMonsterName(monster, raceData)
+    local name = monster and monster.name or raceData and raceData.name or 'Unknown'
+    return formatPreyName(name)
+end
+
+local function getBountyMonsterOutfit(monster, raceData)
+    if raceData and hasValidOutfit(raceData.outfit) then
+        return raceData.outfit
+    end
+
+    if not monster then
+        return {}
+    end
+
+    local lookType = tonumber(monster.lookType) or 0
+    if lookType <= 0 then
+        return {}
+    end
+
+    return {
+        type = lookType,
+        lookType = lookType,
+        head = tonumber(monster.lookHead) or 0,
+        body = tonumber(monster.lookBody) or 0,
+        legs = tonumber(monster.lookLegs) or 0,
+        feet = tonumber(monster.lookFeet) or 0,
+        addons = tonumber(monster.lookAddons) or 0
+    }
+end
+
+function Tracker.Bounty.onTaskData(header, monsters)
+    header = header or {}
+    monsters = monsters or {}
+
+    if g_things and g_things.registerRaceDataFromPacket then
+        for _, monster in ipairs(monsters) do
+            g_things.registerRaceDataFromPacket(monster)
+        end
+    end
+
+    local state = tonumber(header.state) or 0
+    local activeMonster = nil
+
+    for _, monster in ipairs(monsters) do
+        if tonumber(monster.isActive) == 1 then
+            activeMonster = monster
+            break
+        end
+    end
+
+    if not activeMonster and (state == 2 or state == 3) then
+        for _, monster in ipairs(monsters) do
+            if (tonumber(monster.raceId) or 0) > 0 then
+                activeMonster = monster
+                break
+            end
+        end
+    end
+
+    if not activeMonster then
+        Tracker.Bounty.setInactive()
+        return
+    end
+
+    local raceId = tonumber(activeMonster.raceId) or 0
+    local currentKills = tonumber(activeMonster.currentKills) or 0
+    local totalKills = tonumber(activeMonster.totalKills) or 0
+    local completed = state == 3 or tonumber(activeMonster.isCompleted) == 1 or
+        (totalKills > 0 and currentKills >= totalKills)
+    local raceData = g_things and g_things.getRaceData and g_things.getRaceData(raceId) or nil
+    local name = getBountyMonsterName(activeMonster, raceData)
+    local outfit = getBountyMonsterOutfit(activeMonster, raceData)
+
+    if completed then
+        Tracker.Bounty.setCompleted(name, outfit, currentKills, totalKills)
+    else
+        Tracker.Bounty.setActive(name, outfit, currentKills, totalKills)
+    end
+end
+
 function Tracker.Bounty.onKillUpdate(raceId, currentKills, totalKills, isCompleted)
     local raceData = g_things.getRaceData(raceId)
-    local name = raceData and raceData.name or 'Unknown'
-    name = name:capitalize()
+    local name = getBountyMonsterName(nil, raceData)
     local outfit = raceData and raceData.outfit or {}
 
     if isCompleted == 1 then

--- a/modules/game_trackers/classes/kill_tracker.lua
+++ b/modules/game_trackers/classes/kill_tracker.lua
@@ -16,6 +16,9 @@ local SLOT_STATE_INACTIVE = 1
 local SLOT_STATE_ACTIVE = 2
 local SLOT_STATE_SELECTION = 3
 local SLOT_STATE_WILDCARD = 4
+local BOUNTY_STATE_ACTIVE = 2
+local BOUNTY_STATE_COMPLETED = 3
+local BOUNTY_ACTION_REQUEST = 4
 
 local preySlots = {}
 local lastPreyRequest = 0
@@ -187,9 +190,10 @@ local function requestBountyData(force)
     local now = g_clock.millis()
     if force or now - lastBountyRequest > 1000 then
         lastBountyRequest = now
-        -- ACTION_REQUEST from game_task_hunt/classes/bounty-tasks.lua.
-        -- C++ maps it to TaskBoard OPEN_BOUNTY (0x5F option 0).
-        g_game.bountyTaskAction(4, 0)
+        -- Lua action request; C++ maps this action to TaskBoard OPEN_BOUNTY
+        -- (wire option 0). Do not replace this with wire option 0 here:
+        -- action 0 maps to BOUNTY_REROLL.
+        g_game.bountyTaskAction(BOUNTY_ACTION_REQUEST, 0)
     end
 end
 
@@ -704,7 +708,7 @@ function Tracker.Bounty.onTaskData(header, monsters)
         end
     end
 
-    if not activeMonster and (state == 2 or state == 3) then
+    if not activeMonster and (state == BOUNTY_STATE_ACTIVE or state == BOUNTY_STATE_COMPLETED) then
         for _, monster in ipairs(monsters) do
             if (tonumber(monster.raceId) or 0) > 0 then
                 activeMonster = monster
@@ -721,7 +725,7 @@ function Tracker.Bounty.onTaskData(header, monsters)
     local raceId = tonumber(activeMonster.raceId) or 0
     local currentKills = tonumber(activeMonster.currentKills) or 0
     local totalKills = tonumber(activeMonster.totalKills) or 0
-    local completed = state == 3 or tonumber(activeMonster.isCompleted) == 1 or
+    local completed = state == BOUNTY_STATE_COMPLETED or tonumber(activeMonster.isCompleted) == 1 or
         (totalKills > 0 and currentKills >= totalKills)
     local raceData = g_things and g_things.getRaceData and g_things.getRaceData(raceId) or nil
     local name = getBountyMonsterName(activeMonster, raceData)

--- a/modules/game_trackers/classes/kill_tracker.lua
+++ b/modules/game_trackers/classes/kill_tracker.lua
@@ -739,7 +739,7 @@ function Tracker.Bounty.onTaskData(header, monsters)
 end
 
 function Tracker.Bounty.onKillUpdate(raceId, currentKills, totalKills, isCompleted)
-    local raceData = g_things.getRaceData(raceId)
+    local raceData = g_things and g_things.getRaceData and g_things.getRaceData(raceId) or nil
     local name = getBountyMonsterName(nil, raceData)
     local outfit = raceData and raceData.outfit or {}
 

--- a/modules/gamelib/game.lua
+++ b/modules/gamelib/game.lua
@@ -189,7 +189,7 @@ function getCrashBytes(str)
   return crashBytes
 end
 
--- Soul Seal handler (opcode 0xBA/186) — parsed by C++ parseTaskHuntingBasicData
+-- Soul Seal handler (Task Board 0x53 subtype 0x03) — parsed by C++ parseSoulsealsData
 -- Receives: entries (array of {raceId, name, stars, cost, mastered}), balance (uint32)
 function onSoulsealsData(entries, balance)
     g_logger.info("[SoulSeal] Received " .. (type(entries) == "table" and #entries or 0) .. " soulseal entries")

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -316,6 +316,7 @@ private:
     void parseDepotState(const InputMessagePtr& msg);
     void parseMultiOfflineTrainingDialog(const InputMessagePtr& msg);
     void parseTaskHuntingBasicData(const InputMessagePtr& msg);
+    void parseSoulsealsData(const InputMessagePtr& msg);
     void parseTaskBoardData(const InputMessagePtr& msg);
     void parseTaskBoardBountyData(const InputMessagePtr& msg);
     void parseTaskBoardWeeklyData(const InputMessagePtr& msg);

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -321,6 +321,8 @@ private:
     void parseTaskBoardBountyData(const InputMessagePtr& msg);
     void parseTaskBoardWeeklyData(const InputMessagePtr& msg);
     void parseTaskBoardShopData(const InputMessagePtr& msg);
+    void parseTaskBoardBountyKillUpdate(const InputMessagePtr& msg);
+    void parseTaskBoardWeeklyKillUpdate(const InputMessagePtr& msg);
     void parseSupplyTracker(const InputMessagePtr& msg);
     void parseTournamentLeaderboard(const InputMessagePtr& msg);
     void parseCustomItemValues(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4890,14 +4890,49 @@ void ProtocolGame::parseMultiOfflineTrainingDialog(const InputMessagePtr& /*msg*
 
 void ProtocolGame::parseTaskHuntingBasicData(const InputMessagePtr& msg)
 {
-    // Matches server protocol.lua sendSoulSealsData byte-for-byte
-    // Server sends: opcode 0xBA -> balance(U32) + count(U16) +
-    // entries{raceId(U16), name(str), outfit(U16+5 bytes), stars(U8), cost(U32), mastered(U8)}
+    // Server sends: monsterCount(U16), monsters{raceId(U16), difficulty(U8)},
+    // optionCount(U8), options{difficulty(U8), grade(U8), nonBestiaryKills(U16),
+    // nonBestiaryReward(U16), fullBestiaryKills(U16), fullBestiaryReward(U16)},
+    // rerollPrice(U32), removePrice(U32), wildcardSelectPrice(U8), rerollWildcardPrice(U8).
+    auto stringify = [](uint64_t v) { return std::to_string(v); };
+
+    const uint16_t monsterCount = msg->getU16();
+    std::map<int, int> monsterInfo;
+    for (uint16_t i = 0; i < monsterCount; ++i) {
+        monsterInfo[msg->getU16()] = msg->getU8();
+    }
+
+    const uint8_t optionCount = msg->getU8();
+    std::vector<std::map<std::string, std::string>> rewardData;
+    rewardData.reserve(optionCount);
+    for (uint8_t i = 0; i < optionCount; ++i) {
+        std::map<std::string, std::string> option;
+        option["difficulty"] = stringify(msg->getU8());
+        option["grade"] = stringify(msg->getU8());
+        option["nonBestiaryKills"] = stringify(msg->getU16());
+        option["nonBestiaryReward"] = stringify(msg->getU16());
+        option["fullBestiaryKills"] = stringify(msg->getU16());
+        option["fullBestiaryReward"] = stringify(msg->getU16());
+        rewardData.emplace_back(std::move(option));
+    }
+
+    const uint32_t rerollPrice = msg->getU32();
+    const uint32_t removePrice = msg->getU32();
+    const uint8_t wildcardSelectPrice = msg->getU8();
+    const uint8_t rerollWildcardPrice = msg->getU8();
+
+    g_lua.callGlobalField("g_game", "onPreyHuntingBaseData", monsterInfo, rewardData);
+    g_lua.callGlobalField("g_game", "onPreyHuntingPrice", rerollPrice, removePrice, wildcardSelectPrice, rerollWildcardPrice);
+}
+
+void ProtocolGame::parseSoulsealsData(const InputMessagePtr& msg)
+{
+    // Task Board subtype 0x03: balance(U32), entries{raceId(U16), display,
+    // stars(U8), cost(U32), mastered(U8)}.
     auto stringify = [](uint64_t v) { return std::to_string(v); };
 
     const uint32_t balance = msg->getU32();
     const uint16_t count = msg->getU16();
-
     std::vector<std::map<std::string, std::string>> entries;
     entries.reserve(count);
 
@@ -4924,6 +4959,8 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
         parseTaskBoardWeeklyData(msg);
     } else if (mode == 2) {
         parseTaskBoardShopData(msg);
+    } else if (mode == 3) {
+        parseSoulsealsData(msg);
     } else {
         const int unreadSize = msg->getUnreadSize();
         if (unreadSize > 0)

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -5269,20 +5269,24 @@ void ProtocolGame::parseTaskBoardShopData(const InputMessagePtr& msg)
     g_lua.callGlobalField("g_game", "onTaskHuntingShopData", items, taskHuntingPoints);
 }
 
-void ProtocolGame::parseTaskBoardBountyKillUpdate(const InputMessagePtr& msg)
+static void parseGenericKillUpdate(const InputMessagePtr& msg, const char* callbackName)
 {
+    // Task Board subtypes 0x04 (bounty) / 0x05 (weekly):
+    // raceId(U16), currentKills(U16), totalKills(U16), isCompleted(U8).
+    // Mirrors the server task_board protocol kill-update packets.
     const uint16_t raceId = msg->getU16();
     const uint16_t currentKills = msg->getU16();
     const uint16_t totalKills = msg->getU16();
     const uint8_t isCompleted = msg->getU8();
-    g_lua.callGlobalField("g_game", "onBountyKillUpdate", raceId, currentKills, totalKills, isCompleted);
+    g_lua.callGlobalField("g_game", callbackName, raceId, currentKills, totalKills, isCompleted);
+}
+
+void ProtocolGame::parseTaskBoardBountyKillUpdate(const InputMessagePtr& msg)
+{
+    parseGenericKillUpdate(msg, "onBountyKillUpdate");
 }
 
 void ProtocolGame::parseTaskBoardWeeklyKillUpdate(const InputMessagePtr& msg)
 {
-    const uint16_t raceId = msg->getU16();
-    const uint16_t currentKills = msg->getU16();
-    const uint16_t totalKills = msg->getU16();
-    const uint8_t isCompleted = msg->getU8();
-    g_lua.callGlobalField("g_game", "onWeeklyKillUpdate", raceId, currentKills, totalKills, isCompleted);
+    parseGenericKillUpdate(msg, "onWeeklyKillUpdate");
 }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4967,6 +4967,10 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
         parseTaskBoardShopData(msg);
     } else if (mode == 3) {
         parseSoulsealsData(msg);
+    } else if (mode == 4) {
+        parseTaskBoardBountyKillUpdate(msg);
+    } else if (mode == 5) {
+        parseTaskBoardWeeklyKillUpdate(msg);
     } else {
         const int unreadSize = msg->getUnreadSize();
         if (unreadSize > 0)
@@ -5263,4 +5267,22 @@ void ProtocolGame::parseTaskBoardShopData(const InputMessagePtr& msg)
     }
 
     g_lua.callGlobalField("g_game", "onTaskHuntingShopData", items, taskHuntingPoints);
+}
+
+void ProtocolGame::parseTaskBoardBountyKillUpdate(const InputMessagePtr& msg)
+{
+    const uint16_t raceId = msg->getU16();
+    const uint16_t currentKills = msg->getU16();
+    const uint16_t totalKills = msg->getU16();
+    const uint8_t isCompleted = msg->getU8();
+    g_lua.callGlobalField("g_game", "onBountyKillUpdate", raceId, currentKills, totalKills, isCompleted);
+}
+
+void ProtocolGame::parseTaskBoardWeeklyKillUpdate(const InputMessagePtr& msg)
+{
+    const uint16_t raceId = msg->getU16();
+    const uint16_t currentKills = msg->getU16();
+    const uint16_t totalKills = msg->getU16();
+    const uint8_t isCompleted = msg->getU8();
+    g_lua.callGlobalField("g_game", "onWeeklyKillUpdate", raceId, currentKills, totalKills, isCompleted);
 }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -103,17 +103,20 @@ static void pushInspectionImbuements(const std::vector<uint16>& imbuements)
     }
 }
 
+std::string stringifyTaskValue(uint64_t v)
+{
+    return std::to_string(v);
+}
+
 void readTaskCreatureDisplay(const InputMessagePtr& msg, std::map<std::string, std::string>& entry)
 {
-    auto stringify = [](uint64_t v) { return std::to_string(v); };
-
     entry["name"] = msg->getString();
-    entry["lookType"] = stringify(msg->getU16());
-    entry["lookHead"] = stringify(msg->getU8());
-    entry["lookBody"] = stringify(msg->getU8());
-    entry["lookLegs"] = stringify(msg->getU8());
-    entry["lookFeet"] = stringify(msg->getU8());
-    entry["lookAddons"] = stringify(msg->getU8());
+    entry["lookType"] = stringifyTaskValue(msg->getU16());
+    entry["lookHead"] = stringifyTaskValue(msg->getU8());
+    entry["lookBody"] = stringifyTaskValue(msg->getU8());
+    entry["lookLegs"] = stringifyTaskValue(msg->getU8());
+    entry["lookFeet"] = stringifyTaskValue(msg->getU8());
+    entry["lookAddons"] = stringifyTaskValue(msg->getU8());
 }
 }
 
@@ -4894,12 +4897,12 @@ void ProtocolGame::parseTaskHuntingBasicData(const InputMessagePtr& msg)
     // optionCount(U8), options{difficulty(U8), grade(U8), nonBestiaryKills(U16),
     // nonBestiaryReward(U16), fullBestiaryKills(U16), fullBestiaryReward(U16)},
     // rerollPrice(U32), removePrice(U32), wildcardSelectPrice(U8), rerollWildcardPrice(U8).
-    auto stringify = [](uint64_t v) { return std::to_string(v); };
-
     const uint16_t monsterCount = msg->getU16();
     std::map<int, int> monsterInfo;
     for (uint16_t i = 0; i < monsterCount; ++i) {
-        monsterInfo[msg->getU16()] = msg->getU8();
+        const uint16_t raceId = msg->getU16();
+        const uint8_t difficulty = msg->getU8();
+        monsterInfo[static_cast<int>(raceId)] = static_cast<int>(difficulty);
     }
 
     const uint8_t optionCount = msg->getU8();
@@ -4907,12 +4910,12 @@ void ProtocolGame::parseTaskHuntingBasicData(const InputMessagePtr& msg)
     rewardData.reserve(optionCount);
     for (uint8_t i = 0; i < optionCount; ++i) {
         std::map<std::string, std::string> option;
-        option["difficulty"] = stringify(msg->getU8());
-        option["grade"] = stringify(msg->getU8());
-        option["nonBestiaryKills"] = stringify(msg->getU16());
-        option["nonBestiaryReward"] = stringify(msg->getU16());
-        option["fullBestiaryKills"] = stringify(msg->getU16());
-        option["fullBestiaryReward"] = stringify(msg->getU16());
+        option["difficulty"] = stringifyTaskValue(msg->getU8());
+        option["grade"] = stringifyTaskValue(msg->getU8());
+        option["nonBestiaryKills"] = stringifyTaskValue(msg->getU16());
+        option["nonBestiaryReward"] = stringifyTaskValue(msg->getU16());
+        option["fullBestiaryKills"] = stringifyTaskValue(msg->getU16());
+        option["fullBestiaryReward"] = stringifyTaskValue(msg->getU16());
         rewardData.emplace_back(std::move(option));
     }
 
@@ -4927,9 +4930,12 @@ void ProtocolGame::parseTaskHuntingBasicData(const InputMessagePtr& msg)
 
 void ProtocolGame::parseSoulsealsData(const InputMessagePtr& msg)
 {
-    // Task Board subtype 0x03: balance(U32), entries{raceId(U16), display,
-    // stars(U8), cost(U32), mastered(U8)}.
-    auto stringify = [](uint64_t v) { return std::to_string(v); };
+    // Task Board subtype 0x03:
+    // balance(U32), count(U16), entries{
+    //   raceId(U16), name(string), lookType(U16), lookHead(U8), lookBody(U8),
+    //   lookLegs(U8), lookFeet(U8), lookAddons(U8), stars(U8), cost(U32),
+    //   mastered(U8)
+    // }.
 
     const uint32_t balance = msg->getU32();
     const uint16_t count = msg->getU16();
@@ -4938,11 +4944,11 @@ void ProtocolGame::parseSoulsealsData(const InputMessagePtr& msg)
 
     for (uint16_t i = 0; i < count; ++i) {
         std::map<std::string, std::string> entry;
-        entry["raceId"] = stringify(msg->getU16());
+        entry["raceId"] = stringifyTaskValue(msg->getU16());
         readTaskCreatureDisplay(msg, entry);
-        entry["stars"] = stringify(msg->getU8());
-        entry["cost"] = stringify(msg->getU32());
-        entry["mastered"] = stringify(msg->getU8());
+        entry["stars"] = stringifyTaskValue(msg->getU8());
+        entry["cost"] = stringifyTaskValue(msg->getU32());
+        entry["mastered"] = stringifyTaskValue(msg->getU8());
         entry["done"] = entry["mastered"];  // backward compat
         entries.emplace_back(std::move(entry));
     }
@@ -4973,39 +4979,37 @@ void ProtocolGame::parseTaskBoardData(const InputMessagePtr& msg)
 void ProtocolGame::parseTaskBoardBountyData(const InputMessagePtr& msg)
 {
     // Matches server protocol.lua sendBountyTaskData byte-for-byte
-    auto stringify = [](uint64_t v) { return std::to_string(v); };
-
     std::map<std::string, std::string> header;
-    header["state"] = stringify(msg->getU8());
-    header["difficulty"] = stringify(msg->getU8() + 1);  // server sends 0-indexed
+    header["state"] = stringifyTaskValue(msg->getU8());
+    header["difficulty"] = stringifyTaskValue(msg->getU8() + 1);  // server sends 0-indexed
 
     // 3 creature entries
     std::vector<std::map<std::string, std::string>> monsters;
     monsters.reserve(3);
     for (uint8_t i = 0; i < 3; ++i) {
         std::map<std::string, std::string> entry;
-        entry["raceId"] = stringify(msg->getU16());
+        entry["raceId"] = stringifyTaskValue(msg->getU16());
         readTaskCreatureDisplay(msg, entry);
-        entry["currentKills"] = stringify(msg->getU16());
-        entry["totalKills"] = stringify(msg->getU16());
-        entry["rewardXp"] = stringify(msg->getU16());
-        entry["rewardPoints"] = stringify(msg->getU16());
-        entry["grade"] = stringify(msg->getU8());
+        entry["currentKills"] = stringifyTaskValue(msg->getU16());
+        entry["totalKills"] = stringifyTaskValue(msg->getU16());
+        entry["rewardXp"] = stringifyTaskValue(msg->getU16());
+        entry["rewardPoints"] = stringifyTaskValue(msg->getU16());
+        entry["grade"] = stringifyTaskValue(msg->getU8());
         const uint8_t claimState = msg->getU8();
-        entry["claimState"] = stringify(claimState);
-        entry["taskIndex"] = stringify(msg->getU8());
+        entry["claimState"] = stringifyTaskValue(claimState);
+        entry["taskIndex"] = stringifyTaskValue(msg->getU8());
         entry["rewardReroll"] = "1";
         entry["isActive"] = (claimState == 1) ? "1" : "0";
         entry["isCompleted"] = (claimState == 2) ? "1" : "0";
         monsters.emplace_back(std::move(entry));
     }
 
-    header["rerollPoints"] = stringify(msg->getU8());
+    header["rerollPoints"] = stringifyTaskValue(msg->getU8());
     const uint8_t rerollMode = msg->getU8();
-    header["rerollMode"] = stringify(rerollMode);
+    header["rerollMode"] = stringifyTaskValue(rerollMode);
     header["claimDaily"] = rerollMode == 0 ? "1" : "0";
-    header["rerollTimestamp"] = stringify(msg->getU32());
-    header["upgrade"] = stringify(msg->getU8());
+    header["rerollTimestamp"] = stringifyTaskValue(msg->getU32());
+    header["upgrade"] = stringifyTaskValue(msg->getU8());
 
     // 4 talisman paths
     std::vector<std::map<std::string, std::string>> talisman;
@@ -5032,10 +5036,10 @@ void ProtocolGame::parseTaskBoardBountyData(const InputMessagePtr& msg)
         const uint16_t currentValue = getTalismanBonus(currentLevel, i);
         const uint16_t nextValue = canUpgrade ? getTalismanBonus(currentLevel + 1, i) : 0;
 
-        entry["currentValue"] = stringify(currentValue);
-        entry["nextValue"] = stringify(nextValue);
+        entry["currentValue"] = stringifyTaskValue(currentValue);
+        entry["nextValue"] = stringifyTaskValue(nextValue);
         entry["canUpgrade"] = canUpgrade ? "1" : "0";
-        entry["upgradeCost"] = stringify(upgradeCost);
+        entry["upgradeCost"] = stringifyTaskValue(upgradeCost);
         talisman.emplace_back(std::move(entry));
     }
 
@@ -5046,9 +5050,9 @@ void ProtocolGame::parseTaskBoardBountyData(const InputMessagePtr& msg)
     for (uint8_t i = 0; i < 5; ++i) {
         std::map<std::string, std::string> entry;
         if (i < preferredCount) {
-            entry["enabled"] = stringify(msg->getU8());
-            entry["preferredRaceId"] = stringify(msg->getU16());
-            entry["unwantedRaceId"] = stringify(msg->getU16());
+            entry["enabled"] = stringifyTaskValue(msg->getU8());
+            entry["preferredRaceId"] = stringifyTaskValue(msg->getU16());
+            entry["unwantedRaceId"] = stringifyTaskValue(msg->getU16());
         } else {
             entry["enabled"] = "0";
             entry["preferredRaceId"] = "0";
@@ -5066,7 +5070,7 @@ void ProtocolGame::parseTaskBoardBountyData(const InputMessagePtr& msg)
         availableCreatures.reserve(availableCreatureCount);
         for (uint16_t i = 0; i < availableCreatureCount; ++i) {
             std::map<std::string, std::string> entry;
-            entry["raceId"] = stringify(msg->getU16());
+            entry["raceId"] = stringifyTaskValue(msg->getU16());
             readTaskCreatureDisplay(msg, entry);
             availableCreatures.emplace_back(std::move(entry));
         }
@@ -5082,8 +5086,6 @@ void ProtocolGame::parseTaskBoardBountyData(const InputMessagePtr& msg)
 void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
 {
     // Matches server protocol.lua sendWeeklyTaskData byte-for-byte
-    auto stringify = [](uint64_t v) { return std::to_string(v); };
-
     std::vector<std::map<std::string, std::string>> monsters;
 
     // Any creature counters
@@ -5092,8 +5094,8 @@ void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
     if (anyCreatureTotal > 0 || anyCreatureKills > 0) {
         std::map<std::string, std::string> anyEntry;
         anyEntry["raceId"] = "0";
-        anyEntry["current"] = stringify(anyCreatureKills);
-        anyEntry["total"] = stringify(anyCreatureTotal);
+        anyEntry["current"] = stringifyTaskValue(anyCreatureKills);
+        anyEntry["total"] = stringifyTaskValue(anyCreatureTotal);
         anyEntry["state"] = anyCreatureKills >= anyCreatureTotal ? "1" : "0";
         monsters.emplace_back(std::move(anyEntry));
     }
@@ -5102,13 +5104,13 @@ void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
     const uint8_t killTaskCount = msg->getU8();
     for (uint8_t i = 0; i < killTaskCount; ++i) {
         std::map<std::string, std::string> entry;
-        entry["raceId"] = stringify(msg->getU16());
+        entry["raceId"] = stringifyTaskValue(msg->getU16());
         readTaskCreatureDisplay(msg, entry);
         const uint16_t kills = msg->getU16();
         const uint16_t required = msg->getU16();
-        entry["current"] = stringify(kills);
-        entry["total"] = stringify(required);
-        entry["grade"] = stringify(msg->getU8());
+        entry["current"] = stringifyTaskValue(kills);
+        entry["total"] = stringifyTaskValue(required);
+        entry["grade"] = stringifyTaskValue(msg->getU8());
         entry["state"] = kills >= required ? "1" : "0";
         monsters.emplace_back(std::move(entry));
     }
@@ -5119,18 +5121,18 @@ void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
     items.reserve(deliveryTaskCount);
     for (uint8_t i = 0; i < deliveryTaskCount; ++i) {
         std::map<std::string, std::string> entry;
-        entry["itemId"] = stringify(msg->getU16());
-        entry["clientId"] = stringify(msg->getU16());
+        entry["itemId"] = stringifyTaskValue(msg->getU16());
+        entry["clientId"] = stringifyTaskValue(msg->getU16());
         const uint8_t amount = msg->getU8();
         const uint8_t required = msg->getU8();
         const uint32_t available = msg->getU32();
         const uint8_t grade = msg->getU8();
-        entry["amount"] = stringify(amount);
-        entry["required"] = stringify(required);
-        entry["available"] = stringify(available);
-        entry["current"] = stringify(amount);
-        entry["total"] = stringify(required);
-        entry["grade"] = stringify(grade);
+        entry["amount"] = stringifyTaskValue(amount);
+        entry["required"] = stringifyTaskValue(required);
+        entry["available"] = stringifyTaskValue(available);
+        entry["current"] = stringifyTaskValue(amount);
+        entry["total"] = stringifyTaskValue(required);
+        entry["grade"] = stringifyTaskValue(grade);
         entry["claimed"] = "0";
         entry["state"] = amount >= required ? "1" : "0";
         items.emplace_back(std::move(entry));
@@ -5139,22 +5141,22 @@ void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
     // Header fields
     std::map<std::string, std::string> header;
     const uint8_t difficulty = msg->getU8();
-    header["difficulty"] = stringify(difficulty + 1);  // server sends 0-indexed
-    header["maxExperience"] = stringify(msg->getU32());
-    header["maxDeliveryExperience"] = stringify(msg->getU32());
-    header["completedKillTasks"] = stringify(msg->getU8());
-    header["completedDeliveryTasks"] = stringify(msg->getU8());
-    header["weeklyProgress"] = stringify(msg->getU8());
-    header["pointsEarned"] = stringify(msg->getU32());
-    header["soulsealsEarned"] = stringify(msg->getU32());
-    header["soulsealsBalance"] = stringify(msg->getU32());
-    header["needsReward"] = stringify(msg->getU8());
-    header["hasExpansion"] = stringify(msg->getU8());
+    header["difficulty"] = stringifyTaskValue(difficulty + 1);  // server sends 0-indexed
+    header["maxExperience"] = stringifyTaskValue(msg->getU32());
+    header["maxDeliveryExperience"] = stringifyTaskValue(msg->getU32());
+    header["completedKillTasks"] = stringifyTaskValue(msg->getU8());
+    header["completedDeliveryTasks"] = stringifyTaskValue(msg->getU8());
+    header["weeklyProgress"] = stringifyTaskValue(msg->getU8());
+    header["pointsEarned"] = stringifyTaskValue(msg->getU32());
+    header["soulsealsEarned"] = stringifyTaskValue(msg->getU32());
+    header["soulsealsBalance"] = stringifyTaskValue(msg->getU32());
+    header["needsReward"] = stringifyTaskValue(msg->getU8());
+    header["hasExpansion"] = stringifyTaskValue(msg->getU8());
 
     // Compute derived header fields (keep backward compat with Lua UI)
     header["remainingDays"] = "7";
     const uint8_t hasExpansion = std::stoi(header["hasExpansion"]);
-    header["totalTaskSlots"] = stringify(hasExpansion ? 9 : 6);
+    header["totalTaskSlots"] = stringifyTaskValue(hasExpansion ? 9 : 6);
     const uint8_t completedKills = std::stoi(header["completedKillTasks"]);
     const uint8_t completedDeliveries = std::stoi(header["completedDeliveryTasks"]);
     const uint8_t totalCompleted = completedKills + completedDeliveries;
@@ -5163,13 +5165,13 @@ void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
     else if (totalCompleted >= 12) rewardMultiplier = 5;
     else if (totalCompleted >= 8) rewardMultiplier = 3;
     else if (totalCompleted >= 4) rewardMultiplier = 2;
-    header["rewardMultiplier"] = stringify(rewardMultiplier);
+    header["rewardMultiplier"] = stringifyTaskValue(rewardMultiplier);
     header["extraSlot"] = hasExpansion ? "1" : "0";
     header["unlocked"] = hasExpansion ? "1" : "0";
 
     static const uint8_t killTaskPointsByDifficulty[4] = { 25, 50, 100, 110 };
     const uint8_t diffIdx = std::min<uint8_t>(3, std::max<uint8_t>(0, difficulty));
-    header["killTaskPoints"] = stringify(killTaskPointsByDifficulty[diffIdx]);
+    header["killTaskPoints"] = stringifyTaskValue(killTaskPointsByDifficulty[diffIdx]);
     header["deliveryTaskPoints"] = "75";
     header["soulsealPointsPerTask"] = "1";
 
@@ -5179,9 +5181,9 @@ void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
     static const uint16_t difficultyMinLevels[4] = { 1, 150, 300, 500 };
     for (uint8_t i = 0; i < 4; ++i) {
         std::map<std::string, std::string> entry;
-        entry["id"] = stringify(i + 1);
+        entry["id"] = stringifyTaskValue(i + 1);
         entry["name"] = difficultyNames[i];
-        entry["minLevel"] = stringify(difficultyMinLevels[i]);
+        entry["minLevel"] = stringifyTaskValue(difficultyMinLevels[i]);
         difficulties.emplace_back(std::move(entry));
     }
 
@@ -5191,8 +5193,6 @@ void ProtocolGame::parseTaskBoardWeeklyData(const InputMessagePtr& msg)
 void ProtocolGame::parseTaskBoardShopData(const InputMessagePtr& msg)
 {
     // Matches server protocol.lua sendHuntingTaskShopData byte-for-byte
-    auto stringify = [](uint64_t v) { return std::to_string(v); };
-
     std::vector<std::map<std::string, std::string>> items;
     const uint32_t taskHuntingPoints = msg->getU32();
     const uint8_t offerCount = msg->getU8();
@@ -5207,29 +5207,29 @@ void ProtocolGame::parseTaskBoardShopData(const InputMessagePtr& msg)
         const uint8_t purchased = msg->getU8();
         const uint8_t type = msg->getU8();
 
-        entry["id"] = stringify(id);
+        entry["id"] = stringifyTaskValue(id);
         entry["title"] = name;
         entry["description"] = "";  // server doesn't send description
-        entry["count"] = stringify(count);
-        entry["price"] = stringify(price);
+        entry["count"] = stringifyTaskValue(count);
+        entry["price"] = stringifyTaskValue(price);
         entry["bought"] = purchased ? "1" : "0";
-        entry["purchased"] = stringify(purchased);
+        entry["purchased"] = stringifyTaskValue(purchased);
 
         // Type-specific fields
         switch (type) {
         case 0: // Item
             entry["type"] = "Decoration";
-            entry["itemId"] = stringify(msg->getU16());
+            entry["itemId"] = stringifyTaskValue(msg->getU16());
             entry["clientId"] = entry["itemId"];
             break;
         case 1: // Mount
             entry["type"] = "Mount";
-            entry["lookType"] = stringify(msg->getU16());
+            entry["lookType"] = stringifyTaskValue(msg->getU16());
             break;
         case 2: // Outfit
             entry["type"] = "Outfit";
-            entry["lookType"] = stringify(msg->getU16());
-            entry["addon"] = stringify(msg->getU16());
+            entry["lookType"] = stringifyTaskValue(msg->getU16());
+            entry["addon"] = stringifyTaskValue(msg->getU16());
             entry["lookHead"] = "0";
             entry["lookBody"] = "0";
             entry["lookLegs"] = "0";
@@ -5238,7 +5238,7 @@ void ProtocolGame::parseTaskBoardShopData(const InputMessagePtr& msg)
             break;
         case 3: // Item Double
             entry["type"] = "Decoration";
-            entry["itemId"] = stringify(msg->getU16());
+            entry["itemId"] = stringifyTaskValue(msg->getU16());
             entry["clientId"] = entry["itemId"];
             break;
         case 4: // Bonus Promotion

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -1354,6 +1354,9 @@ void ProtocolGame::sendTaskBoardAction(uint8_t option, uint16_t value, uint16_t 
             msg->addU16(value);
             msg->addU16(extraValue);
             break;
+        case 19: // SOULSEAL_FIGHT
+            msg->addU16(value);
+            break;
         // Options with no payload:
         case 0:  // OPEN_BOUNTY
         case 1:  // OPEN_WEEKLY
@@ -1533,7 +1536,8 @@ void ProtocolGame::sendStartOfflineTraining(const uint8_t skillType)
 void ProtocolGame::sendSoulSealsAction(const uint16_t raceId)
 {
     auto msg = std::make_shared<OutputMessage>();
-    msg->addU8(Proto::ClientPreyHuntingAction);
+    msg->addU8(Proto::ClientTaskBoardAction);
+    msg->addU8(19); // SOULSEAL_FIGHT
     msg->addU16(raceId);
     send(msg);
 }

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -1535,11 +1535,8 @@ void ProtocolGame::sendStartOfflineTraining(const uint8_t skillType)
 
 void ProtocolGame::sendSoulSealsAction(const uint16_t raceId)
 {
-    auto msg = std::make_shared<OutputMessage>();
-    msg->addU8(Proto::ClientTaskBoardAction);
-    msg->addU8(19); // SOULSEAL_FIGHT
-    msg->addU16(raceId);
-    send(msg);
+    // SOULSEAL_FIGHT shares the Task Board action wire format (option 19, U16 raceId).
+    sendTaskBoardAction(19, raceId, 0);
 }
 
 void ProtocolGame::sendTutorialChangeVocation(const uint8_t vocationClientId)


### PR DESCRIPTION
## Summary

Fixes Task Hunt/Bounty live synchronization on the client side.

- Updates the C++ Task Board parser to decode the server Task Hunting/Bounty payloads and Soulseal subtype path.
- Removes duplicate Lua parsing of the Task Hunting opcodes so the native parser owns the packets.
- Makes Kill Tracker listen directly to Bounty data updates, so selecting/completing/claiming Bounty state updates without reopening Task Hunt.
- Refreshes Bounty Points and reroll token UI from resource balance updates.

## Root cause

The client was relying on module/window refresh paths for some Bounty/Task Hunt state. If the Task Hunt window was closed, Kill Tracker and footer balances could remain stale until reopening.

## Validation

- Ran Lua syntax validation with `npx --yes luaparse` on touched Lua modules.
- Ran `git diff --check`.
- Did not compile locally per project workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rastreador de mortes agora exibe dados de Tarefas de Recompensa.
  * Sincronização melhorada de pontos de Reroll em Tarefas de Recompensa.

* **Bug Fixes**
  * Pontos de Reroll de Tarefas de Recompensa agora atualizam corretamente na interface ao abrir a janela.
  * Corrigida exibição de dados do Task Board para Selagens de Almas e Tarefas Semanais.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->