### PR TITLE
[codex] Fix Action Bar equip metadata handling

### DIFF
--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -928,7 +928,8 @@ function onChooseItemMouseRelease(self, mousePosition, mouseButton)
       assingobjectwindow.WithCrosshair:setEnabled(true)
     end
 
-    if canAssignEquipItem(item) then
+    local canEquipAssignedItem = canAssignEquipItem(item)
+    if canEquipAssignedItem then
       assingobjectwindow.equipDequip:setEnabled(true)
     end
 
@@ -944,6 +945,9 @@ function onChooseItemMouseRelease(self, mousePosition, mouseButton)
     assingobjectOption:addWidget(assingobjectwindow.equipDequip)
     assingobjectOption:addWidget(assingobjectwindow.use)
     assingobjectOption:selectWidget(assingobjectwindow.use)
+    if canEquipAssignedItem and not (item:isMultiUse() or item:isContainer()) then
+      assingobjectOption:selectWidget(assingobjectwindow.equipDequip)
+    end
 
     assingobjectwindow.okButton.onClick = function()
       local selectId = assingobjectOption:getSelectedWidget():getId()

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -25,6 +25,7 @@ local MULTI_ACTION_DELAY_MS = 500
 local cachedItemWidget = {}
 local dragButton = nil
 local dragItem = nil
+local shouldPreferActionbarEquipAction = nil
 
 local ItemTypeCategory = {
 	Weapon = 3,
@@ -288,13 +289,6 @@ local function isActionbarEquipCategory(category)
 		category == MarketCategory.FistWeapons or
 		category == MarketCategory.WeaponsAll or
 		category == MarketCategory.MetaWeapons
-end
-
-local function isActionbarEquipName(item)
-	local name = getActionbarItemName(item)
-	return name:find("ring", 1, true) ~= nil or
-		name:find("amulet", 1, true) ~= nil or
-		name:find("necklace", 1, true) ~= nil
 end
 
 local function isActionbarFoodName(item)
@@ -1742,13 +1736,18 @@ function onAssignItem(self, mousePosition, mouseButton, button)
 
 	local itemId = 0
 	local itemTier = 0
+	local selectedItem = nil
 	if clickedWidget:getClassName() == 'UIItem' and not clickedWidget:isVirtual() and clickedWidget:getItem() then
-		itemId = clickedWidget:getItem():getId()
-		itemTier = clickedWidget:getItem():getTier()
+		selectedItem = clickedWidget:getItem()
+		itemId = selectedItem:getId()
+		itemTier = selectedItem:getTier()
 	elseif clickedWidget:getClassName() == 'UIGameMap' then
 		local tile = clickedWidget:getTile(mousePosition)
-		if tile then
-			itemId = tile:getTopUseThing():getId()
+		local thing = tile and tile:getTopUseThing()
+		if thing and thing:isItem() then
+			selectedItem = thing
+			itemId = selectedItem:getId()
+			itemTier = selectedItem.getTier and selectedItem:getTier() or 0
 		end
 	end
 
@@ -1757,7 +1756,7 @@ function onAssignItem(self, mousePosition, mouseButton, button)
 		modules.game_textmessage.displayFailureMessage(tr('Invalid object!'))
 		return true
 	end
-	assignItem(button, itemId, itemTier)
+	assignItem(button, itemId, itemTier, false, selectedItem)
 end
 
 function saveMultiState(button)
@@ -2041,7 +2040,7 @@ function assignText(button)
 	end
 end
 
-function assignItem(button, itemId, itemTier, dragEvent)
+function assignItem(button, itemId, itemTier, dragEvent, selectedItem)
 	if not isLoaded then
 		return true
 	end
@@ -2089,8 +2088,13 @@ function assignItem(button, itemId, itemTier, dragEvent)
 		fromSelect = true
 	end
 
-	window.contentPanel.item:setItemId(itemId)
-	if not item or item:getId() == 0 then
+	if selectedItem and selectedItem.clone and selectedItem:getId() == itemId then
+		window.contentPanel.item:setItem(selectedItem:clone())
+		item = window.contentPanel.item:getItem()
+	else
+		window.contentPanel.item:setItemId(itemId)
+	end
+	if not item or item:getId() == 0 or item:getId() ~= itemId then
 		item = window.contentPanel.item:getItem()
 	end
 
@@ -2125,8 +2129,17 @@ function assignItem(button, itemId, itemTier, dragEvent)
 		{ id = "Equip", useType = "Equip" },
 		{ id = "Use", useType = "Use" }
 	}
+	local preferEquipAction = shouldPreferActionbarEquipAction and shouldPreferActionbarEquipAction(item)
 
 	local function canSelectUseType(useType)
+		if preferEquipAction then
+			if useType == "Equip" and button.cache.actionType == UseTypes["Use"] then
+				return true
+			end
+			if useType == "Use" and button.cache.actionType == UseTypes["Use"] then
+				return false
+			end
+		end
 		return fromSelect or button.cache.actionType == 0 or button.cache.actionType == UseTypes[useType]
 	end
 
@@ -2148,7 +2161,9 @@ function assignItem(button, itemId, itemTier, dragEvent)
 
 			if enabled then
 				child:setEnabled(true)
-				if not radio:getSelectedWidget() then
+				if preferEquipAction and data.useType == "Equip" and canSelectUseType(data.useType) then
+					radio:selectWidget(child)
+				elseif not radio:getSelectedWidget() then
 					local canAutoSelect = data.useType == "Equip" or not (item:getClothSlot() > 0 or (item:getClothSlot() == 0 and item:getClassification() > 0))
 					if canSelectUseType(data.useType) and canAutoSelect then
 						radio:selectWidget(child)
@@ -3124,6 +3139,20 @@ function canEquipItem(item)
 	end
 
 	return false
+end
+
+shouldPreferActionbarEquipAction = function(item)
+	if not item or not canEquipItem(item) then
+		return false
+	end
+
+	local category = getActionbarItemCategory(item)
+	local isFood = MarketCategory and category == MarketCategory.Food
+	if item:isContainer() or item:isMultiUse() or isFood or isActionbarFoodName(item) then
+		return false
+	end
+
+	return true
 end
 
 function onSearchTextChange(widget, text)

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -1745,9 +1745,11 @@ function onAssignItem(self, mousePosition, mouseButton, button)
 		local tile = clickedWidget:getTile(mousePosition)
 		local thing = tile and tile:getTopUseThing()
 		if thing and thing:isItem() then
-			selectedItem = thing
-			itemId = selectedItem:getId()
-			itemTier = selectedItem.getTier and selectedItem:getTier() or 0
+			selectedItem = thing.asItem and thing:asItem() or thing
+			if selectedItem then
+				itemId = selectedItem:getId()
+				itemTier = selectedItem.getTier and selectedItem:getTier() or 0
+			end
 		end
 	end
 

--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -344,8 +344,9 @@ GameDisplayItemCharges = 139
 GamePackedPlayerInventory = 140
 GameAstraQuiverCountU16 = 141
 GameAstraOutfitStoreMode = 142
+GameAstraItemMetadata = 143
 
-LastGameFeature = 143
+LastGameFeature = 144
 
 TextColors = {
   red        = '#F55E5E',

--- a/modules/gamelib/ui/uiitem.lua
+++ b/modules/gamelib/ui/uiitem.lua
@@ -140,7 +140,7 @@ function UIItem:onDrop(widget, mousePos, forced)
       return false
     end
 
-    modules.game_actionbar.assignItem(destination:getParent(), item:getId(), item:getTier(), true)
+    modules.game_actionbar.assignItem(destination:getParent(), item:getId(), item:getTier(), true, item)
     return true
   end
 

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -506,8 +506,9 @@ namespace Otc
         GamePackedPlayerInventory = 140,
         GameAstraQuiverCountU16 = 141,
         GameAstraOutfitStoreMode = 142,
+        GameAstraItemMetadata = 143,
 
-        LastGameFeature = 143
+        LastGameFeature = 144
     };
 
     enum PathFindResult {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2134,7 +2134,8 @@ bool Game::isAstraItemStateEnabled()
 {
     return getFeature(Otc::GameDisplayItemDuration) ||
         getFeature(Otc::GameDisplayItemCharges) ||
-        getFeature(Otc::GamePackedPlayerInventory);
+        getFeature(Otc::GamePackedPlayerInventory) ||
+        getFeature(Otc::GameAstraItemMetadata);
 }
 
 void Game::changeMapAwareRange(int xrange, int yrange)

--- a/src/client/item.cpp
+++ b/src/client/item.cpp
@@ -42,6 +42,8 @@
 
 namespace {
 constexpr int ItemQuiversMarketCategory = 25;
+constexpr uint8 AstraItemFlagEquipable = 1 << 0;
+constexpr uint8 AstraItemFlagAmmo = 1 << 1;
 }
 
 Item::Item() :
@@ -56,10 +58,13 @@ Item::Item() :
     m_phase(0),
     m_lastPhase(0),
     m_durationTime(0),
+    m_astraSlotPosition(0),
+    m_astraItemFlags(0),
     m_durationTimePaused(0),
     m_durationIsPaused(false),
     m_hasDisplayDuration(false),
-    m_hasDisplayCharges(false)
+    m_hasDisplayCharges(false),
+    m_hasAstraItemMetadata(false)
 {
     if (g_game.getFeature(Otc::GameEnhancedAnimations)) {
         m_animator = std::make_shared<Animator>();
@@ -380,14 +385,26 @@ bool Item::isQuiver()
 
 bool Item::isAmmo()
 {
-    if (m_serverId == 0)
+    if (m_hasAstraItemMetadata && (m_astraItemFlags & AstraItemFlagAmmo) != 0)
+        return true;
+
+    if (m_serverId != 0) {
+        const auto& itemType = g_things.getItemType(m_serverId);
+        return itemType && itemType->getCategory() == ItemCategoryAmmunition;
+    }
+
+    if (m_clientId == 0)
         return false;
 
-    return g_things.getItemType(m_serverId)->getCategory() == ItemCategoryAmmunition;
+    const auto& itemType = g_things.findItemTypeByClientId(m_clientId);
+    return itemType && itemType->getCategory() == ItemCategoryAmmunition;
 }
 
 bool Item::isEquipableByServerType()
 {
+    if (m_hasAstraItemMetadata && (m_astraItemFlags & AstraItemFlagEquipable) != 0)
+        return true;
+
     if (m_serverId != 0) {
         const auto& itemType = g_things.getItemType(m_serverId);
         return itemType && itemType->isEquipable();
@@ -414,6 +431,13 @@ bool Item::isChargeableByCategory()
     return itemType && itemType->getCategory() == ItemCategoryCharges;
 }
 
+void Item::setAstraItemMetadata(uint16 slotPosition, uint8 flags)
+{
+    m_astraSlotPosition = slotPosition;
+    m_astraItemFlags = flags;
+    m_hasAstraItemMetadata = true;
+}
+
 bool Item::isMoveable()
 {
     return !rawGetThingType()->isNotMoveable();
@@ -436,7 +460,16 @@ bool Item::inCorpse()
 
 int Item::getWeaponType()
 {
-    return g_things.getItemType(m_serverId)->getWeaponType();
+    if (m_serverId != 0) {
+        const auto& itemType = g_things.getItemType(m_serverId);
+        return itemType ? itemType->getWeaponType() : 0;
+    }
+
+    if (m_clientId == 0)
+        return 0;
+
+    const auto& itemType = g_things.findItemTypeByClientId(m_clientId);
+    return itemType ? itemType->getWeaponType() : 0;
 }
 
 ItemPtr Item::clone()

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -179,8 +179,8 @@ public:
     bool hasExpireStop() { return Thing::hasExpireStop(); }
 
     ItemPtr clone();
-    ItemPtr asItem() { return static_self_cast<Item>(); }
-    bool isItem() { return true; }
+    ItemPtr asItem() override { return static_self_cast<Item>(); }
+    bool isItem() override { return true; }
 
     ItemVector getContainerItems() { return m_containerItems; }
     ItemPtr getContainerItem(int slot) { return m_containerItems[slot]; }

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -167,6 +167,10 @@ public:
     bool isAmmo();
     bool isChargeableByCategory();
     bool isEquipableByServerType();
+    void setAstraItemMetadata(uint16 slotPosition, uint8 flags);
+    bool hasAstraItemMetadata() { return m_hasAstraItemMetadata; }
+    uint16 getAstraSlotPosition() { return m_astraSlotPosition; }
+    uint8 getAstraItemFlags() { return m_astraItemFlags; }
     int getWeaponType();
     int getClassification() { const int classification = Thing::getClassification(); return classification > 0 ? classification : getWeaponType(); }
     bool hasWearOut() { return Thing::hasWearOut(); }
@@ -225,10 +229,13 @@ private:
 
     uint64 m_durationTime;
     uint32 m_charges = 0;
+    uint16 m_astraSlotPosition;
+    uint8 m_astraItemFlags;
     ticks_t m_durationTimePaused;
     bool m_durationIsPaused;
     bool m_hasDisplayDuration;
     bool m_hasDisplayCharges;
+    bool m_hasAstraItemMetadata;
 
     stdext::packed_storage<uint16> m_customAttribs;
 };

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -467,6 +467,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Thing>("isMarked", &Thing::isMarked);
     g_lua.bindClassMemberFunction<Thing>("getMarkedColor", &Thing::getMarkedColor);
     g_lua.bindClassMemberFunction<Thing>("isItem", &Thing::isItem);
+    g_lua.bindClassMemberFunction<Thing>("asItem", &Thing::asItem);
     g_lua.bindClassMemberFunction<Thing>("isMonster", &Thing::isMonster);
     g_lua.bindClassMemberFunction<Thing>("isNpc", &Thing::isNpc);
     g_lua.bindClassMemberFunction<Thing>("isCreature", &Thing::isCreature);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4817,10 +4817,12 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, int id, bool hasDescri
         }
     }
 
-    if (hasExtendedItemData && g_game.getFeature(Otc::GameAstraItemMetadata)) {
+    if (g_game.getFeature(Otc::GameAstraItemMetadata)) {
         const uint16 slotPosition = msg->getU16();
         const uint8 flags = msg->getU8();
-        item->setAstraItemMetadata(slotPosition, flags);
+        if (hasExtendedItemData) {
+            item->setAstraItemMetadata(slotPosition, flags);
+        }
     }
 
     return item;

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4817,6 +4817,12 @@ ItemPtr ProtocolGame::getItem(const InputMessagePtr& msg, int id, bool hasDescri
         }
     }
 
+    if (hasExtendedItemData && g_game.getFeature(Otc::GameAstraItemMetadata)) {
+        const uint16 slotPosition = msg->getU16();
+        const uint8 flags = msg->getU8();
+        item->setAstraItemMetadata(slotPosition, flags);
+    }
+
     return item;
 }
 

--- a/src/client/thing.h
+++ b/src/client/thing.h
@@ -63,6 +63,7 @@ public:
     Color updatedMarkedColor();
 
     virtual bool isItem() { return false; }
+    virtual ItemPtr asItem() { return nullptr; }
     virtual bool isEffect() { return false; }
     virtual bool isMissile() { return false; }
     virtual bool isCreature() { return false; }


### PR DESCRIPTION
## Summary

This PR fixes Action Bar object assignment for equipment whose equipability is only known from runtime/server metadata, including rings, amulets/necklaces, and arrows/ammo.

## What changed

- Added `GameAstraItemMetadata` as a negotiated client feature.
- Parsed Astra item metadata from item packets and stored it on `Item`.
- Let `Item:isAmmo()` and `Item:isEquipableByServerType()` use the Astra metadata before local client fallbacks.
- Preserved the real selected/dragged `Item` object when assigning Action Bar objects, instead of rebuilding a virtual item from only `itemId`.
- Removed the fragile Action Bar name fallback for `ring`/`amulet`/`necklace`.
- Preferred `Equip/Unequip` in assign dialogs when the item is known to be equipable, while keeping use behavior available for valid use items.
- Consumed Astra item metadata whenever the feature is active, even in item inspection contexts that do not store extended item state, to keep packet parsing aligned with the server.

## Why

The 8.60 client DAT/local item data does not reliably expose slot/equip metadata for rings, amulets, and arrows. The server already knows this through `slotPosition` and `weaponType`, so the client must consume that metadata instead of relying on names, item IDs, or client-side XML/OTB data.

The parser also needs to consume the metadata bytes in inspection packets after the companion server PR sends the negotiated item-state block there as well.

## Impact

This restores Action Bar equip assignment for rings, amulets, and arrows without hardcoding item IDs. It requires the companion server PR: https://github.com/Mateuzkl/forgottenserver-downgrade-1.8-8.60/pull/123.

## Validation

- Ran `git diff --check` for the changed client files.
- Verified the PR diff excludes `init.lua`, local analysis notes, and generated/unrelated files.
- Build/runtime validation was not run because the local environment does not expose the required build/Lua tooling in PATH.
