### PR TITLE
Fix Astra creature icon stack rendering

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -344,9 +344,11 @@ void Creature::drawInformation(const Point& point, bool useGray, const Rect& par
     }
 
     if (!m_creatureIcons.empty()) {
-        const auto countFont = g_fonts.getFont("verdana-cap-bold");
-        const float iconX = backgroundRect.x() + 15.5 + 12;
-        const float iconY = backgroundRect.y() + 5;
+        static const auto countFont = g_fonts.fontExists("verdana-cap-bold")
+            ? g_fonts.getFont("verdana-cap-bold")
+            : g_fonts.getDefaultFont();
+        const int iconX = backgroundRect.x() + 15 + 12;
+        const int iconY = backgroundRect.y() + 5;
         const int iconStepY = 14;
 
         for (size_t i = 0; i < m_creatureIcons.size() && i < 4; ++i) {

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -344,11 +344,9 @@ void Creature::drawInformation(const Point& point, bool useGray, const Rect& par
     }
 
     if (!m_creatureIcons.empty()) {
-        static const auto countFont = g_fonts.fontExists("verdana-cap-bold")
-            ? g_fonts.getFont("verdana-cap-bold")
-            : g_fonts.getDefaultFont();
-        const int iconX = backgroundRect.x() + 15 + 12;
-        const int iconY = backgroundRect.y() + 5;
+        const auto countFont = g_fonts.getFont("verdana-cap-bold");
+        const float iconX = backgroundRect.x() + 15.5 + 12;
+        const float iconY = backgroundRect.y() + 5;
         const int iconStepY = 14;
 
         for (size_t i = 0; i < m_creatureIcons.size() && i < 4; ++i) {

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -343,26 +343,25 @@ void Creature::drawInformation(const Point& point, bool useGray, const Rect& par
         g_drawQueue->addTexturedRect(iconRect, m_iconTexture, Rect(0, 0, m_iconTexture->getSize()));
     }
 
-    // Draw creature quest/modification icons below the emblem/type row
-    // Aligned to same X column as emblem/skull (backgroundRect.x + 13.5 + 12)
     if (!m_creatureIcons.empty()) {
-        float iconX = backgroundRect.x() + 13.5 + 12;
-        // Position below skull/shield row if no emblem, or below emblem if present
-        bool hasEmblem = (m_emblem != Otc::EmblemNone && m_emblemTexture);
-        float iconY = backgroundRect.y() + (hasEmblem ? 27 : 19);
+        const auto countFont = g_fonts.getFont("verdana-cap-bold");
+        const float iconX = backgroundRect.x() + 15.5 + 12;
+        const float iconY = backgroundRect.y() + 5;
+        const int iconStepY = 14;
+
         for (size_t i = 0; i < m_creatureIcons.size() && i < 4; ++i) {
             auto [iconId, category, iconCount] = m_creatureIcons[i];
             TexturePtr tex = i < m_creatureIconTextures.size() ? m_creatureIconTextures[i] : getCreatureIconTexture(iconId, category);
             if (tex) {
-                Rect r(iconX, iconY, tex->getSize());
+                Rect r(iconX, iconY + i * iconStepY, tex->getSize());
                 g_drawQueue->addTexturedRect(r, tex, Rect(0, 0, tex->getSize()));
+
                 if (iconCount > 0) {
                     std::string countStr = std::to_string(iconCount);
-                    g_drawQueue->addText(g_fonts.getDefaultFont(), countStr,
-                        Rect(iconX + tex->getWidth() + 1, iconY, 20, tex->getHeight()),
-                        Fw::AlignLeftCenter, Color::white);
+                    g_drawQueue->addText(countFont, countStr,
+                        Rect(r.right() + 2, r.y() - 1, 24, r.height() + 2),
+                        Fw::AlignLeftCenter, Color::white, true);
                 }
-                iconX += tex->getWidth() + (iconCount > 0 ? 16 : 2);
             }
         }
     }

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4754,6 +4754,20 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
         int speed = msg->getU16();
         if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getProtocolVersion() >= 1240)
             msg->getU8();
+
+        const bool hasAstraCreatureIcons = g_game.getFeature(Otc::GameAstraCreatureIcons);
+        std::vector<std::tuple<uint8_t, uint8_t, uint16_t>> creatureIcons;
+        if (hasAstraCreatureIcons) {
+            uint8_t count = msg->getU8();
+            creatureIcons.reserve(count);
+            for (uint8_t i = 0; i < count; ++i) {
+                uint8_t iconId = msg->getU8();
+                uint8_t category = msg->getU8();
+                uint16_t iconCount = msg->getU16();
+                creatureIcons.emplace_back(iconId, category, iconCount);
+            }
+        }
+
         int skull = msg->getU8();
         int shield = msg->getU8();
 
@@ -4781,10 +4795,6 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
             }
         }
 
-        const bool hasAstraCreatureIcons =
-            g_game.getFeature(Otc::GameAstraCreatureIcons) ||
-            (g_game.getFeature(Otc::GameCreatureIcons) && g_game.getFeature(Otc::GameAstraQuiverCountU16));
-
         if (g_game.getFeature(Otc::GameCreatureIcons)) {
             icon = msg->getU8();
         }
@@ -4806,18 +4816,6 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
 
         if (g_game.getProtocolVersion() >= 854 || g_game.getFeature(Otc::GameCreatureWalkthrough))
             unpass = msg->getU8();
-
-        std::vector<std::tuple<uint8_t, uint8_t, uint16_t>> creatureIcons;
-        if (hasAstraCreatureIcons) {
-            uint8_t count = msg->getU8();
-            creatureIcons.reserve(count);
-            for (uint8_t i = 0; i < count; ++i) {
-                uint8_t iconId = msg->getU8();
-                uint8_t category = msg->getU8();
-                uint16_t iconCount = msg->getU16();
-                creatureIcons.emplace_back(iconId, category, iconCount);
-            }
-        }
 
         if (creature) {
             creature->setHealthPercent(healthPercent);


### PR DESCRIPTION
## Summary
- Render creature quest/modification icons as a vertical stack beside the outfit, matching the global/Mehah positioning.
- Draw icon counters with the CAP font and shadow for better readability.
- Parse Astra creature icon stacks immediately after creature speed when the server enables `GameAstraCreatureIcons`, and stop treating `AstraQuiverCountU16` as an inline creature-icon signal.

## Validation
- Reviewed the Astra and Mehah render paths.
- Ran `git diff --check` on the changed files.
- Did not compile the client, per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ajustada a exibição dos ícones de criatura para manter o alinhamento correto e a ordem visual em diferentes situações.
  * Corrigida a sobreposição de contagens, que agora aparece de forma mais clara e consistente sobre cada ícone.
  * Melhorado o carregamento e a atualização dos ícones de criatura, reduzindo inconsistências na aparência durante mudanças de estado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how Astra creature quest/modification icons are rendered — from a horizontal row to a vertical stack beside the health bar — and relocates their parse position in the protocol stream from after `unpass` to immediately after the creature's speed field. The `GameAstraQuiverCountU16` flag is removed as a secondary trigger for icon parsing so that only `GameAstraCreatureIcons` activates the block.

- **`creature.cpp`**: Icons are now stacked vertically at a fixed column (`backgroundRect.x() + 27.5`, `backgroundRect.y() + 5 + i×14`), matching the stated Mehah layout. Counter text switches to "verdana-cap-bold" with shadow.
- **`protocolgameparse.cpp`**: The Astra icon block is read before skull/shield/emblem/NPC-icon/marks/unpass; previously it was read last. This ordering change is the highest-risk part of the PR and has not been validated against a running Astra server (per the PR description).

<h3>Confidence Score: 3/5</h3>

Not safe to merge without validating the new protocol byte order against a live Astra server — a wrong position silently corrupts skull, shield, emblem, NPC icon, and walkthrough for all creatures while GameAstraCreatureIcons is active.

The rendering change in creature.cpp is straightforward and low-risk. The critical unknown is protocolgameparse.cpp: the Astra icon block was moved from the end of the creature record to immediately after the speed field, a position change that was reasoned about but neither compiled nor tested against an actual Astra server. A wrong ordering causes silent stream misalignment with no error thrown.

src/client/protocolgameparse.cpp — the new parse position for the Astra icon block needs to be cross-checked against the Astra server's actual wire protocol before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/client/creature.cpp | Switches Astra creature icon rendering from a dynamic-X horizontal layout to a fixed vertical stack (iconStepY=14) at a fixed column 2 px right of the skull icon; also replaces the default font with "verdana-cap-bold" with shadow for counters. |
| src/client/protocolgameparse.cpp | Moves the Astra icon block parse from after `unpass` to immediately after the speed field (before skull/shield/emblem), and removes the `GameAstraQuiverCountU16` fallback trigger. The new parse position has not been verified against the actual Astra server wire format. |

<sub>Reviews (3): Last reviewed commit: ["Revert &quot;Harden Astra icon counter font&quot;"](https://github.com/mateuzkl/astraclient/commit/2a85252e0c8f50fcf86c9a69b2d500d7019c5fb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42994534)</sub>

<!-- /greptile_comment -->