### PR TITLE
Fix tile click priority over quickloot

### DIFF
--- a/modules/game_interface/gameinterface.lua
+++ b/modules/game_interface/gameinterface.lua
@@ -1609,8 +1609,8 @@ local function findQuickLootThing(tile, useThing, lookThing, allowPickupable)
   return nil
 end
 
-local function shouldBlockQuickLootForCreature(quickLootThing, useThing, lookThing, creatureThing)
-  return creatureThing and not creatureThing:isPlayer() and quickLootThing ~= useThing and quickLootThing ~= lookThing
+local function shouldBlockQuickLootForCreature(creatureThing)
+  return creatureThing and not callThingBool(creatureThing, 'isLocalPlayer')
 end
 
 function processClassicControl(tile, menuPosition, mouseButton, autoWalkPos, lookThing, useThing, creatureThing, attackCreature, marking)
@@ -1630,7 +1630,7 @@ function processClassicControl(tile, menuPosition, mouseButton, autoWalkPos, loo
   local quickLootThing = findQuickLootThing(tile, useThing, lookThing, isLootLeftClick) or lootThing or useThing
 
   if quickLootThing and useLoot and isQuickLootFeatureEnabled() then
-    if shouldBlockQuickLootForCreature(quickLootThing, useThing, lookThing, creatureThing) then
+    if shouldBlockQuickLootForCreature(creatureThing) then
       goto next
     end
 
@@ -1761,7 +1761,7 @@ function processRegularControl(tile, menuPosition, mouseButton, autoWalkPos, loo
 
   local quickLootThing = findQuickLootThing(tile, useThing, lookThing, false)
   if quickLootThing and g_keyboard.isShiftPressed() and mouseButton == MouseRightButton and isQuickLootFeatureEnabled() then
-    if shouldBlockQuickLootForCreature(quickLootThing, useThing, lookThing, creatureThing) then
+    if shouldBlockQuickLootForCreature(creatureThing) then
       goto next
     end
 
@@ -1841,7 +1841,7 @@ function processSmartControl(tile, menuPosition, mouseButton, autoWalkPos, lookT
 
   local quickLootThing = findQuickLootThing(tile, useThing, lookThing, false)
   if quickLootThing and g_keyboard.isAltPressed() and mouseButton == MouseLeftButton and isQuickLootFeatureEnabled() then
-    if shouldBlockQuickLootForCreature(quickLootThing, useThing, lookThing, creatureThing) then
+    if shouldBlockQuickLootForCreature(creatureThing) then
       goto next
     end
 


### PR DESCRIPTION
## Summary
- Prefer live creatures over quickloot when a corpse/container shares the same tile.
- Let normal attack/menu handling continue instead of sending quickloot for the corpse underneath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Ajustado o comportamento do “quick loot” para ser bloqueado de forma mais consistente ao interagir com criaturas que não sejam o jogador local.
  * Melhorada a lógica de decisão em diferentes modos de controle, reduzindo inconsistências no uso do loot rápido.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR simplifies the `shouldBlockQuickLootForCreature` helper to always block quickloot when any live creature (other than the local player) is present on a tile, removing the previous conditions that allowed quickloot to proceed when the loot target matched `useThing` or `lookThing`. It also switches from the direct `isPlayer()` call to `callThingBool(creatureThing, 'isLocalPlayer')`, which means other players' presence now blocks quickloot too, not just monsters/NPCs.

- The function signature is reduced from four parameters to one, and the call sites across all three control modes (`processClassicControl`, `processRegularControl`, `processSmartControl`) are updated accordingly.
- The behavioral change for other-player creatures (previously their presence did not block quickloot; now it does) is consistent with the stated intent of always preferring live-creature interaction over quicklooting a corpse beneath them.

<h3>Confidence Score: 5/5</h3>

This is a focused, low-risk change to tile-click interaction priority that replaces a multi-condition guard with a simpler, more correct one.

The change removes the conditions that accidentally allowed quickloot to fire even when a live creature was present on the same tile as the corpse. The simplified helper is easier to reason about and is consistently applied across all three control modes.

No files require special attention; the change is self-contained within the shouldBlockQuickLootForCreature helper and its three call sites.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/game_interface/gameinterface.lua | Simplifies shouldBlockQuickLootForCreature to block quickloot whenever any non-local-player creature is on the tile; removes the now-unnecessary quickLootThing/useThing/lookThing parameter comparisons, and consistently applies this across all three control modes. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Tile click event] --> B{quickLootThing found\nAND useLoot/key enabled\nAND feature enabled?}
    B -- No --> G[Normal attack / menu / walk handling]
    B -- Yes --> C{shouldBlockQuickLootForCreature}
    C -- "creatureThing present\nAND not local player?" --> D[goto next\n= skip quickloot]
    D --> G
    C -- "no creature OR creature\nis local player" --> E{isQuickLootTargetThing\nor inCorpse?}
    E -- Yes --> F[g_game.quickLoot - send loot request]
    E -- No --> G

    style F fill:#2d6a4f,color:#fff
    style D fill:#d62828,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Tile click event] --> B{quickLootThing found\nAND useLoot/key enabled\nAND feature enabled?}
    B -- No --> G[Normal attack / menu / walk handling]
    B -- Yes --> C{shouldBlockQuickLootForCreature}
    C -- "creatureThing present\nAND not local player?" --> D[goto next\n= skip quickloot]
    D --> G
    C -- "no creature OR creature\nis local player" --> E{isQuickLootTargetThing\nor inCorpse?}
    E -- Yes --> F[g_game.quickLoot - send loot request]
    E -- No --> G

    style F fill:#2d6a4f,color:#fff
    style D fill:#d62828,color:#fff
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(interface): prefer creatures over qu..."](https://github.com/mateuzkl/astraclient/commit/642a417c23074382b8bd08f519bf590f3bb19898) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43012077)</sub>

<!-- /greptile_comment -->