### PR TITLE
Fix store item offers with icons

### DIFF
--- a/docs/protocol-features-8.60.md
+++ b/docs/protocol-features-8.60.md
@@ -1,0 +1,228 @@
+# AstraClient 8.60 Protocol Features
+
+This document explains the 8.60 feature flags used by AstraClient and how they differ from OTCv8 Classic.
+
+PT-BR version: `docs/protocol-features-8.60.pt-BR.md`
+
+Read this before changing any `g_game.enableFeature(...)` or `g_game.disableFeature(...)` call. Some flags are visual, but others change packet layout. Enabling the wrong flag can desync the protocol parser.
+
+## Important Files
+
+- `modules/game_features/features.lua`: default feature profile by client version.
+- `modules/gamelib/const.lua`: Lua feature ids.
+- `src/client/const.h`: C++ feature ids.
+- `src/client/protocolgameparse.cpp`: packet parser and `parseFeatures`.
+- `modules/client_entergame/entergame.lua`: features received from HTTP login and `server_params`.
+
+On the server side, the main reference is `ProtocolGame::sendFeatures()` in `src/protocolgame.cpp`.
+
+## Main Rule
+
+Not every feature is just UI.
+
+Some features change packet size or packet field order. If the client enables one of those features and the server does not send the matching extra bytes, the next fields are read from the wrong offset.
+
+Common symptoms:
+
+- wrong item ids;
+- broken containers;
+- black map or wrong tiles;
+- unknown opcode errors;
+- look/use stops working;
+- crash or disconnect when opening backpacks, corpses, loot, or store inbox.
+
+## How Astra Enables Features
+
+AstraClient uses a direct `version == 860` profile in `modules/game_features/features.lua`.
+
+The client calls `g_game.resetFeatures()` and then enables only the expected Astra 8.60 feature set.
+
+Features can also be negotiated by the server:
+
+- HTTP login `features` field;
+- game packet `GameServerFeatures` (`0x43`), parsed by `parseFeatures`;
+- `server_params` in `init.lua`, which Astra can use to enable extra features.
+
+Use `server_params` only for safe features. Do not use it for item/map/container packet-layout features.
+
+## Astra 8.60 Base Features
+
+These are enabled because they are part of the expected Astra 8.60 base protocol:
+
+```lua
+GameLooktypeU16
+GameMessageStatements
+GameLoginPacketEncryption
+GamePlayerAddons
+GamePlayerStamina
+GameNewFluids
+GameMessageLevel
+GamePlayerStateU16
+GameNewOutfitProtocol
+GameWritableDate
+GameProtocolChecksum
+GameAccountNames
+GameDoubleFreeCapacity
+GameChallengeOnLogin
+GameMessageSizeCheck
+GameTileAddThingWithStackpos
+GameCreatureEmblems
+```
+
+## Astra 8.60 Client Extensions
+
+These are hardcoded in the Astra 8.60 profile:
+
+```lua
+GameAttackSeq
+GameBot
+GameExtendedOpcode
+GameSkillsBase
+GamePlayerMounts
+GameMagicEffectU16
+GameDistanceEffectU16
+GameDoubleHealth
+GameOfflineTrainingTime
+GameBaseSkillU16
+GameAdditionalSkills
+GameIdleAnimations
+GameEnhancedAnimations
+GameExtendedClientPing
+GameSpritesU32
+GameDoublePlayerGoodsMoney
+GameCreatureIcons
+GameColorizedLootValue
+GameBrowseField
+GamePlayerFamiliars
+GameProficiency
+GameUnjustifiedPoints
+GamePrey
+```
+
+Notes:
+
+- `GameSpritesU32` must match the extended `.spr` assets used by the client.
+- `GamePlayerFamiliars` affects Astra outfit data. Do not copy it into OTC Classic without parser support.
+- `GameColorizedLootValue` exists in Astra and is not present in this OTC Classic branch.
+- `GameProficiency` exists as a client feature, but keep it only when the server packet format is aligned with it.
+
+## Server-Negotiated Features
+
+The server can send features through packet `0x43` (`GameServerFeatures`). Astra also accepts features from HTTP login.
+
+The current server `sendFeatures()` sends, among others:
+
+```cpp
+ExtendedOpcode = true
+SkillsBase = true
+PlayerMounts = true
+MagicEffectU16 = true
+OfflineTrainingTime = true
+DoubleSkills = true
+BaseSkillU16 = true
+AdditionalSkills = true
+ExtendedClientPing = true
+CreatureIcons = true
+ContainerPagination = true
+BrowseField = true
+QuickLootFlags = shouldSendQuickLootFlags()
+ThingUpgradeClassification = false
+ItemTierByte = shouldSendItemTierByte()
+```
+
+When the connected client is Astra, the server may also send:
+
+```cpp
+ExperienceBonus = true
+PlayerFamiliars = true
+AstraCreatureIcons = true
+AstraQuiverCountU16 = true
+AstraOutfitStoreMode = true
+DisplayItemDuration = true
+DisplayItemCharges = true
+PackedPlayerInventory = true
+AstraItemMetadata = true
+```
+
+Those `Astra*` flags require Astra parser support. Do not copy them into OTC Classic.
+
+## Dangerous Flags
+
+These three flags are the most common source of protocol bugs:
+
+```lua
+GameQuickLootFlags              -- id 123
+GameThingUpgradeClassification  -- id 130
+GameItemTierByte                -- id 131
+```
+
+Do not change them from `disableFeature` to `enableFeature` unless the server is changed at the same time.
+
+### GameQuickLootFlags
+
+Changes item/container quick-loot flag parsing. If the client expects this byte and the server does not send it, the parser consumes the next packet field as a flag.
+
+### GameThingUpgradeClassification
+
+Changes item classification/tier parsing. The current server sends this feature as `false` for OTCv8/Astra.
+
+### GameItemTierByte
+
+Adds a tier byte to item parsing. It must be enabled only when `shouldSendItemTierByte()` is also enabled on the server.
+
+## Differences From OTCv8 Classic
+
+OTCv8 Classic uses version ranges such as `version >= 770`, `version >= 780`, `version >= 860`, and so on.
+
+In the `version >= 860` block, OTC Classic mainly enables:
+
+```lua
+GameAttackSeq
+GameBot
+GameExtendedOpcode
+GameSkillsBase
+GamePlayerMounts
+GameMagicEffectU16
+GameDistanceEffectU16
+GameDoubleHealth
+GameOfflineTrainingTime
+GameBaseSkillU16
+GameAdditionalSkills
+GameIdleAnimations
+GameEnhancedAnimations
+GameExtendedClientPing
+GameSpritesU32
+GameDoublePlayerGoodsMoney
+GameCreatureIcons
+GamePurseSlot
+GamePrey
+```
+
+OTC Classic explicitly keeps these disabled by default:
+
+```lua
+g_game.disableFeature(GameQuickLootFlags)
+g_game.disableFeature(GameThingUpgradeClassification)
+g_game.disableFeature(GameItemTierByte)
+```
+
+Astra is not a direct copy of that block. Astra 8.60 has its own feature profile and parser-specific extensions.
+
+## Checklist Before Changing a Feature
+
+- [ ] Is the feature UI-only, or does it change network packets?
+- [ ] Does the id exist in both `modules/gamelib/const.lua` and `src/client/const.h`?
+- [ ] Does the server send the same feature in `sendFeatures()` or HTTP login?
+- [ ] If it affects items, did you check `getItem`, `addItem`, containers, map, and inventory?
+- [ ] If it affects creatures/outfits, did you check outfit window, creature icons, and login?
+- [ ] Did you test login, walking, look, use, backpack, corpse, store inbox, and logout?
+- [ ] If the feature is negotiated, did you test both `false` and `true`?
+
+## Practical Rule
+
+For Astra 8.60:
+
+- stable Astra profile features can stay in `modules/game_features/features.lua`;
+- packet-layout features should be negotiated by the server;
+- Astra-only features must not be copied to OTC Classic;
+- `GameQuickLootFlags`, `GameThingUpgradeClassification`, and `GameItemTierByte` must follow the server, not a client-side guess.

--- a/docs/protocol-features-8.60.pt-BR.md
+++ b/docs/protocol-features-8.60.pt-BR.md
@@ -1,0 +1,226 @@
+# AstraClient 8.60 protocol features
+
+Este guia separa as features usadas pelo AstraClient das features usadas pelo OTCv8 Classic.
+
+O objetivo e evitar bug de protocolo causado por ligar `g_game.enableFeature(...)` sem o servidor mandar os bytes esperados.
+
+## Arquivos importantes
+
+- `modules/game_features/features.lua`: features padrao por versao do client.
+- `modules/gamelib/const.lua`: ids das features no Lua.
+- `src/client/const.h`: ids das features no C++.
+- `src/client/protocolgameparse.cpp`: parser de pacotes e `parseFeatures`.
+- `modules/client_entergame/entergame.lua`: features recebidas via login HTTP e `server_params`.
+
+No server, a referencia principal e `ProtocolGame::sendFeatures()` em `src/protocolgame.cpp`.
+
+## Regra principal
+
+Nem toda feature e apenas visual.
+
+Algumas features mudam o tamanho ou a ordem dos pacotes. Se o client habilita uma dessas features e o server nao envia os bytes extras, o parser sai de alinhamento.
+
+Sintomas comuns:
+
+- item aparece com ID errado;
+- container abre quebrado;
+- map fica preto ou com tiles errados;
+- erro de opcode desconhecido;
+- look/use para de funcionar;
+- crash ou disconnect ao abrir backpack, loot, corpo ou store inbox.
+
+## Como o Astra habilita features
+
+O Astra usa um perfil direto para `version == 860` em `modules/game_features/features.lua`.
+
+Ele reseta todas as features com `g_game.resetFeatures()` e depois habilita apenas o conjunto esperado para o Astra 8.60.
+
+Tambem existem features que podem vir do server:
+
+- login HTTP: campo `features`;
+- game packet `GameServerFeatures` (`0x43`), lido por `parseFeatures`;
+- `server_params` no `init.lua`, que o Astra tambem pode usar para habilitar features extras.
+
+Use `server_params` apenas para features seguras. Nao use esse caminho para feature que muda pacote de item/mapa/container.
+
+## Astra 8.60: features base
+
+Estas features sao habilitadas para o Astra 8.60 porque fazem parte do protocolo/base esperada:
+
+```lua
+GameLooktypeU16
+GameMessageStatements
+GameLoginPacketEncryption
+GamePlayerAddons
+GamePlayerStamina
+GameNewFluids
+GameMessageLevel
+GamePlayerStateU16
+GameNewOutfitProtocol
+GameWritableDate
+GameProtocolChecksum
+GameAccountNames
+GameDoubleFreeCapacity
+GameChallengeOnLogin
+GameMessageSizeCheck
+GameTileAddThingWithStackpos
+GameCreatureEmblems
+```
+
+## Astra 8.60: extensoes habilitadas no client
+
+Estas estao hardcoded no Astra 8.60:
+
+```lua
+GameAttackSeq
+GameBot
+GameExtendedOpcode
+GameSkillsBase
+GamePlayerMounts
+GameMagicEffectU16
+GameDistanceEffectU16
+GameDoubleHealth
+GameOfflineTrainingTime
+GameBaseSkillU16
+GameAdditionalSkills
+GameIdleAnimations
+GameEnhancedAnimations
+GameExtendedClientPing
+GameSpritesU32
+GameDoublePlayerGoodsMoney
+GameCreatureIcons
+GameColorizedLootValue
+GameBrowseField
+GamePlayerFamiliars
+GameProficiency
+GameUnjustifiedPoints
+GamePrey
+```
+
+Observacoes:
+
+- `GameSpritesU32` precisa bater com os assets estendidos (`.spr`) usados pelo client.
+- `GamePlayerFamiliars` altera dados de outfit no Astra; nao copie isso para o OTC Classic sem suporte no parser.
+- `GameColorizedLootValue` e uma feature do Astra, nao existe no OTC Classic desta branch.
+- `GameProficiency` existe como feature no client, mas so deve ser mantida se o server tambem estiver alinhado com os pacotes usados por ela.
+
+## Features negociadas pelo server
+
+O server pode enviar features pelo packet `0x43` (`GameServerFeatures`). O Astra tambem aceita features pelo login HTTP.
+
+No server atual, `sendFeatures()` envia, entre outras:
+
+```cpp
+ExtendedOpcode = true
+SkillsBase = true
+PlayerMounts = true
+MagicEffectU16 = true
+OfflineTrainingTime = true
+DoubleSkills = true
+BaseSkillU16 = true
+AdditionalSkills = true
+ExtendedClientPing = true
+CreatureIcons = true
+ContainerPagination = true
+BrowseField = true
+QuickLootFlags = shouldSendQuickLootFlags()
+ThingUpgradeClassification = false
+ItemTierByte = shouldSendItemTierByte()
+```
+
+Quando o client e Astra, o server tambem pode enviar:
+
+```cpp
+ExperienceBonus = true
+PlayerFamiliars = true
+AstraCreatureIcons = true
+AstraQuiverCountU16 = true
+AstraOutfitStoreMode = true
+DisplayItemDuration = true
+DisplayItemCharges = true
+PackedPlayerInventory = true
+AstraItemMetadata = true
+```
+
+Essas features precisam combinar com o parser do Astra. Nao copie as flags `Astra*` para o OTC Classic.
+
+## Features perigosas
+
+Estas tres sao as mais comuns de causar bug de protocolo:
+
+```lua
+GameQuickLootFlags              -- id 123
+GameThingUpgradeClassification  -- id 130
+GameItemTierByte                -- id 131
+```
+
+Nao troque `disableFeature` por `enableFeature` nelas sem alterar o server junto.
+
+### GameQuickLootFlags
+
+Muda leitura/escrita de flags de quick loot em itens/containers. Se o client espera a flag e o server nao envia, o proximo byte do pacote vira lixo para o parser.
+
+### GameThingUpgradeClassification
+
+Muda leitura de classificacao/tier em item. No server atual, essa feature e enviada como `false` para OTCv8/Astra.
+
+### GameItemTierByte
+
+Muda leitura de tier com um byte extra. So deve ficar ativa quando `shouldSendItemTierByte()` no server tambem estiver ativo.
+
+## Diferencas para OTCv8 Classic
+
+O OTCv8 Classic desta branch usa regras por faixas de versao (`if version >= 770`, `>= 780`, `>= 860`, etc.).
+
+No bloco `version >= 860`, o OTC Classic habilita principalmente:
+
+```lua
+GameAttackSeq
+GameBot
+GameExtendedOpcode
+GameSkillsBase
+GamePlayerMounts
+GameMagicEffectU16
+GameDistanceEffectU16
+GameDoubleHealth
+GameOfflineTrainingTime
+GameBaseSkillU16
+GameAdditionalSkills
+GameIdleAnimations
+GameEnhancedAnimations
+GameExtendedClientPing
+GameSpritesU32
+GameDoublePlayerGoodsMoney
+GameCreatureIcons
+GamePurseSlot
+GamePrey
+```
+
+E deixa explicito que estas ficam desligadas por padrao:
+
+```lua
+g_game.disableFeature(GameQuickLootFlags)
+g_game.disableFeature(GameThingUpgradeClassification)
+g_game.disableFeature(GameItemTierByte)
+```
+
+O Astra nao e uma copia direta desse bloco. O Astra 8.60 tem features proprias e parser proprio para algumas extensoes.
+
+## Checklist antes de mexer em feature
+
+- [ ] A feature e so visual/UI ou muda pacote de rede?
+- [ ] O id existe em `modules/gamelib/const.lua` e `src/client/const.h`?
+- [ ] O server envia a mesma feature em `sendFeatures()` ou login HTTP?
+- [ ] Se muda item, conferi `getItem`, `addItem`, container, map e inventory?
+- [ ] Se muda creature/outfit, conferi outfit window, creature icons e login?
+- [ ] Testei login, walk, look, use, open backpack, corpse, store inbox e logout?
+- [ ] Testei com a feature `false` e `true` quando ela e negociada?
+
+## Regra pratica
+
+Para o Astra 8.60:
+
+- feature comum e estavel do perfil Astra pode ficar em `modules/game_features/features.lua`;
+- feature que muda pacote deve vir do server por handshake;
+- feature Astra-only nao deve ser copiada para OTC Classic;
+- `GameQuickLootFlags`, `GameThingUpgradeClassification` e `GameItemTierByte` devem seguir o server, nao a vontade do client.

--- a/mods/game_store/classes/Home.lua
+++ b/mods/game_store/classes/Home.lua
@@ -192,7 +192,7 @@ function HomeOffer:createOffers()
 			g_game.requestStoreOffers(SERVICE_OFFER_ID, "", offer.id)
 		end
 
-		if offer.icon ~= "" then
+		if offer.icon ~= "" and widget.image then
 			local currentWidget = widget.image
 			currentWidget.currentImageRequest = Store.currentRequest
 			Store.imageRequests[Store.currentRequest] = currentWidget
@@ -204,7 +204,7 @@ function HomeOffer:createOffers()
 			end
 
 			Store:downloadImage(currentWidget.currentImageRequest, "64/"..offer.icon)
-		elseif offer.itemId ~= 0 then
+		elseif offer.itemId ~= 0 and widget.item then
 			widget.item:setItemId(offer.itemId)
 			widget.item:hook()
 		elseif offer.offerType == 1 then
@@ -352,7 +352,7 @@ function HomeOffer:createDailyOffers()
 			HomeOffer:processDailyOfferPurchase(offer.id)
 		end
 
-		if offer.icon ~= "" then
+		if offer.icon ~= "" and widget.image then
 			local currentWidget = widget.image
 			currentWidget.currentImageRequest = Store.currentRequest
 			Store.imageRequests[Store.currentRequest] = currentWidget
@@ -364,7 +364,7 @@ function HomeOffer:createDailyOffers()
 			end
 
 			Store:downloadImage(currentWidget.currentImageRequest, "64/"..offer.icon)
-		elseif offer.itemId ~= 0 then
+		elseif offer.itemId ~= 0 and widget.item then
 			widget.item:setItemId(offer.itemId)
 			widget.item:hook()
 		elseif offer.offerType == 1 then

--- a/mods/game_store/classes/Offers.lua
+++ b/mods/game_store/classes/Offers.lua
@@ -456,7 +456,7 @@ function Offers:refreshOffers(displayOffer, redirect, filter)
 				calldescription(offer.id)
 			end
 		end
-		if offer.icon ~= "" then
+		if offer.icon ~= "" and widget.image then
 			local currentWidget = widget.image
 			currentWidget.currentImageRequest = Store.currentRequest
 			Store.imageRequests[Store.currentRequest] = currentWidget
@@ -468,7 +468,7 @@ function Offers:refreshOffers(displayOffer, redirect, filter)
 			end
 
 			Store:downloadImage(currentWidget.currentImageRequest, "64/"..offer.icon)
-    	elseif offer.itemId ~= 0 then
+		elseif offer.itemId ~= 0 and widget.item then
 			widget.item:setItemId(offer.itemId)
 			widget.item:hook()
 		elseif offer.offerType == CATEGORY_MOUNT then
@@ -730,7 +730,7 @@ function Offers:onSelectionOffer(_, selectedWidget)
 	local offer = Offers.selectedWidget.offer
 	calldescription(offer.id)
 
-	if offer.icon ~= "" then
+	if offer.icon ~= "" and selectedWidget.image then
 		local widget = Offers.displayPanel.infopanel.image
 		if selectedWidget.image.imagePath then
 			clearWidgetImageRequest(widget)

--- a/modules/game_console/classes/Chat.lua
+++ b/modules/game_console/classes/Chat.lua
@@ -610,6 +610,21 @@ function Chat:onTalk(name, level, mode, text, channelId, pos, statement, groupId
 end
 
 function Chat:onTextMessage(mode, text)
+    -- TFS 8.60 sends orange console text as codes 19/20, which this client maps to MonsterSay/MonsterYell.
+    if g_game.getClientVersion() < 861 and
+        (mode == MessageModes.MonsterSay or mode == MessageModes.MonsterYell) then
+        local tab = self:getTabByName(SERVER_LOG_NAME)
+        if not tab then
+            return
+        end
+
+        self:addMessage(tab, SERVER_LOG_NAME, '', 0, mode, text, 0)
+        for _, serverLogTab in pairs(self.tabsServerLog) do
+            self:addMessage(serverLogTab, serverLogTab:getName(), '', 0, mode, text, 0)
+        end
+        return
+    end
+
     local messageType = MessageTypes[mode]
     if not messageType or messageType.hideInConsole or not messageType.consoleTab or mode == MessageModes.Market then
         return

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -187,6 +187,19 @@ local function getTopDecorationKitWrapableThing(tile)
   return nil
 end
 
+local function isDecorationKitThing(thing)
+  return thing and thing:isItem() and (thing:getId() == ITEM_DECORATION_KIT or isDecorationKitWrapable(thing))
+end
+
+local function showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing)
+  if not isDecorationKitThing(useThing) then
+    return false
+  end
+
+  createThingMenu(tile, menuPosition, lookThing, useThing, creatureThing)
+  return true
+end
+
 function canTalkToNpc(creature)
   if not creature or not creature:isNpc() then
     return false
@@ -1265,21 +1278,23 @@ function createThingMenu(tile, menuPosition, lookThing, useThing, creatureThing)
 
   if not g_app.isMobile() then shortcut = '(Alt)' else shortcut = nil end
   if useThing and not useThing:isStatic() then
-    if useThing:isContainer() then
-      if useThing:getParentContainer() then
-        menu:addOption(tr('Open'), function() g_game.open(useThing, useThing:getParentContainer()) end)
-        menu:addOption(tr('Open in new window'), function() g_game.openContainer(useThing) end)
-      else
-        menu:addOption(tr('Open in new window'), function() g_game.openContainer(useThing) end)
-      end
-    else
-      if useThing:isMultiUse() then
-        menu:addOption(tr('Use with ...'), function() startUseWith(useThing) end)
-      else
-        if creatureThing and creatureThing:isNpc() then
-          menu:addOption(tr('Use'), function() g_game.use(creatureThing) end)
+    if not isDecorationKitThing(useThing) then
+      if useThing:isContainer() then
+        if useThing:getParentContainer() then
+          menu:addOption(tr('Open'), function() g_game.open(useThing, useThing:getParentContainer()) end)
+          menu:addOption(tr('Open in new window'), function() g_game.openContainer(useThing) end)
         else
-          menu:addOption(tr('Use'), function() g_game.use(useThing) end)
+          menu:addOption(tr('Open in new window'), function() g_game.openContainer(useThing) end)
+        end
+      else
+        if useThing:isMultiUse() then
+          menu:addOption(tr('Use with ...'), function() startUseWith(useThing) end)
+        else
+          if creatureThing and creatureThing:isNpc() then
+            menu:addOption(tr('Use'), function() g_game.use(creatureThing) end)
+          else
+            menu:addOption(tr('Use'), function() g_game.use(useThing) end)
+          end
         end
       end
     end
@@ -1633,6 +1648,10 @@ function processClassicControl(tile, menuPosition, mouseButton, autoWalkPos, loo
   :: next ::
 
   if useThing and mouseButton == MouseRightButton and g_keyboard.isShiftPressed() then
+    if showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
+      return true
+    end
+
     if useThing and useThing:isContainer() then
       g_game.open(useThing)
       return true
@@ -1641,14 +1660,24 @@ function processClassicControl(tile, menuPosition, mouseButton, autoWalkPos, loo
     local thing = g_things.getThingType(useThing:getId())
     if creatureThing and not thing:hasAttribute(ThingAttrForceUse) and not creatureThing:getTile():hasDoor() then
       g_game.follow(creatureThing)
+    elseif showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
+      return true
     elseif useThing then
       g_game.use(useThing)
     end
   end
 
   if useThing and keyboardModifiers == KeyboardNoModifier and mouseButton == MouseRightButton and not g_mouse.isPressed(MouseLeftButton) then
+    if showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
+      return true
+    end
+
     local thing = g_things.getThingType(useThing:getId())
     if not creatureThing and thing:hasAttribute(ThingAttrForceUse) then
+      if showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
+        return true
+      end
+
       g_game.use(useThing)
       return true
     end
@@ -1678,6 +1707,8 @@ function processClassicControl(tile, menuPosition, mouseButton, autoWalkPos, loo
       end
     elseif useThing:isMultiUse() then
       startUseWith(useThing)
+      return true
+    elseif showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
       return true
     else
       g_game.use(useThing)
@@ -1747,6 +1778,10 @@ function processRegularControl(tile, menuPosition, mouseButton, autoWalkPos, loo
     g_game.look(lookThing)
     return true
   elseif useThing and keyboardModifiers == KeyboardCtrlModifier and (mouseButton == MouseLeftButton or mouseButton == MouseRightButton) then
+    if showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
+      return true
+    end
+
     if useThing:isContainer() then
       if useThing:getParentContainer() then
         g_game.open(useThing, useThing:getParentContainer())
@@ -1756,6 +1791,8 @@ function processRegularControl(tile, menuPosition, mouseButton, autoWalkPos, loo
       return true
     elseif useThing:isMultiUse() then
       startUseWith(useThing)
+      return true
+    elseif showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
       return true
     else
       g_game.use(useThing)
@@ -1823,6 +1860,10 @@ function processSmartControl(tile, menuPosition, mouseButton, autoWalkPos, lookT
       end
       return true
     elseif useThing and mouseButton == MouseLeftButton then
+      if showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
+        return true
+      end
+
       if useThing:isContainer() then
         if useThing:getParentContainer() then
           g_game.open(useThing, useThing:getParentContainer())
@@ -1831,6 +1872,8 @@ function processSmartControl(tile, menuPosition, mouseButton, autoWalkPos, lookT
         end
       elseif useThing:isMultiUse() then
         startUseWith(useThing)
+      elseif showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing) then
+        return true
       elseif useThing:isUsable() or useThing:isForceUse() or useThing:isPickupable() then
         g_game.use(useThing)
       elseif (useThing:isGround() or useThing:isGroundBorder() or useThing:isFullGround() or useThing:isIgnoreLook() or useThing:isNotPathable()) and autoWalkPos then
@@ -2454,7 +2497,7 @@ function setupLeftActions()
       local tile = g_map.getTile(usePos)
       if not tile then return end
       local thing = tile:getTopUseThing()
-      if thing then
+      if thing and not isDecorationKitThing(thing) then
         g_game.use(thing)
       end
     end

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -38,6 +38,154 @@ local widgetItem
 local lastAction = 0
 local npcTalkMaxDistance = 3
 local ITEM_DECORATION_KIT = 23398
+-- 8.6 dat does not flag Store decoration-kit outputs as wrapable.
+local ITEM_DECORATION_KIT_WRAPABLE_RANGES = {
+  {12699, 12699},
+  {22736, 22737},
+  {23399, 23411},
+  {23414, 23414},
+  {23417, 23445},
+  {23448, 23455},
+  {23536, 23537},
+  {23691, 23691},
+  {23693, 23720},
+  {23722, 23725},
+  {24416, 24435},
+  {25103, 25104},
+  {25174, 25175},
+  {25182, 25183},
+  {25200, 25200},
+  {25210, 25233},
+  {25720, 25723},
+  {25879, 25883},
+  {25889, 25893},
+  {25899, 25900},
+  {25903, 25914},
+  {26075, 26078},
+  {26081, 26084},
+  {26088, 26099},
+  {26101, 26123},
+  {26150, 26167},
+  {26170, 26174},
+  {27661, 27671},
+  {27673, 27675},
+  {27679, 27689},
+  {27691, 27700},
+  {27702, 27703},
+  {28525, 28525},
+  {28559, 28564},
+  {28671, 28671},
+  {28674, 28690},
+  {28694, 28694},
+  {28696, 28699},
+  {28912, 28914},
+  {28919, 28948},
+  {30227, 30230},
+  {30232, 30249},
+  {31183, 31197},
+  {31207, 31214},
+  {31217, 31226},
+  {31382, 31382},
+  {31462, 31462},
+  {31464, 31464},
+  {31466, 31469},
+  {31679, 31684},
+  {31687, 31698},
+  {31703, 31706},
+  {31931, 31951},
+  {31955, 31956},
+  {32123, 32123},
+  {32128, 32166},
+  {32473, 32536},
+  {32541, 32566},
+  {32751, 32756},
+  {32775, 32793},
+  {32795, 32801},
+  {32907, 32912},
+  {32918, 32918},
+  {32943, 32974},
+  {32979, 32979},
+  {33026, 33049},
+  {34027, 34071},
+  {34269, 34276},
+  {34278, 34278},
+  {34280, 34280},
+  {34282, 34282},
+  {34284, 34305},
+  {34309, 34309},
+  {34312, 34325},
+  {34332, 34332},
+  {35153, 35193},
+  {35203, 35209},
+  {35582, 35582},
+  {35584, 35586},
+  {35851, 35900},
+  {35911, 35939},
+  {35941, 35944},
+  {35949, 35949},
+  {35954, 35964},
+  {35969, 35969},
+  {35973, 35974},
+  {36617, 36654},
+  {36748, 36754},
+  {36756, 36756},
+  {36833, 36833},
+  {36865, 36869},
+  {36995, 36995},
+  {37004, 37034},
+  {37165, 37165},
+  {37174, 37212},
+  {37519, 37520},
+  {37700, 37700},
+  {37746, 37746},
+  {37763, 37816},
+  {38640, 38640},
+  {38707, 38707},
+  {39419, 39447},
+  {39496, 39502},
+  {39504, 39510},
+  {39517, 39526},
+  {39668, 39668},
+  {39767, 39810},
+  {42267, 42308},
+  {42320, 42368},
+  {50435, 50436},
+  {51186, 51186},
+  {51188, 51190},
+  {51196, 51199},
+  {51204, 51223},
+  {51237, 51237},
+}
+
+local function isDecorationKitWrapable(thing)
+  if not thing or not thing:isItem() then
+    return false
+  end
+
+  local thingId = thing:getId()
+  for _, range in ipairs(ITEM_DECORATION_KIT_WRAPABLE_RANGES) do
+    if thingId >= range[1] and thingId <= range[2] then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function getTopDecorationKitWrapableThing(tile)
+  if not tile or type(tile.getThings) ~= 'function' then
+    return nil
+  end
+
+  local things = tile:getThings()
+  for i = #things, 1, -1 do
+    if isDecorationKitWrapable(things[i]) then
+      return things[i]
+    end
+  end
+
+  return nil
+end
 
 function canTalkToNpc(creature)
   if not creature or not creature:isNpc() then
@@ -1144,10 +1292,15 @@ function createThingMenu(tile, menuPosition, lookThing, useThing, creatureThing)
       end
     end
 
-    if useThing:isWrapable() then
-      menu:addOption(tr('Wrap'), function() g_game.wrap(useThing) end)
-    elseif tile and tile:getTopWrapableThing() then
-      menu:addOption(tr('Wrap'), function() g_game.wrap(tile:getTopWrapableThing()) end)
+    local wrapThing
+    if useThing:isWrapable() or isDecorationKitWrapable(useThing) then
+      wrapThing = useThing
+    elseif tile then
+      wrapThing = tile:getTopWrapableThing() or getTopDecorationKitWrapableThing(tile)
+    end
+
+    if wrapThing then
+      menu:addOption(tr('Wrap'), function() g_game.wrap(wrapThing) end)
     end
 
     if useThing:isUnwrapable() or useThing:getId() == ITEM_DECORATION_KIT then

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -37,6 +37,7 @@ local keybindClearOldMessage = KeyBind:getKeyBind("Misc.", "Clear oldest message
 local widgetItem
 local lastAction = 0
 local npcTalkMaxDistance = 3
+local ITEM_DECORATION_KIT = 23398
 
 function canTalkToNpc(creature)
   if not creature or not creature:isNpc() then
@@ -1149,7 +1150,7 @@ function createThingMenu(tile, menuPosition, lookThing, useThing, creatureThing)
       menu:addOption(tr('Wrap'), function() g_game.wrap(tile:getTopWrapableThing()) end)
     end
 
-    if useThing:isUnwrapable() then
+    if useThing:isUnwrapable() or useThing:getId() == ITEM_DECORATION_KIT then
       menu:addOption(tr('Unwrap'), function() g_game.wrap(useThing) end)
     end
     local podiumIds = {RENOWN_PODIUM, LEGACY_RENOWN_PODIUM, VIGOUR_PODIUM, TENACITY_PODIUM, ASTRA_MONSTER_PODIUM}

--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -188,7 +188,7 @@ local function getTopDecorationKitWrapableThing(tile)
 end
 
 local function isDecorationKitThing(thing)
-  return thing and thing:isItem() and (thing:getId() == ITEM_DECORATION_KIT or isDecorationKitWrapable(thing))
+  return thing and thing:isItem() and thing:getId() == ITEM_DECORATION_KIT
 end
 
 local function showDecorationKitMenu(tile, menuPosition, lookThing, useThing, creatureThing)

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,13 @@ AstraClient is the public client identity for this project.
 Created/maintained by Mateuzkl.
 
 
+## Protocol Features
+
+Read the feature guide before changing `g_game.enableFeature` or `g_game.disableFeature`:
+
+- English: `docs/protocol-features-8.60.md`
+- PT-BR: `docs/protocol-features-8.60.pt-BR.md`
+
 ## Build
 
 ### Windows


### PR DESCRIPTION
## What changed

- Guard store offer image rendering so `ImageOffer` logic only runs when the created widget actually has an `image` child.
- Let item-based offers with an icon fall back to the `item` widget in offer lists, home offers, daily offers, and the selected-offer panel.

## Why

House/decor store offers can arrive with both `itemId` and `icon`. The client chooses the `ItemOffer` template because `itemId` is present, but the old render path checked `icon` first and tried to write to `widget.image`, which does not exist on `ItemOffer`. That caused:

`/mods/game_store/classes/Offers.lua:461: attempt to index local 'currentWidget' (a nil value)`

## Validation

- Ran `git diff --check -- mods/game_store/classes/Offers.lua mods/game_store/classes/Home.lua`.
- Verified there are no remaining unguarded `if offer.icon ~= "" then` branches in those store offer render files.

Note: no Lua CLI is installed in this PowerShell environment, so I could not run a standalone Lua syntax check.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Guards the store offer image-rendering path so `widget.image` is checked before being accessed, fixing a nil-indexing crash (`attempt to index local 'currentWidget' (a nil value)`) that affected house/decor offers with both `itemId` and `icon` set. Adds a fallback to the `item` widget for these offers in the offer list, home offers, daily offers, and the selected-offer panel.

- **Offers.lua / Home.lua**: Four call sites that wrote to `widget.image` without checking its existence are now guarded by `and widget.image` (and `and widget.item` on the fallback branch), correctly routing icon+itemId offers through the item widget when the created widget is an `ItemOffer`.
- **gameinterface.lua**: Adds a decoration-kit interaction system — a large table of wrappable item ID ranges, helper functions (`isDecorationKitWrapable`, `getTopDecorationKitWrapableThing`, `showDecorationKitMenu`), and hooks into the three control-mode handlers so that right/left-clicking a decoration kit opens its context menu instead of directly using it.
- **Chat.lua**: Intercepts MonsterSay/MonsterYell message modes (codes 19/20) for client version < 861 and routes them to the server log tab, matching how TFS 8.60 uses those codes for orange console text.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the nil-crash fix is correct across all four call sites, and the new decoration-kit and chat-routing logic is well-guarded.

The store offer fix is minimal and surgically correct: adding `and widget.image` / `and widget.item` guards exactly where the crash originated, while leaving the selection-panel branch (which uses a fixed infopanel widget) untouched as intended. The decoration-kit additions in gameinterface.lua are additive and self-contained. The only issues found are a few unreachable `showDecorationKitMenu` calls — harmless dead code that does not affect runtime behavior.

The redundant `showDecorationKitMenu` calls in `modules/game_interface/gameinterface.lua` are worth cleaning up for clarity, but they do not affect correctness.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| mods/game_store/classes/Offers.lua | Two sites guarded: `widget.image` check in refreshOffers and `selectedWidget.image` check in onSelectionOffer. The itemId fallback in onSelectionOffer correctly uses the fixed infopanel widget, so no additional guard is needed there. |
| mods/game_store/classes/Home.lua | Two call sites (createOffers and createDailyOffers) guarded symmetrically with the Offers.lua fix; both icon and item branches now check widget child existence before access. |
| modules/game_interface/gameinterface.lua | Adds decoration-kit interaction logic. showDecorationKitMenu is called once at the top of each control-handler block and then redundantly in a later elseif branch — dead code, but harmless. The wrap/unwrap and menu-suppression logic appears correct. |
| modules/game_console/classes/Chat.lua | Correctly reroutes MonsterSay/MonsterYell (TFS 8.60 codes 19/20) to the server log tab for client versions below 861, preventing them from being processed as creature speech messages. |
| docs/protocol-features-8.60.md | New developer reference doc for 8.60 feature flags; documentation only, no logic changes. |
| readme.md | Adds links to the new protocol feature docs; documentation only. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Store offer arrives with icon + itemId] --> B{Widget type?}
    B -->|ImageOffer has widget.image| C{icon != '' and widget.image?}
    B -->|ItemOffer no widget.image| C
    C -->|YES: widget.image exists| D[Download icon to widget.image]
    C -->|NO: widget.image is nil| E{itemId != 0 and widget.item?}
    E -->|YES: widget.item exists| F[setItemId on widget.item]
    E -->|NO| G{offerType?}
    G -->|MOUNT| H[setOutfit mountId]
    G -->|OUTFIT| I[setOutfit type/colors]
    G -->|other| J[no visual]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Store offer arrives with icon + itemId] --> B{Widget type?}
    B -->|ImageOffer has widget.image| C{icon != '' and widget.image?}
    B -->|ItemOffer no widget.image| C
    C -->|YES: widget.image exists| D[Download icon to widget.image]
    C -->|NO: widget.image is nil| E{itemId != 0 and widget.item?}
    E -->|YES: widget.item exists| F[setItemId on widget.item]
    E -->|NO| G{offerType?}
    G -->|MOUNT| H[setOutfit mountId]
    G -->|OUTFIT| I[setOutfit type/colors]
    G -->|other| J[no visual]
```

</a>

<sub>Reviews (7): Last reviewed commit: ["fix(interface): allow direct use on wrap..."](https://github.com/mateuzkl/astraclient/commit/0e2b6c31ae3e7d9c3daf37c0f969ce1dd5327463) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41932369)</sub>

<!-- /greptile_comment -->