### PR TITLE
Fix unlocked achievements in Cyclopedia

### DIFF
--- a/mods/game_cyclopedia/classes/character.lua
+++ b/mods/game_cyclopedia/classes/character.lua
@@ -41,6 +41,20 @@ local function getAchievementCatalog()
 	return ACHIEVEMENTS or {}
 end
 
+local function requestAchievementData()
+	local protocol = g_game.getProtocolGame()
+	if not protocol then
+		return false
+	end
+
+	local msg = OutputMessage.create()
+	msg:addU8(0xE5)
+	msg:addU32(0) -- Current character.
+	msg:addU8(5) -- Achievements.
+	protocol:send(msg)
+	return true
+end
+
 local SkillNames = {
 	[1] = "Magic Level",
 	[6] = "Shielding",
@@ -288,7 +302,7 @@ function Character.onChangeCharacterPanel(buttonId)
 		buttons[buttonId].buttons:setOn(true)
 		buttons[buttonId].buttons.arrowRef:setImageSource("/game_cyclopedia/images/ui/arrow-right")
 		buttons[buttonId].buttons.arrowRef:setVisible(true)
-		if buttonId == 3 then windowPanel:destroyChildren() g_game.requestCyclopediaData(5) Character.initAchievements()
+		if buttonId == 3 then windowPanel:destroyChildren() requestAchievementData() Character.initAchievements()
 		elseif buttonId == 4 then windowPanel:destroyChildren() Character.initSummary() g_game.requestCyclopediaData(6)
 		elseif buttonId == 5 then windowPanel:destroyChildren() Character.initAppearences() g_game.requestCyclopediaData(7)
 		elseif buttonId == 6 then windowPanel:destroyChildren() Titles.initPanel() g_game.requestCyclopediaData(11) end

--- a/modules/game_protocol/protocol.lua
+++ b/modules/game_protocol/protocol.lua
@@ -648,28 +648,38 @@ function registerProtocol()
 		local secretMax = msg:getU16()
 		local size = msg:getU16() -- Unlocked
 		local definitions = ACHIEVEMENTS or {}
+		local definitionsByName = {}
+		for definitionId, definition in pairs(definitions) do
+			if definition.name then
+				definitionsByName[definition.name:lower()] = definitionId
+			end
+		end
 		local achievements = {}
 		for i = 1, size do
 			local id = msg:getU16()
 			local timestamp = msg:getU32()
-			local secret = msg:getU8() > 0
+			local flags = msg:getU8()
+			local secret = flags % 2 == 1
+			-- Legacy packets used 1 to mean both secret and metadata present.
+			local hasMetadata = flags == 1 or flags >= 2
 			local definition = definitions[id]
-			if not definition then
-				for _, candidate in pairs(definitions) do
-					if candidate.id == id then
-						definition = candidate
-						break
-					end
-				end
-			end
-
 			local name = definition and definition.name or string.format('Achievement %d', id)
 			local description = definition and definition.description or ''
 			local grade = definition and definition.grade or 0
-			if secret then
+			if hasMetadata then
 				name = msg:getString()
 				description = msg:getString()
 				grade = msg:getU8()
+			end
+
+			local catalogId = definitionsByName[name:lower()]
+			if catalogId then
+				id = catalogId
+				definition = definitions[id]
+				secret = definition.secret == true
+				name = definition.name
+				description = definition.description or description
+				grade = definition.grade or grade
 			end
 
 			achievements[id] = {


### PR DESCRIPTION
## Summary

- request achievement data with the Crystal character-info packet layout
- resolve legacy TFS achievement IDs against Astra's global catalog by name
- display unlocked achievements, points, grades, and progress correctly

## Server dependency

Requires TFS commit `ee1fcc0` on `port-crystal-global15x-scripts`.

## Validation

- `git diff --check` passes
- existing achievement storages are preserved
- old and new achievement metadata packet flags remain parse-compatible
- Astra compilation intentionally left to the project owner