### PR TITLE
Fix Prey wildcard selection parsing

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -1669,10 +1669,16 @@ function moveStackableItem(item, toPos)
 
   countWindow = g_ui.createWidget('CountWindow', rootWidget)
   local itembox = countWindow.contentPanel:getChildById('item')
+  local itemCountLabel = countWindow.contentPanel:getChildById('itemCount')
   local scrollbar = countWindow.contentPanel:getChildById('countScrollBar')
+  local setItemboxCount = function(value)
+    itembox:setItemCount(value)
+    itemCountLabel:setText(tostring(value))
+  end
+
   g_client.setInputLockWidget(countWindow)
   itembox:setItemId(item:getId())
-  itembox:setItemCount(count)
+  setItemboxCount(count)
   scrollbar:setMaximum(count)
   scrollbar:setMinimum(1)
   scrollbar:setValue(count)
@@ -1731,7 +1737,7 @@ function moveStackableItem(item, toPos)
   g_keyboard.bindKeyPress("Num+Enter", function() moveFunc() end, spinbox)
 
   scrollbar.onValueChange = function(self, value)
-    itembox:setItemCount(value)
+    setItemboxCount(value)
     spinbox.onValueChange = nil
     spinbox:setValue(value)
     spinbox.onValueChange = spinBoxValueChange

--- a/modules/game_interface/styles/countwindow.otui
+++ b/modules/game_interface/styles/countwindow.otui
@@ -25,8 +25,19 @@ CountWindow < NewMainWindow
       anchors.top: parent.top
       focusable: false
       virtual: true
-      virtual-count: true
       show-count: false
+
+    Label
+      id: itemCount
+      anchors.left: item.left
+      anchors.right: item.right
+      anchors.top: item.top
+      anchors.bottom: item.bottom
+      focusable: false
+      phantom: true
+      font: cipsoftFont
+      color: #ffffff
+      text-align: bottomRight
 
     UIWidget
       size: 167 24

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -1376,6 +1376,10 @@ function onPreyWildcard(slot, races, timeUntilFreeReroll, lockType, bonusType, b
     return
   end
 
+  bonusType = bonusType or PREY_BONUS_NONE
+  bonusValue = bonusValue or 0
+  bonusGrade = bonusGrade or 0
+
   itemListMin[slot] = 0
   itemListMax[slot] = #races
   currentRaces[slot] = races
@@ -1393,13 +1397,6 @@ function onPreyWildcard(slot, races, timeUntilFreeReroll, lockType, bonusType, b
   prey.wildcard:show()
 
   prey.wildcard.monsterList:focusChild(nil)
-  prey.wildcard.monsterList:destroyChildren()
-
-  local count = 0
-  for i = 1, poolSize[slot] do
-    local monster = g_ui.createWidget("WildcardLabel", prey.wildcard.monsterList)
-    table.insert(itemsPool[slot], monster)
-  end
 
   maxFitItems[slot] = math.floor(prey.wildcard.monsterList:getHeight() / itemSize[slot])
 

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -46,6 +46,7 @@ local SLOT_STATE_INACTIVE = 1
 local SLOT_STATE_ACTIVE = 2
 local SLOT_STATE_SELECTION = 3
 local SLOT_STATE_WILDCARD = 4
+local SLOT_STATE_WILDCARD_FROM_ALL = 5
 
 local PREY_UNLOCK_NONE = 2
 
@@ -122,6 +123,27 @@ local function parsePreyData(protocol, msg)
     local timeUntilFreeReroll = readTimeUntilFreeReroll(msg)
     local lockType = readPreyLockType(msg)
     signalcall(g_game.onPreySelection, slot, PREY_BONUS_NONE, -1, -1, names, outfits, timeUntilFreeReroll, lockType)
+  elseif state == SLOT_STATE_WILDCARD then
+    local bonusType = msg:getU8()
+    local bonusValue = msg:getU16()
+    local bonusGrade = msg:getU8()
+    local races = {}
+    local count = msg:getU16()
+    for i = 1, count do
+      races[i] = msg:getU16()
+    end
+    local timeUntilFreeReroll = readTimeUntilFreeReroll(msg)
+    local lockType = readPreyLockType(msg)
+    signalcall(g_game.onPreyWildcard, slot, races, timeUntilFreeReroll, lockType, bonusType, bonusValue, bonusGrade)
+  elseif state == SLOT_STATE_WILDCARD_FROM_ALL then
+    local races = {}
+    local count = msg:getU16()
+    for i = 1, count do
+      races[i] = msg:getU16()
+    end
+    local timeUntilFreeReroll = readTimeUntilFreeReroll(msg)
+    local lockType = readPreyLockType(msg)
+    signalcall(g_game.onPreyWildcard, slot, races, timeUntilFreeReroll, lockType, PREY_BONUS_NONE, 0, 0)
   else
     g_logger.error("Unknown prey data state: " .. state)
   end
@@ -204,6 +226,7 @@ function init()
     onPreyPrice = onPreyPrice,
     onPreyLocked = onPreyLocked,
     onPreyWildcard = onPreyWildcard,
+    onPreyChangeFromAll = onPreyChangeFromAll,
     onPreyInactive = onPreyInactive,
     onPreyActive = onPreyActive,
     onPreySelection = onPreySelection
@@ -336,6 +359,7 @@ function terminate()
     onPreyPrice = onPreyPrice,
     onPreyLocked = onPreyLocked,
     onPreyWildcard = onPreyWildcard,
+    onPreyChangeFromAll = onPreyChangeFromAll,
     onPreyInactive = onPreyInactive,
     onPreyActive = onPreyActive,
     onPreySelection = onPreySelection
@@ -1332,7 +1356,7 @@ function updateWildCardWindow()
       end
       monster.icon:setVisible(false)
       monster:setTextOffset("0 0")
-      monster.onHoverChange = function(monster, hovered) onSpecialHover("selectionList", bonusType, bonusValue) end
+      monster.onHoverChange = function(monster, hovered) onSpecialHover("selectionList", prey.bonusType, prey.bonusValue) end
       table.insert(itemsPool[i], monster)
     end
 
@@ -1373,7 +1397,7 @@ function onPreyWildcard(slot, races, timeUntilFreeReroll, lockType, bonusType, b
 
   local count = 0
   for i = 1, poolSize[slot] do
-    g_ui.createWidget("WildcardLabel", prey.wildcard.monsterList)
+    local monster = g_ui.createWidget("WildcardLabel", prey.wildcard.monsterList)
     table.insert(itemsPool[slot], monster)
   end
 
@@ -1402,6 +1426,14 @@ function onPreyWildcard(slot, races, timeUntilFreeReroll, lockType, bonusType, b
   setUnsupportedSettings()
   updatePreyWidget(slot, SLOT_STATE_WILDCARD)
   updateWildCardWindow()
+end
+
+function onPreyChangeFromAll(slot, first, second, third, fourth, fifth, sixth)
+  if type(first) == "table" then
+    return onPreyWildcard(slot, first, second, third, fourth, fifth, sixth)
+  end
+
+  return onPreyWildcard(slot, fourth or {}, fifth, sixth, first, second, third)
 end
 
 function onPreyLocked(slot, unlockState, timeUntilFreeReroll, lockType, permanentPrice)

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -47,6 +47,7 @@ local SLOT_STATE_ACTIVE = 2
 local SLOT_STATE_SELECTION = 3
 local SLOT_STATE_WILDCARD = 4
 local SLOT_STATE_WILDCARD_FROM_ALL = 5
+local SLOT_STATE_WILDCARD_WITH_MONSTERS = 6
 
 local PREY_UNLOCK_NONE = 2
 
@@ -82,10 +83,7 @@ local function readTimeUntilFreeReroll(msg)
 end
 
 local function readPreyLockType(msg)
-  if g_game.getFeature(GameTibia12Protocol) then
-    return msg:getU8()
-  end
-  return 0
+  return msg:getU8()
 end
 
 local function parsePreyData(protocol, msg)
@@ -140,6 +138,23 @@ local function parsePreyData(protocol, msg)
     local count = msg:getU16()
     for i = 1, count do
       races[i] = msg:getU16()
+    end
+    local timeUntilFreeReroll = readTimeUntilFreeReroll(msg)
+    local lockType = readPreyLockType(msg)
+    signalcall(g_game.onPreyWildcard, slot, races, timeUntilFreeReroll, lockType, PREY_BONUS_NONE, 0, 0)
+  elseif state == SLOT_STATE_WILDCARD_WITH_MONSTERS then
+    local races = {}
+    creatureList = creatureList or {}
+    local count = msg:getU16()
+    for i = 1, count do
+      local raceId = msg:getU16()
+      local name = msg:getString()
+      local outfit = readPreyOutfit(msg)
+      races[i] = raceId
+      creatureList[raceId] = { name, outfit.type, outfit.auxType or 0, outfit.head or 0, outfit.body or 0, outfit.legs or 0, outfit.feet or 0, outfit.addons or 0 }
+      if g_things.registerRaceData then
+        g_things.registerRaceData(raceId, name, outfit)
+      end
     end
     local timeUntilFreeReroll = readTimeUntilFreeReroll(msg)
     local lockType = readPreyLockType(msg)
@@ -278,9 +293,10 @@ function onHover(widget)
     local timeleft = timeleftTranslation(preySlot.timeLeft)
     local typeDesc = bonusTypeTranslate(preySlot.bonusType)
     local bonusDescription = bonusTypeTranslateText(preySlot.bonusType, preySlot.bonusValue)
+    local bonusGrade = tonumber(preySlot.bonusGrade) or 0
     local starBonus = ""
     for i = 1, 10 do
-      if i <= preySlot.bonusGrade then
+      if i <= bonusGrade then
         starBonus = starBonus .. "^"
       else
         starBonus = starBonus .. ";"
@@ -442,19 +458,25 @@ function setUnsupportedSettings()
         state.buttonsPanel.lockPreyPrice.text:setColor("#d33c3c")
       end
 
-      state.buttonsPanel.autoReroll.autoRerollCheck.onClick = function()
-        if state.buttonsPanel.autoReroll.autoRerollCheck:isChecked() then
-          g_game.preyAction(i - 1, PREY_ACTION_LOCK_PREY, 0)
+      local autoRerollCheck = state.buttonsPanel.autoReroll.autoRerollCheck
+      autoRerollCheck.onClick = function()
+        local enabled = not autoRerollCheck:isChecked()
+        autoRerollCheck:setChecked(enabled)
+        if enabled then
+          onEnableAutoReroll(i - 1, autoRerollCheck)
         else
-          onEnableAutoReroll(i - 1)
+          g_game.preyAction(i - 1, PREY_ACTION_LOCK_PREY, 0)
         end
       end
 
-      state.buttonsPanel.lockPrey.lockPreyCheck.onClick = function()
-        if state.buttonsPanel.lockPrey.lockPreyCheck:isChecked() then
-          g_game.preyAction(i - 1, PREY_ACTION_LOCK_PREY, 0)
+      local lockPreyCheck = state.buttonsPanel.lockPrey.lockPreyCheck
+      lockPreyCheck.onClick = function()
+        local enabled = not lockPreyCheck:isChecked()
+        lockPreyCheck:setChecked(enabled)
+        if enabled then
+          onEnableLockPrey(i - 1, lockPreyCheck)
         else
-          onEnableLockPrey(i - 1)
+          g_game.preyAction(i - 1, PREY_ACTION_LOCK_PREY, 0)
         end
       end
 
@@ -664,6 +686,7 @@ end
 function setBonusGradeStars(slot, grade)
   local prey = preyWindow["slot"..(slot + 1)]
   local gradePanel = prey.active.creatureAndBonus.bonus.grade
+  grade = tonumber(grade) or 0
 
   gradePanel:destroyChildren()
   for i=1,10 do
@@ -835,7 +858,7 @@ function onWildcardChange(prey, selected, lastSelected, slot)
 
   lastSelectedLabel[slot] = selected
   selectedMonster[slot] = tonumber(selected:getId())
-  local creature = g_things.getMonsterList()[selectedMonster[slot]]
+  local creature = creatureList[selectedMonster[slot]]
   if not creature then return end
   prey.title:setText("Selected: " .. short_text(creature[1], 18))
   prey.wildcard.panel.creature:setOutfit({type = creature[2], auxType = creature[3], head = creature[4], body = creature[5], legs = creature[6], feet = creature[7], addons = creature[8]})
@@ -888,9 +911,10 @@ function updatePreyWidget(slot, state)
     local typeDesc = bonusTypeTranslate(preySlot.bonusType)
     local extendedDesc = preySlot.lockType == 0 and "false" or "true"
     local bonusDescription = bonusTypeTranslateText(preySlot.bonusType, preySlot.bonusValue)
+    local bonusGrade = tonumber(preySlot.bonusGrade) or 0
     local starBonus = ""
     for i = 1, 10 do
-      if i <= preySlot.bonusGrade then
+      if i <= bonusGrade then
         starBonus = starBonus .. "^"
       else
         starBonus = starBonus .. ";"
@@ -1019,7 +1043,7 @@ function onUnlockPermanentPreySlot(slot, price)
   }, okFunc, cancelFunc)
 end
 
-function onEnableAutoReroll(slot)
+function onEnableAutoReroll(slot, checkbox)
   if supportWindow then
     return
   end
@@ -1037,6 +1061,9 @@ function onEnableAutoReroll(slot)
   end
 
   local cancelFunc = function()
+    if checkbox then
+      checkbox:setChecked(false)
+    end
     supportWindow:destroy()
     supportWindow = nil
     preyWindow:show(true)
@@ -1052,7 +1079,7 @@ function onEnableAutoReroll(slot)
   }, okFunc, cancelFunc)
 end
 
-function onEnableLockPrey(slot)
+function onEnableLockPrey(slot, checkbox)
    if supportWindow then
     return
   end
@@ -1070,6 +1097,9 @@ function onEnableLockPrey(slot)
   end
 
   local cancelFunc = function()
+    if checkbox then
+      checkbox:setChecked(false)
+    end
     supportWindow:destroy()
     supportWindow = nil
     preyWindow:show(true)
@@ -1091,6 +1121,12 @@ function onPreyActive(slot, currentHolderName, currentHolderOutfit, bonusType, b
     return
   end
 
+  bonusType = tonumber(bonusType) or PREY_BONUS_NONE
+  bonusValue = tonumber(bonusValue) or 0
+  bonusGrade = tonumber(bonusGrade) or 0
+  timeLeft = tonumber(timeLeft) or 0
+  timeUntilFreeReroll = tonumber(timeUntilFreeReroll) or 0
+  lockType = tonumber(lockType) or 0
   local percent = (timeLeft / (2 * 60 * 60)) * 100
   prey.inactive:hide()
   prey.locked:hide()

--- a/modules/game_prey/prey.lua
+++ b/modules/game_prey/prey.lua
@@ -83,6 +83,9 @@ local function readTimeUntilFreeReroll(msg)
 end
 
 local function readPreyLockType(msg)
+  if msg:getUnreadSize() < 1 then
+    return 0
+  end
   return msg:getU8()
 end
 
@@ -94,7 +97,7 @@ local function parsePreyData(protocol, msg)
     local unlockState = msg:getU8()
     local timeUntilFreeReroll = readTimeUntilFreeReroll(msg)
     local lockType = readPreyLockType(msg)
-    local permanentPrice = msg:getU32()
+    local permanentPrice = msg:getUnreadSize() >= 4 and msg:getU32() or 0
     signalcall(g_game.onPreyLocked, slot, unlockState, timeUntilFreeReroll, lockType, permanentPrice)
   elseif state == SLOT_STATE_INACTIVE then
     local timeUntilFreeReroll = readTimeUntilFreeReroll(msg)
@@ -144,7 +147,7 @@ local function parsePreyData(protocol, msg)
     signalcall(g_game.onPreyWildcard, slot, races, timeUntilFreeReroll, lockType, PREY_BONUS_NONE, 0, 0)
   elseif state == SLOT_STATE_WILDCARD_WITH_MONSTERS then
     local races = {}
-    creatureList = creatureList or {}
+    creatureList = creatureList or g_things.getMonsterList()
     local count = msg:getU16()
     for i = 1, count do
       local raceId = msg:getU16()
@@ -523,6 +526,17 @@ end
 
 function hide(ignoreTracker)
   creatureList = nil
+  monsterList = nil
+  itemListMin = {}
+  itemListMax = {}
+  itemSize = {}
+  maxFitItems = {}
+  poolSize = {}
+  itemsPool = {}
+  currentRaces = {}
+  currentSearchRaces = {}
+  lastSelectedLabel = {}
+  selectedMonster = {}
   preyWindow:hide()
   if not ignoreTracker then
     preyTracker:close()
@@ -858,7 +872,7 @@ function onWildcardChange(prey, selected, lastSelected, slot)
 
   lastSelectedLabel[slot] = selected
   selectedMonster[slot] = tonumber(selected:getId())
-  local creature = creatureList[selectedMonster[slot]]
+  local creature = creatureList and creatureList[selectedMonster[slot]]
   if not creature then return end
   prey.title:setText("Selected: " .. short_text(creature[1], 18))
   prey.wildcard.panel.creature:setOutfit({type = creature[2], auxType = creature[3], head = creature[4], body = creature[5], legs = creature[6], feet = creature[7], addons = creature[8]})
@@ -1447,7 +1461,6 @@ function onPreyWildcard(slot, races, timeUntilFreeReroll, lockType, bonusType, b
   local preyPanel = prey.wildcard.panel
   preyPanel.onHoverChange = function(preyPanel, hovered) onSpecialHover("selectionList", bonusType, bonusValue) end
 
-  monsterList = prey.wildcard.monsterList
   prey.wildcard.choose.button.choosePreyButton:setActionId(slot + 1)
   prey.wildcard.choose.button.choosePreyButton.onClick = function()
     return g_game.preyAction(slot, 4, selectedMonster[slot])

--- a/modules/game_skills/skills.lua
+++ b/modules/game_skills/skills.lua
@@ -81,14 +81,14 @@ local function onWheelSkillStats(protocol, opcode, data)
     critSeparator:setVisible(false)
   end
   if critChanceWidget and math.abs(critChance) > 0.0001 then
-    critChanceWidget:recursiveGetChildById("value"):setText(string.format("+%.2f%%", critChance * 100))
+    critChanceWidget:recursiveGetChildById("value"):setText("+" .. math.floor(critChance * 100 + 0.5) .. "%")
     critChanceWidget:recursiveGetChildById("value"):setColor("#44ad25")
     critChanceWidget:setVisible(true)
   elseif critChanceWidget then
     critChanceWidget:setVisible(false)
   end
   if critDamageWidget and math.abs(critDamage) > 0.0001 then
-    critDamageWidget:recursiveGetChildById("value"):setText(string.format("+%.2f%%", critDamage * 100))
+    critDamageWidget:recursiveGetChildById("value"):setText("+" .. math.floor(critDamage * 100 + 0.5) .. "%")
     critDamageWidget:recursiveGetChildById("value"):setColor("#44ad25")
     critDamageWidget:setVisible(true)
   elseif critDamageWidget then

--- a/modules/game_trackers/classes/kill_tracker.lua
+++ b/modules/game_trackers/classes/kill_tracker.lua
@@ -325,6 +325,14 @@ function Tracker.Prey.onPreyWildcard(slot, races, timeUntilFreeReroll, lockType,
     updatePreySlot(slot)
 end
 
+function Tracker.Prey.onPreyChangeFromAll(slot, first, second, third, fourth, fifth, sixth)
+    if type(first) == "table" then
+        return Tracker.Prey.onPreyWildcard(slot, first, second, third, fourth, fifth, sixth)
+    end
+
+    return Tracker.Prey.onPreyWildcard(slot, fourth or {}, fifth, sixth, first, second, third)
+end
+
 function Tracker.Prey.onPreyTimeLeft(slot, timeLeft)
     if preySlots[slot] then
         preySlots[slot].timeLeft = timeLeft or 0
@@ -384,6 +392,7 @@ function Tracker.Prey.init()
         onPreyActive = Tracker.Prey.onPreyActive,
         onPreySelection = Tracker.Prey.onPreySelection,
         onPreyWildcard = Tracker.Prey.onPreyWildcard,
+        onPreyChangeFromAll = Tracker.Prey.onPreyChangeFromAll,
         onPreyTimeLeft = Tracker.Prey.onPreyTimeLeft,
         onBountyTaskData = Tracker.Bounty.onTaskData,
         onBountyKillUpdate = Tracker.Bounty.onKillUpdate
@@ -430,6 +439,7 @@ function Tracker.Prey.terminate()
         onPreyActive = Tracker.Prey.onPreyActive,
         onPreySelection = Tracker.Prey.onPreySelection,
         onPreyWildcard = Tracker.Prey.onPreyWildcard,
+        onPreyChangeFromAll = Tracker.Prey.onPreyChangeFromAll,
         onPreyTimeLeft = Tracker.Prey.onPreyTimeLeft,
         onBountyTaskData = Tracker.Bounty.onTaskData,
         onBountyKillUpdate = Tracker.Bounty.onKillUpdate


### PR DESCRIPTION
## Summary
- Parse the Prey choose-from-all raceId list state sent by the server.
- Wire `onPreyChangeFromAll` to the same wildcard handler for compatibility with the C++ parser path.
- Fix wildcard list widget pooling so the specific-creature list can render correctly.

## Validation
- `git diff --cached --check`
- Lua sanity parse of `modules/game_prey/prey.lua` after stripping existing `goto continue` labels for parser compatibility.
- Lua parse of `modules/game_trackers/classes/kill_tracker.lua` with `luaparse`.

No compile run here; Mateus compiles locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado suporte a wildcard no sistema de presa com múltiplos estados de slot.
  * Implementado novo tratamento de eventos para mudanças de presa.

* **Correções de Bugs**
  * Sincronização aprimorada da contagem de itens com a barra de rolagem.

* **Melhorias de Interface**
  * Formato atualizado da exibição de chance crítica e dano crítico para percentuais arredondados inteiros.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->