### PR TITLE
perf: reduce analyser and Bosstiary stalls

### DIFF
--- a/mods/game_analyser/analyser.lua
+++ b/mods/game_analyser/analyser.lua
@@ -118,7 +118,7 @@ end
 
 function terminate()
   LootAnalyser:cancelPendingWindowUpdate()
-  DropTrackerAnalyser:cancelPendingWindowUpdate()
+  DropTrackerAnalyser:terminate()
 
   if analyserMiniWindow then
     analyserMiniWindow:destroy()

--- a/mods/game_analyser/analyser.lua
+++ b/mods/game_analyser/analyser.lua
@@ -7,6 +7,8 @@ openedWindows = {}
 
 local OPCODE_KILL_TRACKER = 0xD1
 local MAX_KILL_TRACKER_DEPTH = 4
+local SLOW_KILL_TRACKER_US = 5000
+local lastSlowKillTrackerWarning = nil
 
 local analyserWindows = {
   huntingButton = 'styles/hunting',
@@ -125,6 +127,8 @@ end
 function terminate()
   ProtocolGame.unregisterOpcode(OPCODE_KILL_TRACKER)
 
+  DropTrackerAnalyser:cancelPendingWindowUpdate()
+
   if analyserMiniWindow then
     analyserMiniWindow:destroy()
     analyserMiniWindow = nil
@@ -190,6 +194,7 @@ local function parseCompactKillTrackerItems(msg, dropItems, depth)
 end
 
 function parseCompactKillTracker(protocol, msg)
+  local startedAt = g_clock.realMicros()
   local monsterName = msg:getString()
   local monsterOutfit = {
     type = msg:getU16(),
@@ -201,7 +206,21 @@ function parseCompactKillTracker(protocol, msg)
   }
   local dropItems = {}
   parseCompactKillTrackerItems(msg, dropItems, 1)
+  local decodedAt = g_clock.realMicros()
   signalcall(g_game.onKillTracker, monsterName, monsterOutfit, dropItems)
+
+  local finishedAt = g_clock.realMicros()
+  local totalUs = finishedAt - startedAt
+  local now = g_clock.realMillis()
+  if totalUs >= SLOW_KILL_TRACKER_US and
+      (not lastSlowKillTrackerWarning or now - lastSlowKillTrackerWarning >= 1000) then
+    lastSlowKillTrackerWarning = now
+    g_logger.warning(string.format(
+      "[SlowLua] game_analyser/analyser.lua:parseCompactKillTracker took %.3f ms " ..
+      "(decode=%.3f ms, callbacks=%.3f ms, drops=%d, monster=%s)",
+      totalUs / 1000, (decodedAt - startedAt) / 1000,
+      (finishedAt - decodedAt) / 1000, #dropItems, monsterName))
+  end
 end
 
 function startNewSession(login)

--- a/mods/game_analyser/analyser.lua
+++ b/mods/game_analyser/analyser.lua
@@ -5,11 +5,6 @@ end
 
 openedWindows = {}
 
-local OPCODE_KILL_TRACKER = 0xD1
-local MAX_KILL_TRACKER_DEPTH = 4
-local SLOW_KILL_TRACKER_US = 5000
-local lastSlowKillTrackerWarning = nil
-
 local analyserWindows = {
   huntingButton = 'styles/hunting',
   lootButton = 'styles/loot',
@@ -25,9 +20,6 @@ local analyserWindows = {
 
 -- objects
 function init()
-  ProtocolGame.unregisterOpcode(OPCODE_KILL_TRACKER)
-  ProtocolGame.registerOpcode(OPCODE_KILL_TRACKER, parseCompactKillTracker)
-
   analyserMiniWindow = g_ui.loadUI('analyser', m_interface.getRightPanel())
   analyserMiniWindow:disableResize()
   analyserMiniWindow:close()
@@ -125,8 +117,7 @@ function init()
 end
 
 function terminate()
-  ProtocolGame.unregisterOpcode(OPCODE_KILL_TRACKER)
-
+  LootAnalyser:cancelPendingWindowUpdate()
   DropTrackerAnalyser:cancelPendingWindowUpdate()
 
   if analyserMiniWindow then
@@ -168,59 +159,6 @@ function terminate()
       onShieldChange = onShieldChange,
   })
 
-end
-
-local function parseCompactKillTrackerItems(msg, dropItems, depth)
-  local itemCount = msg:getU8()
-  if depth > MAX_KILL_TRACKER_DEPTH then
-    return
-  end
-
-  for _ = 1, itemCount do
-    local item = Item.create(msg:getU16())
-    if item and item:isContainer() then
-      parseCompactKillTrackerItems(msg, dropItems, depth + 1)
-      table.insert(dropItems, item)
-    else
-      local count = msg:getU8()
-      msg:getU16() -- worth
-      msg:getString() -- item name
-      if item and item:getId() ~= 0 then
-        item:setCount(math.max(1, count))
-        table.insert(dropItems, item)
-      end
-    end
-  end
-end
-
-function parseCompactKillTracker(protocol, msg)
-  local startedAt = g_clock.realMicros()
-  local monsterName = msg:getString()
-  local monsterOutfit = {
-    type = msg:getU16(),
-    head = msg:getU8(),
-    body = msg:getU8(),
-    legs = msg:getU8(),
-    feet = msg:getU8(),
-    addons = msg:getU8()
-  }
-  local dropItems = {}
-  parseCompactKillTrackerItems(msg, dropItems, 1)
-  local decodedAt = g_clock.realMicros()
-  signalcall(g_game.onKillTracker, monsterName, monsterOutfit, dropItems)
-
-  local finishedAt = g_clock.realMicros()
-  local totalUs = finishedAt - startedAt
-  local now = g_clock.realMillis()
-  if totalUs >= SLOW_KILL_TRACKER_US and
-      (not lastSlowKillTrackerWarning or now - lastSlowKillTrackerWarning >= 1000) then
-    lastSlowKillTrackerWarning = now
-    g_logger.warning(string.format(
-      "[SlowLua] game_analyser/analyser.lua:parseCompactKillTracker took %.3f ms " ..
-      "(decode=%.3f ms, callbacks=%.3f ms, drops=%d, monster=%s)",
-      totalUs / 1000, (decodedAt - startedAt) / 1000,
-      (finishedAt - decodedAt) / 1000, #dropItems, monsterName))
-  end
 end
 
 function startNewSession(login)
@@ -346,7 +284,9 @@ function toggleAnalysers(buttonId)
     widget:open()
     buttonWidget:setOn(true)
 
-    if buttonId == 'impactButton' then
+    if buttonId == 'lootButton' then
+      LootAnalyser:updateWindow(true, true)
+    elseif buttonId == 'impactButton' then
       ImpactAnalyser:checkAnchos()
     elseif buttonId == 'damageButton' then
       InputAnalyser:checkAnchos()
@@ -395,8 +335,15 @@ function onImpactTracker(analyzerType, amount, effect, target)
   end
 end
 
-function onKillTracker(monsterName, monsterOutfit, dropItems)
+function onKillTracker(monsterName, monsterOutfit, dropItems, lootItems, lootNames)
   HuntingAnalyser:addMonsterKilled(monsterName)
+
+  for index, item in ipairs(lootItems or {}) do
+    local name = lootNames and lootNames[index] or item:getName()
+    HuntingAnalyser:addLootedItems(item, name)
+    LootAnalyser:addLootedItems(item, name)
+  end
+
   DropTrackerAnalyser:checkMonsterKilled(monsterName, monsterOutfit, dropItems)
 end
 

--- a/mods/game_analyser/classes/DropTrackerAnalyser.lua
+++ b/mods/game_analyser/classes/DropTrackerAnalyser.lua
@@ -9,11 +9,16 @@ if not DropTrackerAnalyser then
 
 		-- private
 		window = nil,
+		pendingWindowUpdate = nil,
 	}
 	DropTrackerAnalyser.__index = DropTrackerAnalyser
 end
 
 function DropTrackerAnalyser:create()
+	if DropTrackerAnalyser.pendingWindowUpdate then
+		removeEvent(DropTrackerAnalyser.pendingWindowUpdate)
+		DropTrackerAnalyser.pendingWindowUpdate = nil
+	end
 	DropTrackerAnalyser.window = openedWindows['dropButton']
 
 	DropTrackerAnalyser.launchTime = g_clock.millis()
@@ -23,16 +28,39 @@ function DropTrackerAnalyser:create()
 	DropTrackerAnalyser.trackedItems = {}
 end
 
+function DropTrackerAnalyser:queueWindowUpdate()
+	if DropTrackerAnalyser.pendingWindowUpdate then
+		return
+	end
+
+	DropTrackerAnalyser.pendingWindowUpdate = scheduleEvent(function()
+		DropTrackerAnalyser.pendingWindowUpdate = nil
+		if DropTrackerAnalyser.window then
+			DropTrackerAnalyser:updateWindow()
+		end
+	end, 1)
+end
+
+function DropTrackerAnalyser:cancelPendingWindowUpdate()
+	if DropTrackerAnalyser.pendingWindowUpdate then
+		removeEvent(DropTrackerAnalyser.pendingWindowUpdate)
+		DropTrackerAnalyser.pendingWindowUpdate = nil
+	end
+end
+
 function DropTrackerAnalyser:checkTracker()
 	local needUpdate = false
+	local now = os.time()
 	for itemId, config in pairs(DropTrackerAnalyser.trackedItems) do
-		if not config.persistent and (os.time() - config.recordStartTimestamp > 120) then
+		if not config.persistent and (now - config.recordStartTimestamp > 120) then
 			DropTrackerAnalyser.trackedItems[itemId] = nil
 			needUpdate = true
 		else
-			-- check monstertracker
-			for id, mInfo in ipairs(config.monsterDrop) do
-				if (os.time() - mInfo.time) > 45 then
+			-- Expire data even while the window is hidden. Previously the UI early
+			-- return kept these rows in memory until the tracker was opened again.
+			for id = #config.monsterDrop, 1, -1 do
+				if (now - config.monsterDrop[id].time) > 45 then
+					table.remove(config.monsterDrop, id)
 					needUpdate = true
 				end
 			end
@@ -124,6 +152,7 @@ function DropTrackerAnalyser:updateWindow(ignoreVisible)
 						-- loop)
 						table.insert(toBeRemoved, id)
 					else
+						monsterWidget.drops:setText("(" ..formatMoney(monsterDrop.count, ",") .. ")")
 						monsterWidget.toBeRemoved = nil
 					end
 				end
@@ -139,8 +168,8 @@ function DropTrackerAnalyser:updateWindow(ignoreVisible)
 			-- there is no need to keep it on monsterDrop
 			-- table if its removal was already scheduled
 			-- and by keeping it, it would be re-added eventually
-			for _, id in ipairs(toBeRemoved) do
-				table.remove(config.monsterDrop, id)
+			for id = #toBeRemoved, 1, -1 do
+				table.remove(config.monsterDrop, toBeRemoved[id])
 			end
 		end
 	end
@@ -192,7 +221,7 @@ function DropTrackerAnalyser:sendDropedItems(msg, textMessageConsole)
     modules.game_console.addText(textMessageConsole, MessageModes.ChannelManagement, tabName)
 end
 
-function DropTrackerAnalyser:tryAddingMonsterDrop(item, monsterName, monsterOutfit, dropItems, dropedItems)
+function DropTrackerAnalyser:tryAddingMonsterDrop(item, monsterName, monsterOutfit, dropedItems, dropedItemIds)
 	local itemId = item:getId()
 	local tracker = DropTrackerAnalyser.trackedItems[itemId]
 	local itemPrice = item:getPriceValue() and item:getPriceValue() or 0
@@ -208,10 +237,33 @@ function DropTrackerAnalyser:tryAddingMonsterDrop(item, monsterName, monsterOutf
 		return
 	end
 
-	dropedItems[#dropedItems + 1] = itemId
-	tracker.dropCount = tracker.dropCount + item:getCount()
-	tracker.recordStartTimestamp = os.time()
-	tracker.monsterDrop[#tracker.monsterDrop + 1] = {monsterName = monsterName, outfit = monsterOutfit, time = os.time(), count = item:getCount()}
+	if not dropedItemIds[itemId] then
+		dropedItemIds[itemId] = true
+		dropedItems[#dropedItems + 1] = itemId
+	end
+
+	local now = os.time()
+	local itemCount = item:getCount()
+	tracker.dropCount = tracker.dropCount + itemCount
+	tracker.recordStartTimestamp = now
+
+	-- Reuse the recent row for the same monster instead of creating one widget
+	-- per kill. Large hunts used to grow this list rapidly and stall the UI.
+	for _, monsterDrop in ipairs(tracker.monsterDrop) do
+		if monsterDrop.monsterName == monsterName and (now - monsterDrop.time) <= 45 then
+			monsterDrop.count = monsterDrop.count + itemCount
+			monsterDrop.time = now
+			monsterDrop.outfit = monsterOutfit
+			return
+		end
+	end
+
+	tracker.monsterDrop[#tracker.monsterDrop + 1] = {
+		monsterName = monsterName,
+		outfit = monsterOutfit,
+		time = now,
+		count = itemCount
+	}
 end
 
 function DropTrackerAnalyser:checkMonsterKilled(monsterName, monsterOutfit, dropItems)
@@ -222,8 +274,9 @@ function DropTrackerAnalyser:checkMonsterKilled(monsterName, monsterOutfit, drop
 	DropTrackerAnalyser.autoTrackAboveValue = tonumber(DropTrackerAnalyser.autoTrackAboveValue) or 1
 
 	local dropedItems = {}
+	local dropedItemIds = {}
 	for _, item in pairs(dropItems) do
-		DropTrackerAnalyser:tryAddingMonsterDrop(item, monsterName, monsterOutfit, dropItems, dropedItems)
+		DropTrackerAnalyser:tryAddingMonsterDrop(item, monsterName, monsterOutfit, dropedItems, dropedItemIds)
 	end
 
 	if #dropedItems ~= 0 then
@@ -246,10 +299,14 @@ function DropTrackerAnalyser:checkMonsterKilled(monsterName, monsterOutfit, drop
 
 		setStringColor(textMessage, " dropped by "..monsterName.."!", "#f0b400")
 		setStringColor(textMessageConsole, " dropped by "..monsterName.."!", "#f0b400")
-		DropTrackerAnalyser:sendDropedItems(textMessage, textMessageConsole)
+		scheduleEvent(function()
+			DropTrackerAnalyser:sendDropedItems(textMessage, textMessageConsole)
+		end, 1)
 	end
 
-	DropTrackerAnalyser:updateWindow()
+	-- Widget traversal is the expensive part of the kill callback. Coalesce kills
+	-- received in the same frame and update the visible window on the UI queue.
+	DropTrackerAnalyser:queueWindowUpdate()
 end
 
 function DropTrackerAnalyser:isInDropTracker(itemId)
@@ -342,4 +399,3 @@ function DropTrackerAnalyser:saveConfigJson()
 
 	g_resources.writeFileContents(file, result)
 end
-

--- a/mods/game_analyser/classes/DropTrackerAnalyser.lua
+++ b/mods/game_analyser/classes/DropTrackerAnalyser.lua
@@ -10,15 +10,13 @@ if not DropTrackerAnalyser then
 		-- private
 		window = nil,
 		pendingWindowUpdate = nil,
+		pendingDroppedItemsEvents = {},
 	}
 	DropTrackerAnalyser.__index = DropTrackerAnalyser
 end
 
 function DropTrackerAnalyser:create()
-	if DropTrackerAnalyser.pendingWindowUpdate then
-		removeEvent(DropTrackerAnalyser.pendingWindowUpdate)
-		DropTrackerAnalyser.pendingWindowUpdate = nil
-	end
+	DropTrackerAnalyser:cancelPendingWindowUpdate()
 	DropTrackerAnalyser.window = openedWindows['dropButton']
 
 	DropTrackerAnalyser.launchTime = g_clock.millis()
@@ -46,6 +44,15 @@ function DropTrackerAnalyser:cancelPendingWindowUpdate()
 		removeEvent(DropTrackerAnalyser.pendingWindowUpdate)
 		DropTrackerAnalyser.pendingWindowUpdate = nil
 	end
+	for event in pairs(DropTrackerAnalyser.pendingDroppedItemsEvents) do
+		removeEvent(event)
+	end
+	DropTrackerAnalyser.pendingDroppedItemsEvents = {}
+end
+
+function DropTrackerAnalyser:terminate()
+	DropTrackerAnalyser:cancelPendingWindowUpdate()
+	DropTrackerAnalyser.window = nil
 end
 
 function DropTrackerAnalyser:checkTracker()
@@ -299,14 +306,19 @@ function DropTrackerAnalyser:checkMonsterKilled(monsterName, monsterOutfit, drop
 
 		setStringColor(textMessage, " dropped by "..monsterName.."!", "#f0b400")
 		setStringColor(textMessageConsole, " dropped by "..monsterName.."!", "#f0b400")
-		scheduleEvent(function()
-			DropTrackerAnalyser:sendDropedItems(textMessage, textMessageConsole)
+		local droppedItemsEvent
+		droppedItemsEvent = scheduleEvent(function()
+			DropTrackerAnalyser.pendingDroppedItemsEvents[droppedItemsEvent] = nil
+			if DropTrackerAnalyser.window then
+				DropTrackerAnalyser:sendDropedItems(textMessage, textMessageConsole)
+			end
 		end, 1)
-	end
+		DropTrackerAnalyser.pendingDroppedItemsEvents[droppedItemsEvent] = true
 
-	-- Widget traversal is the expensive part of the kill callback. Coalesce kills
-	-- received in the same frame and update the visible window on the UI queue.
-	DropTrackerAnalyser:queueWindowUpdate()
+		-- Widget traversal is the expensive part of the kill callback. Coalesce kills
+		-- received in the same frame and update the visible window on the UI queue.
+		DropTrackerAnalyser:queueWindowUpdate()
+	end
 end
 
 function DropTrackerAnalyser:isInDropTracker(itemId)

--- a/mods/game_analyser/classes/HuntingAnalyser.lua
+++ b/mods/game_analyser/classes/HuntingAnalyser.lua
@@ -1,34 +1,3 @@
--- using object, in the future you can open more than one window
-local valueInSeconds = function(t)
-    local now = g_clock.millis()
-    local firstValid = 1
-    local length = #t
-    while firstValid <= length and now - t[firstValid].tick > 3000 do
-        firstValid = firstValid + 1
-    end
-
-    if firstValid > 1 then
-        local kept = length - firstValid + 1
-        for index = 1, kept do
-            t[index] = t[firstValid + index - 1]
-        end
-        for index = kept + 1, length do
-            t[index] = nil
-        end
-    end
-
-    if #t == 0 then
-        return 0
-    end
-
-    local total = 0
-    for _, value in ipairs(t) do
-        total = total + value.amount
-    end
-    local elapsed = math.max(1000, now - t[1].tick)
-    return math.ceil((total * 1000) / elapsed)
-end
-
 local function compactNumber(value)
 	if type(tokformat) == 'function' then
 		return tokformat(value)
@@ -167,7 +136,7 @@ local function getPerHourValue(primary)
 end
 
 function HuntingAnalyser:updateWindow(ignoreVisible)
-	local curHPS = valueInSeconds(HuntingAnalyser.healingTicks)
+	local curHPS = calculateRateInWindow(HuntingAnalyser.healingTicks, 3000)
 	HuntingAnalyser.healingHour = math.max(HuntingAnalyser.healingHour, curHPS)
 
 	if not HuntingAnalyser.window:isVisible() and not ignoreVisible then

--- a/mods/game_analyser/classes/HuntingAnalyser.lua
+++ b/mods/game_analyser/classes/HuntingAnalyser.lua
@@ -1,28 +1,32 @@
 -- using object, in the future you can open more than one window
 local valueInSeconds = function(t)
-    local d = 0
-    local time = 0
     local now = g_clock.millis()
-    if #t > 0 then
-		local itemsToBeRemoved = 0
-        for i, v in ipairs(t) do
-            if now - v.tick <= 3000 then
-                if time == 0 then
-                    time = v.tick
-                end
-                d = d + v.amount
-            else
-				itemsToBeRemoved = itemsToBeRemoved + 1
-            end
-        end
-
-		-- items are added in order, so we can safely
-		-- remove only the first items
-		for i = 1, itemsToBeRemoved do
-			table.remove(t, 1)
-		end
+    local firstValid = 1
+    local length = #t
+    while firstValid <= length and now - t[firstValid].tick > 3000 do
+        firstValid = firstValid + 1
     end
-    return math.ceil(d/((now-time)/1000))
+
+    if firstValid > 1 then
+        local kept = length - firstValid + 1
+        for index = 1, kept do
+            t[index] = t[firstValid + index - 1]
+        end
+        for index = kept + 1, length do
+            t[index] = nil
+        end
+    end
+
+    if #t == 0 then
+        return 0
+    end
+
+    local total = 0
+    for _, value in ipairs(t) do
+        total = total + value.amount
+    end
+    local elapsed = math.max(1000, now - t[1].tick)
+    return math.ceil((total * 1000) / elapsed)
 end
 
 local function compactNumber(value)
@@ -163,6 +167,9 @@ local function getPerHourValue(primary)
 end
 
 function HuntingAnalyser:updateWindow(ignoreVisible)
+	local curHPS = valueInSeconds(HuntingAnalyser.healingTicks)
+	HuntingAnalyser.healingHour = math.max(HuntingAnalyser.healingHour, curHPS)
+
 	if not HuntingAnalyser.window:isVisible() and not ignoreVisible then
 		return
 	end
@@ -295,8 +302,6 @@ function HuntingAnalyser:updateWindow(ignoreVisible)
 		contentsPanel.healing.lastValue = HuntingAnalyser.healing
 	end
 
-	local curHPS = valueInSeconds(HuntingAnalyser.healingTicks)
-	HuntingAnalyser.healingHour = HuntingAnalyser.healingHour > curHPS and HuntingAnalyser.healingHour or curHPS
 	if not tonumber(HuntingAnalyser.healingHour) then
 		HuntingAnalyser.healingHour = 0
 	end
@@ -458,7 +463,6 @@ end
 
 function HuntingAnalyser:addDealDamage(value)
 	HuntingAnalyser.damage = HuntingAnalyser.damage + value
-	HuntingAnalyser.damageTicks[#HuntingAnalyser.damageTicks + 1] = {amount = value, tick = g_clock.millis()}
 end
 
 function HuntingAnalyser:addMonsterKilled(monsterName)

--- a/mods/game_analyser/classes/ImpactAnalyser.lua
+++ b/mods/game_analyser/classes/ImpactAnalyser.lua
@@ -47,36 +47,6 @@ local effectsFiles = {
 	[12] = 'agony',
 }
 
-local valueInSeconds = function(t)
-    local now = g_clock.millis()
-    local firstValid = 1
-    local length = #t
-    while firstValid <= length and now - t[firstValid].tick > 10000 do
-        firstValid = firstValid + 1
-    end
-
-    if firstValid > 1 then
-        local kept = length - firstValid + 1
-        for index = 1, kept do
-            t[index] = t[firstValid + index - 1]
-        end
-        for index = kept + 1, length do
-            t[index] = nil
-        end
-    end
-
-    if #t == 0 then
-        return 0
-    end
-
-    local total = 0
-    for _, value in ipairs(t) do
-        total = total + value.amount
-    end
-    local elapsed = math.max(1000, now - t[1].tick)
-    return math.ceil((total * 1000) / elapsed)
-end
-
 function ImpactAnalyser:create()
 	ImpactAnalyser.launchTime = 0
 	ImpactAnalyser.session = 0
@@ -136,8 +106,8 @@ function ImpactAnalyser:reset(allTimeDps, allTimeHps)
 end
 
 function ImpactAnalyser:updateWindow(ignoreVisible)
-	local currentDPS = valueInSeconds(ImpactAnalyser.damageTicks)
-	local currentHPS = valueInSeconds(ImpactAnalyser.healingTicks)
+	local currentDPS = calculateRateInWindow(ImpactAnalyser.damageTicks, 10000)
+	local currentHPS = calculateRateInWindow(ImpactAnalyser.healingTicks, 10000)
 	ImpactAnalyser.maxDPS = math.max(ImpactAnalyser.maxDPS, currentDPS)
 	ImpactAnalyser.maxHPS = math.max(ImpactAnalyser.maxHPS, currentHPS)
 
@@ -229,13 +199,13 @@ function ImpactAnalyser:updateGraphics()
 	if true then
 		return
 	end
-	local curHPS = valueInSeconds(ImpactAnalyser.damageTicks)
+	local curHPS = calculateRateInWindow(ImpactAnalyser.damageTicks, 10000)
 	if not curHPS then curHPS = 0 end
 	ImpactAnalyser.maxDPS = ImpactAnalyser.maxDPS > curHPS and ImpactAnalyser.maxDPS or curHPS
 	ImpactAnalyser.window.contentsPanel.graphDpsPanel:addValue(curHPS)
 
 
-	local curHPS = valueInSeconds(ImpactAnalyser.healingTicks)
+	local curHPS = calculateRateInWindow(ImpactAnalyser.healingTicks, 10000)
 	if not curHPS then curHPS = 0 end
 	ImpactAnalyser.maxHPS = ImpactAnalyser.maxHPS > curHPS and ImpactAnalyser.maxHPS or curHPS
 	ImpactAnalyser.window.contentsPanel.graphHealPanel:addValue(curHPS)

--- a/mods/game_analyser/classes/ImpactAnalyser.lua
+++ b/mods/game_analyser/classes/ImpactAnalyser.lua
@@ -48,29 +48,33 @@ local effectsFiles = {
 }
 
 local valueInSeconds = function(t)
-    local d = 0
-    local time = 0
     local now = g_clock.millis()
-    if #t > 0 then
-		local itemsToBeRemoved = 0
-        for i, v in ipairs(t) do
-            if now - v.tick <= 10000 then
-                if time == 0 then
-                    time = v.tick
-                end
-                d = d + v.amount
-            else
-				itemsToBeRemoved = itemsToBeRemoved + 1
-            end
-        end
-
-		-- items are added in order, so we can safely
-		-- remove only the first items
-		for i = 1, itemsToBeRemoved do
-			table.remove(t, 1)
-		end
+    local firstValid = 1
+    local length = #t
+    while firstValid <= length and now - t[firstValid].tick > 10000 do
+        firstValid = firstValid + 1
     end
-    return math.ceil(d/((now-time)/1000))
+
+    if firstValid > 1 then
+        local kept = length - firstValid + 1
+        for index = 1, kept do
+            t[index] = t[firstValid + index - 1]
+        end
+        for index = kept + 1, length do
+            t[index] = nil
+        end
+    end
+
+    if #t == 0 then
+        return 0
+    end
+
+    local total = 0
+    for _, value in ipairs(t) do
+        total = total + value.amount
+    end
+    local elapsed = math.max(1000, now - t[1].tick)
+    return math.ceil((total * 1000) / elapsed)
 end
 
 function ImpactAnalyser:create()
@@ -132,6 +136,11 @@ function ImpactAnalyser:reset(allTimeDps, allTimeHps)
 end
 
 function ImpactAnalyser:updateWindow(ignoreVisible)
+	local currentDPS = valueInSeconds(ImpactAnalyser.damageTicks)
+	local currentHPS = valueInSeconds(ImpactAnalyser.healingTicks)
+	ImpactAnalyser.maxDPS = math.max(ImpactAnalyser.maxDPS, currentDPS)
+	ImpactAnalyser.maxHPS = math.max(ImpactAnalyser.maxHPS, currentHPS)
+
 	if not ImpactAnalyser.window:isVisible() and not ignoreVisible then
 		return
 	end
@@ -140,27 +149,23 @@ function ImpactAnalyser:updateWindow(ignoreVisible)
 
 	contentsPanel.dmg:setText(formatMoney(ImpactAnalyser.damageTotal, ","))
 	contentsPanel.allTimeHigh:setText(formatMoney(ImpactAnalyser.allTimeHightDps, ","))
-	local curHPS = valueInSeconds(ImpactAnalyser.damageTicks)
-	if not curHPS then curHPS = 0 end
-	ImpactAnalyser.maxDPS = ImpactAnalyser.maxDPS > curHPS and ImpactAnalyser.maxDPS or curHPS
-
 	contentsPanel.maxDps:setText(formatMoney(ImpactAnalyser.maxDPS, ","))
-	contentsPanel.dps:setText(formatMoney(curHPS, ","))
+	contentsPanel.dps:setText(formatMoney(currentDPS, ","))
 
 	contentsPanel.targetDps:setText(formatMoney(ImpactAnalyser.targetDPS, ","))
 	-- movido pro check de 15s
-	contentsPanel.graphDpsPanel:addValue(curHPS)
+	contentsPanel.graphDpsPanel:addValue(currentDPS)
 
-	if ImpactAnalyser.targetDPS == 1 and ImpactAnalyser.curHPS == 0 then
+	if ImpactAnalyser.targetDPS == 1 and currentDPS == 0 then
 		ImpactAnalyser.window.contentsPanel.dpsBG.dpsArrow:setMarginLeft(targetMaxMargin / 2)
 	else
 		local target = math.max(1, ImpactAnalyser.targetDPS)
-		local current = curHPS
+		local current = currentDPS
 		local percent = (current * 71) / target
 		ImpactAnalyser.window.contentsPanel.dpsBG.dpsArrow:setMarginLeft(math.min(targetMaxMargin, math.ceil(percent)))
 	end
 
-	ImpactAnalyser.window.contentsPanel.dpsBG:setTooltip(string.format("Current: %d\nTarget: %d", curHPS, ImpactAnalyser.targetDPS))
+	ImpactAnalyser.window.contentsPanel.dpsBG:setTooltip(string.format("Current: %d\nTarget: %d", currentDPS, ImpactAnalyser.targetDPS))
 
 	----------------------- DAMAGE TYPE -----------------------------
 	for _, child in pairs(contentsPanel.dmgTypes:getChildren()) do
@@ -200,27 +205,23 @@ function ImpactAnalyser:updateWindow(ignoreVisible)
 	contentsPanel.hpsTotal:setText(formatMoney(ImpactAnalyser.healingTotal, ","))
 	contentsPanel.allTimeHighHealing:setText(formatMoney(ImpactAnalyser.allTimeHightHps, ","))
 
-	local curHPS = valueInSeconds(ImpactAnalyser.healingTicks)
-	if not curHPS then curHPS = 0 end
-	ImpactAnalyser.maxHPS = ImpactAnalyser.maxHPS > curHPS and ImpactAnalyser.maxHPS or curHPS
-
 	contentsPanel.maxHps:setText(formatMoney(ImpactAnalyser.maxHPS, ","))
-	contentsPanel.hps:setText(formatMoney(curHPS, ","))
+	contentsPanel.hps:setText(formatMoney(currentHPS, ","))
 
 	contentsPanel.targetHps:setText(formatMoney(ImpactAnalyser.targetHPS, ","))
 	-- movido pro check de 15s
-	contentsPanel.graphHealPanel:addValue(curHPS)
+	contentsPanel.graphHealPanel:addValue(currentHPS)
 
-	if ImpactAnalyser.targetHPS == 1 and ImpactAnalyser.curHPS == 0 then
+	if ImpactAnalyser.targetHPS == 1 and currentHPS == 0 then
 		ImpactAnalyser.window.contentsPanel.hpsBG.hpsArrow:setMarginLeft(targetMaxMargin / 2)
 	else
 		local target = math.max(1, ImpactAnalyser.targetHPS)
-		local current = curHPS
+		local current = currentHPS
 		local percent = (current * 71) / target
 		ImpactAnalyser.window.contentsPanel.hpsBG.hpsArrow:setMarginLeft(math.min(targetMaxMargin, math.ceil(percent)))
 	end
 
-	ImpactAnalyser.window.contentsPanel.hpsBG:setTooltip(string.format("Current: %d\nTarget: %d", curHPS, ImpactAnalyser.targetHPS))
+	ImpactAnalyser.window.contentsPanel.hpsBG:setTooltip(string.format("Current: %d\nTarget: %d", currentHPS, ImpactAnalyser.targetHPS))
 end
 
 function ImpactAnalyser:updateGraphics()
@@ -528,4 +529,3 @@ function ImpactAnalyser:saveConfigJson()
 	
 	g_resources.writeFileContents(file, result)
 end
-

--- a/mods/game_analyser/classes/InputAnalyser.lua
+++ b/mods/game_analyser/classes/InputAnalyser.lua
@@ -62,29 +62,33 @@ local obj = {
 }
 
 local valueInSeconds = function(t)
-    local d = 0
-    local time = 0
     local now = g_clock.millis()
-    if #t > 0 then
-		local itemsToBeRemoved = 0
-        for i, v in ipairs(t) do
-            if now - v.tick <= 3000 then
-                if time == 0 then
-                    time = v.tick
-                end
-                d = d + v.amount
-            else
-				itemsToBeRemoved = itemsToBeRemoved + 1
-            end
-        end
-
-		-- items are added in order, so we can safely
-		-- remove only the first items
-		for i = 1, itemsToBeRemoved do
-			table.remove(t, 1)
-		end
+    local firstValid = 1
+    local length = #t
+    while firstValid <= length and now - t[firstValid].tick > 3000 do
+        firstValid = firstValid + 1
     end
-    return math.ceil(d/((now-time)/1000))
+
+    if firstValid > 1 then
+        local kept = length - firstValid + 1
+        for index = 1, kept do
+            t[index] = t[firstValid + index - 1]
+        end
+        for index = kept + 1, length do
+            t[index] = nil
+        end
+    end
+
+    if #t == 0 then
+        return 0
+    end
+
+    local total = 0
+    for _, value in ipairs(t) do
+        total = total + value.amount
+    end
+    local elapsed = math.max(1000, now - t[1].tick)
+    return math.ceil((total * 1000) / elapsed)
 end
 
 function InputAnalyser:create()

--- a/mods/game_analyser/classes/InputAnalyser.lua
+++ b/mods/game_analyser/classes/InputAnalyser.lua
@@ -61,36 +61,6 @@ local obj = {
 	eventGraph = nil,
 }
 
-local valueInSeconds = function(t)
-    local now = g_clock.millis()
-    local firstValid = 1
-    local length = #t
-    while firstValid <= length and now - t[firstValid].tick > 3000 do
-        firstValid = firstValid + 1
-    end
-
-    if firstValid > 1 then
-        local kept = length - firstValid + 1
-        for index = 1, kept do
-            t[index] = t[firstValid + index - 1]
-        end
-        for index = kept + 1, length do
-            t[index] = nil
-        end
-    end
-
-    if #t == 0 then
-        return 0
-    end
-
-    local total = 0
-    for _, value in ipairs(t) do
-        total = total + value.amount
-    end
-    local elapsed = math.max(1000, now - t[1].tick)
-    return math.ceil((total * 1000) / elapsed)
-end
-
 function InputAnalyser:create()
 	InputAnalyser.window = openedWindows['damageButton']
 
@@ -256,7 +226,7 @@ function InputAnalyser:updateWindow(ignoreVisible)
 end
 
 function InputAnalyser:checkDPS()
-	local curDPS = valueInSeconds(InputAnalyser.damageTicks)
+	local curDPS = calculateRateInWindow(InputAnalyser.damageTicks, 3000)
 	if not curDPS or not tonumber(curDPS) then curDPS = 0 end
 	InputAnalyser.curDPS = curDPS
 	local lastDps = tonumber(InputAnalyser.maxDPS) or 1

--- a/mods/game_analyser/classes/LootAnalyser.lua
+++ b/mods/game_analyser/classes/LootAnalyser.lua
@@ -12,6 +12,7 @@ if not LootAnalyser then
 		window = nil,
 		event = nil,
 		eventGraph = nil,
+		pendingWindowUpdate = nil,
 	}
 
 	LootAnalyser.__index = LootAnalyser
@@ -21,6 +22,7 @@ local targetMaxMargin = 142
 
 
 function LootAnalyser:create()
+	LootAnalyser:cancelPendingWindowUpdate()
 	LootAnalyser.launchTime = 0
 	LootAnalyser.session = 0
 	LootAnalyser.goldValue = 0
@@ -35,6 +37,32 @@ function LootAnalyser:create()
 	-- private
 	LootAnalyser.window = openedWindows['lootButton']
 	LootAnalyser.eventGraph = nil
+end
+
+function LootAnalyser:queueWindowUpdate()
+	if LootAnalyser.pendingWindowUpdate then
+		return
+	end
+
+	LootAnalyser.pendingWindowUpdate = scheduleEvent(function()
+		LootAnalyser.pendingWindowUpdate = nil
+		if not LootAnalyser.window then
+			return
+		end
+
+		LootAnalyser:checkBalance(true)
+		LootAnalyser:updateGraphics()
+		if LootAnalyser.window:isVisible() then
+			LootAnalyser:updateWindow(true, true)
+		end
+	end, 1)
+end
+
+function LootAnalyser:cancelPendingWindowUpdate()
+	if LootAnalyser.pendingWindowUpdate then
+		removeEvent(LootAnalyser.pendingWindowUpdate)
+		LootAnalyser.pendingWindowUpdate = nil
+	end
 end
 
 
@@ -56,6 +84,7 @@ function onLootingExtra(mousePosition)
 end
 
 function LootAnalyser:reset()
+	LootAnalyser:cancelPendingWindowUpdate()
 	LootAnalyser.launchTime = g_clock.millis()
 	LootAnalyser.session = 0
 	LootAnalyser.goldValue = 0
@@ -91,7 +120,7 @@ function LootAnalyser:updateBasePriceFromLootedItems(itemId, newPriceValue)
 	end
 end
 
-function LootAnalyser:checkBalance()
+function LootAnalyser:checkBalance(deferWindowUpdate)
 	local oldBalance = LootAnalyser.goldValue
 	if LootAnalyser.forceUpdateBalance then
 		local loot = 0
@@ -107,7 +136,9 @@ function LootAnalyser:checkBalance()
 	end
 
 	if LootAnalyser.updateBalance or oldBalance ~= LootAnalyser.goldValue then
-		LootAnalyser:updateWindow(false)
+		if not deferWindowUpdate then
+			LootAnalyser:updateWindow(false)
+		end
 		LootAnalyser.updateBalance = false
 	end
 end
@@ -189,10 +220,7 @@ function LootAnalyser:addLootedItems(item, name)
 	-- update balance
 	LootAnalyser.goldValue = LootAnalyser.goldValue + (itemInfo.basePrice * count)
 	LootAnalyser.updateBalance = true
-
-	LootAnalyser:checkBalance()
-	LootAnalyser:updateGraphics()
-	LootAnalyser:updateWindow(true)
+	LootAnalyser:queueWindowUpdate()
 end
 
 function LootAnalyser:setLootPerHourGauge(value)

--- a/mods/game_cyclopedia/classes/bosstiary.lua
+++ b/mods/game_cyclopedia/classes/bosstiary.lua
@@ -27,6 +27,8 @@ local previousButton = nil
 local nextButton = nil
 local searchField = nil
 local rawBosstiaryData = nil
+local windowDataGeneration = 0
+local creatureRenderGeneration = 0
 
 local sortTypes = {
 	[1] = {name = "Bane", icon = "/game_cyclopedia/images/icons/icon-bosstiary-1"},
@@ -66,6 +68,8 @@ toolMessages = {
 }
 
 function Bosstiary.reset()
+	windowDataGeneration = windowDataGeneration + 1
+	creatureRenderGeneration = creatureRenderGeneration + 1
 	sortFields = {}
 	bosstiaryCreatures = {}
 	bosstiaryCurrentPage = 1
@@ -180,29 +184,44 @@ end
 
 function Bosstiary.onBosstiaryWindowData(data)
 	-- Init fields
-	bosstiaryMonsterPanel = g_ui.getRootWidget():recursiveGetChildById('bosstiaryMonsterPanel')
-	pageCounter = g_ui.getRootWidget():recursiveGetChildById('pageCount')
-	previousButton = g_ui.getRootWidget():recursiveGetChildById('backListButton')
-	nextButton = g_ui.getRootWidget():recursiveGetChildById('nextListButton')
-	searchField = g_ui.getRootWidget():recursiveGetChildById('searchBosstiary')
+	local rootWidget = g_ui.getRootWidget()
+	bosstiaryMonsterPanel = rootWidget:recursiveGetChildById('bosstiaryMonsterPanel')
+	pageCounter = rootWidget:recursiveGetChildById('pageCount')
+	previousButton = rootWidget:recursiveGetChildById('backListButton')
+	nextButton = rootWidget:recursiveGetChildById('nextListButton')
+	searchField = rootWidget:recursiveGetChildById('searchBosstiary')
+	windowDataGeneration = windowDataGeneration + 1
+	local generation = windowDataGeneration
 	if rawBosstiaryData then
 		-- already opened
 		rawBosstiaryData = data
-		Bosstiary.updateTracker()
+		scheduleEvent(function()
+			if generation == windowDataGeneration then
+				Bosstiary.updateTracker()
+			end
+		end, 1)
 		return
 	end
 
 	rawBosstiaryData = data
 	sortFields = {}
 
-	Bosstiary.initSortFields()
-	if redirectText ~= nil then
-		Bosstiary.onSearch(redirectText)
-		redirectText = nil
-	else
-		Bosstiary.configureBossList(rawBosstiaryData)
-		Bosstiary.showCreatures()
-	end
+	-- Building the filters and boss cards in the network signal callback used to
+	-- block one frame. Start the work on the UI queue; showCreatures renders the
+	-- cards in small batches below.
+	scheduleEvent(function()
+		if generation ~= windowDataGeneration then
+			return
+		end
+		Bosstiary.initSortFields()
+		if redirectText ~= nil then
+			Bosstiary.onSearch(redirectText)
+			redirectText = nil
+		else
+			Bosstiary.configureBossList(rawBosstiaryData)
+			Bosstiary.showCreatures()
+		end
+	end, 1)
 
 	cyclopediaWindow.optionsPanel:focus()
 	if VisibleCyclopediaPanel then
@@ -212,7 +231,11 @@ function Bosstiary.onBosstiaryWindowData(data)
 	if searchField then
 		searchField:focus()
 	end
-	Bosstiary.updateTracker()
+	scheduleEvent(function()
+		if generation == windowDataGeneration then
+			Bosstiary.updateTracker()
+		end
+	end, 16)
 end
 
 function Bosstiary.updateTracker()
@@ -275,10 +298,85 @@ function Bosstiary.initSortFields()
 	end
 end
 
+local function createCreatureCard(data)
+	local monsters = g_ui.createWidget('CyclopediaBosstiaryWindow', bosstiaryMonsterPanel)
+	local unlocked = data.kills > 0
+	if data.outfit then
+		local name = unlocked and string.capitalize(data.outfit[1]) or "?"
+		monsters:setText(short_text(name, 17))
+		if #name > 17 then
+			monsters.monster.outfit:setTooltip(name)
+		end
+
+		if unlocked then
+			monsters.trackBosstiary:enable()
+		else
+			monsters.trackBosstiary:disable()
+		end
+
+		local hasLookType = data.outfit[2] > 0
+		local hasLookTypeEx = data.outfit[3] > 0
+		local monsterShader = (unlocked and (hasLookType or hasLookTypeEx) and "" or "outfit_black")
+		monsters.monster.outfit:setOutfit({type = data.outfit[2], auxType = data.outfit[3], head = data.outfit[4], body = data.outfit[5], legs = data.outfit[6], feet = data.outfit[7], addons = data.outfit[8], shader = monsterShader})
+		monsters.monster.outfit:setRaceID(data.bossID)
+		monsters:setId(data.bossID)
+	end
+
+	local baseKill = baseKillData[data.category + 1]
+	if not baseKill then
+		monsters:destroy()
+		return
+	end
+	monsters.progressFirst.first:setPercent(0)
+	monsters.progressSecond.second:setPercent(0)
+	monsters.progressThird.third:setPercent(0)
+
+	monsters.progressFirst.first:setTooltip(data.kills .. " / " .. baseKill.firstUnlock)
+	monsters.progressSecond.second:setTooltip(data.kills .. " / " .. baseKill.secondUnlock)
+	monsters.progressThird.third:setTooltip(data.kills .. " / " .. baseKill.thirdUnlock)
+
+	if data.isTracked == 1 then
+		monsters.trackBosstiary:setChecked(true)
+	end
+	monsters.trackBosstiary.onCheckChange = Bosstiary.checkBosstiaryTrack
+
+	local currentKills = data.kills
+	local firstPercent = math.min((currentKills * 100) / math.max(baseKill.firstUnlock, 1), 100)
+	monsters.progressFirst.first:setPercent(firstPercent)
+	if currentKills >= baseKill.firstUnlock then
+		monsters.starFisrt:setImageSource("/game_cyclopedia/images/icons/star/enable1")
+		local secondRange = math.max(baseKill.secondUnlock - baseKill.firstUnlock, 1)
+		local secondPercent = math.min(((currentKills - baseKill.firstUnlock) * 100) / secondRange, 100)
+		monsters.progressSecond.second:setPercent(secondPercent)
+	end
+
+	if currentKills >= baseKill.secondUnlock then
+		monsters.starSecond:setImageSource("/game_cyclopedia/images/icons/star/enable2")
+		local thirdRange = math.max(baseKill.thirdUnlock - baseKill.secondUnlock, 1)
+		local thirdPercent = math.min(((currentKills - baseKill.secondUnlock) * 100) / thirdRange, 100)
+		monsters.progressThird.third:setPercent(thirdPercent)
+	end
+
+	if currentKills >= baseKill.thirdUnlock then
+		monsters.progressFirst.first:setImageSource('/game_cyclopedia/images/ui/monster-bar-green')
+		monsters.progressSecond.second:setImageSource('/game_cyclopedia/images/ui/monster-bar-green')
+		monsters.progressThird.third:setImageSource('/game_cyclopedia/images/ui/monster-bar-green')
+		monsters.starThird:setImageSource("/game_cyclopedia/images/icons/star/enable3")
+	end
+
+	local category = data.category + 1
+	monsters.monster.outfit:setAnimate(true)
+	monsters.progressSecond.second.killCounterLabel:setText(data.kills)
+	monsters.iconBosstiary:setImageSource('/game_cyclopedia/images/icons/icon-bosstiary-' .. category)
+	monsters.iconBosstiary:setTooltip(tr(toolMessages[category], BosstiaryReward[category].prowess, BosstiaryReward[category].expertise, BosstiaryReward[category].mastery))
+end
+
 function Bosstiary.showCreatures()
-  if not bosstiaryMonsterPanel then
-    return true
-  end
+	if not bosstiaryMonsterPanel then
+		return true
+	end
+	creatureRenderGeneration = creatureRenderGeneration + 1
+	local generation = creatureRenderGeneration
 
 	bosstiaryMonsterPanel:destroyChildren()
 	pageCounter:setText(bosstiaryCurrentPage .. " / " .. #bosstiaryCreatures)
@@ -307,73 +405,23 @@ function Bosstiary.showCreatures()
 		nextButton:setEnabled(false)
 	end
 
-	for _, data in pairs(bosstiaryCreatures[bosstiaryCurrentPage]) do
-		local monsters = g_ui.createWidget('CyclopediaBosstiaryWindow', bosstiaryMonsterPanel)
-		local unlocked = data.kills > 0
-		if data.outfit then
-			local name = unlocked and string.capitalize(data.outfit[1]) or "?"
-			monsters:setText(short_text(name, 17))
-			if #name > 17 then
-				monsters.monster.outfit:setTooltip(name)
-			end
-
-			if unlocked then
-				monsters.trackBosstiary:enable()
-			else
-				monsters.trackBosstiary:disable()
-			end
-
-			local hasLookType = data.outfit[2] > 0
-			local hasLookTypeEx = data.outfit[3] > 0
-
-			local monsterShader = (unlocked and (hasLookType or hasLookTypeEx) and "" or "outfit_black")
-			monsters.monster.outfit:setOutfit({type = data.outfit[2], auxType = data.outfit[3], head = data.outfit[4], body = data.outfit[5], legs = data.outfit[6], feet = data.outfit[7], addons = data.outfit[8], shader = monsterShader})
-			monsters.monster.outfit:setRaceID(data.bossID)
-			monsters:setId(data.bossID)
+	local pageEntries = bosstiaryCreatures[bosstiaryCurrentPage] or {}
+	local index = 1
+	local function renderNextBatch()
+		if generation ~= creatureRenderGeneration then
+			return
 		end
-
-		local baseKill = baseKillData[data.category + 1]
-		monsters.progressFirst.first:setPercent(0)
-		monsters.progressSecond.second:setPercent(0)
-		monsters.progressThird.third:setPercent(0)
-
-		monsters.progressFirst.first:setTooltip(data.kills .. " / " .. baseKill.firstUnlock)
-		monsters.progressSecond.second:setTooltip(data.kills .. " / " .. baseKill.secondUnlock)
-		monsters.progressThird.third:setTooltip(data.kills .. " / " .. baseKill.thirdUnlock)
-
-		if data.isTracked == 1 then
-			monsters.trackBosstiary:setChecked(true)
+		local lastIndex = math.min(index + 1, #pageEntries)
+		while index <= lastIndex do
+			createCreatureCard(pageEntries[index])
+			index = index + 1
 		end
-
-		monsters.trackBosstiary.onCheckChange = Bosstiary.checkBosstiaryTrack
-
-		local currentKills = data.kills
-		local firstPercent = math.min((currentKills * 100) / baseKill.firstUnlock, 100)
-		monsters.progressFirst.first:setPercent(firstPercent)
-		if currentKills >= baseKill.firstUnlock then
-			monsters.starFisrt:setImageSource("/game_cyclopedia/images/icons/star/enable1")
-			local secondPercent = math.min(((currentKills - baseKill.firstUnlock) * 100) / (baseKill.secondUnlock - baseKill.firstUnlock), 100)
-			monsters.progressSecond.second:setPercent(secondPercent)
+		if index <= #pageEntries then
+			scheduleEvent(renderNextBatch, 1)
 		end
-
-		if currentKills >= baseKill.secondUnlock then
-			monsters.starSecond:setImageSource("/game_cyclopedia/images/icons/star/enable2")
-			local thirdPercent = math.min(((currentKills - baseKill.secondUnlock) * 100) / (baseKill.thirdUnlock - baseKill.secondUnlock), 100)
-			monsters.progressThird.third:setPercent(thirdPercent)
-		end
-
-		if currentKills >= baseKill.thirdUnlock then
-			monsters.progressFirst.first:setImageSource('/game_cyclopedia/images/ui/monster-bar-green')
-			monsters.progressSecond.second:setImageSource('/game_cyclopedia/images/ui/monster-bar-green')
-			monsters.progressThird.third:setImageSource('/game_cyclopedia/images/ui/monster-bar-green')
-			monsters.starThird:setImageSource("/game_cyclopedia/images/icons/star/enable3")
-		end
-
-		local category = data.category + 1
-		monsters.monster.outfit:setAnimate(true)
-		monsters.progressSecond.second.killCounterLabel:setText(data.kills)
-		monsters.iconBosstiary:setImageSource('/game_cyclopedia/images/icons/icon-bosstiary-' .. data.category + 1)
-		monsters.iconBosstiary:setTooltip(tr(toolMessages[category], BosstiaryReward[category].prowess, BosstiaryReward[category].expertise, BosstiaryReward[category].mastery))
+	end
+	if #pageEntries > 0 then
+		scheduleEvent(renderNextBatch, 1)
 	end
 end
 

--- a/mods/game_cyclopedia/classes/bosstiary.lua
+++ b/mods/game_cyclopedia/classes/bosstiary.lua
@@ -194,15 +194,21 @@ function Bosstiary.onBosstiaryWindowData(data)
 	local generation = windowDataGeneration
 	if rawBosstiaryData then
 		-- already opened
+		local activeSearch = searchField and searchField:getText() or nil
+		creatureRenderGeneration = creatureRenderGeneration + 1
 		rawBosstiaryData = data
 		scheduleEvent(function()
 			if generation == windowDataGeneration then
+				Bosstiary.configureBossList(rawBosstiaryData, activeSearch)
+				bosstiaryCurrentPage = math.max(1, math.min(bosstiaryCurrentPage, #bosstiaryCreatures))
+				Bosstiary.showCreatures()
 				Bosstiary.updateTracker()
 			end
 		end, 1)
 		return
 	end
 
+	creatureRenderGeneration = creatureRenderGeneration + 1
 	rawBosstiaryData = data
 	sortFields = {}
 

--- a/modules/client_terminal/terminal.lua
+++ b/modules/client_terminal/terminal.lua
@@ -167,8 +167,11 @@ function init()
   g_keyboard.bindKeyPress('Ctrl+C',
     function()
       if commandTextEdit:hasSelection() or not terminalSelectText:hasSelection() then return false end
-      g_window.setClipboardText(terminalSelectText:getSelection())
-    return true
+      local selection = terminalSelectText:getSelection()
+      scheduleEvent(function()
+        g_window.setClipboardText(selection)
+      end, 1)
+      return true
     end, commandTextEdit)
   g_keyboard.bindKeyDown('Tab', completeCommand, commandTextEdit)
   g_keyboard.bindKeyPress('Shift+Enter', addNewline, commandTextEdit)

--- a/modules/corelib/util.lua
+++ b/modules/corelib/util.lua
@@ -293,6 +293,36 @@ function numbertoboolean(number)
   end
 end
 
+function calculateRateInWindow(values, retentionWindowMs)
+  local now = g_clock.millis()
+  local firstValid = 1
+  local length = #values
+  while firstValid <= length and now - values[firstValid].tick > retentionWindowMs do
+    firstValid = firstValid + 1
+  end
+
+  if firstValid > 1 then
+    local kept = length - firstValid + 1
+    for index = 1, kept do
+      values[index] = values[firstValid + index - 1]
+    end
+    for index = kept + 1, length do
+      values[index] = nil
+    end
+  end
+
+  if #values == 0 then
+    return 0
+  end
+
+  local total = 0
+  for _, value in ipairs(values) do
+    total = total + value.amount
+  end
+  local elapsed = math.max(1000, now - values[1].tick)
+  return math.ceil((total * 1000) / elapsed)
+end
+
 function protectedcall(func, ...)
   local status, ret = pcall(func, ...)
   if status then
@@ -314,7 +344,10 @@ local SLOW_SIGNAL_WARNING_INTERVAL_MS = 1000
 local slowSignalWarnings = {}
 
 local function reportSlowSignalCallback(callback, elapsedUs, signalOrigin)
-  local callbackInfo = debug.getinfo(callback, "Sln")
+  local callbackInfo = nil
+  if type(callback) == 'function' then
+    callbackInfo = debug.getinfo(callback, "Sln")
+  end
   local callbackSource = "lua"
   local callbackName = "anonymous"
   if callbackInfo then

--- a/modules/corelib/util.lua
+++ b/modules/corelib/util.lua
@@ -309,6 +309,45 @@ function protectedcall(func, ...)
   return false
 end
 
+local SLOW_SIGNAL_CALLBACK_US = 5000
+local SLOW_SIGNAL_WARNING_INTERVAL_MS = 1000
+local slowSignalWarnings = {}
+
+local function reportSlowSignalCallback(callback, elapsedUs, signalOrigin)
+  local callbackInfo = debug.getinfo(callback, "Sln")
+  local callbackSource = "lua"
+  local callbackName = "anonymous"
+  if callbackInfo then
+    callbackSource = callbackInfo.short_src or callbackInfo.source or callbackSource
+    if callbackInfo.linedefined and callbackInfo.linedefined > 0 then
+      callbackSource = callbackSource .. ":" .. callbackInfo.linedefined
+    end
+    callbackName = callbackInfo.name or callbackName
+  end
+
+  local warningKey = callbackSource .. "#" .. callbackName
+  local now = g_clock.realMillis()
+  local lastWarning = slowSignalWarnings[warningKey]
+  if lastWarning and now - lastWarning < SLOW_SIGNAL_WARNING_INTERVAL_MS then
+    return
+  end
+  slowSignalWarnings[warningKey] = now
+
+  g_logger.warning(string.format(
+    "[SlowLua] callback %s (%s) took %.3f ms; signal origin: %s",
+    callbackName, callbackSource, elapsedUs / 1000, signalOrigin))
+end
+
+local function callSignalCallback(callback, signalOrigin, ...)
+  local startedAt = g_clock.realMicros()
+  local status, ret = pcall(callback, ...)
+  local elapsedUs = g_clock.realMicros() - startedAt
+  if elapsedUs >= SLOW_SIGNAL_CALLBACK_US then
+    reportSlowSignalCallback(callback, elapsedUs, signalOrigin)
+  end
+  return status, ret
+end
+
 function signalcall(param, ...)
   local desc = "lua"
   local info = debug.getinfo(2, "Sl")
@@ -317,7 +356,7 @@ function signalcall(param, ...)
   end
 
   if type(param) == 'function' then
-    local status, ret = pcall(param, ...)
+    local status, ret = callSignalCallback(param, desc, ...)
     if status then
       return ret
     else
@@ -325,7 +364,7 @@ function signalcall(param, ...)
     end
   elseif type(param) == 'table' then
     for k,v in pairs(param) do
-      local status, ret = pcall(v, ...)
+      local status, ret = callSignalCallback(v, desc, ...)
       if status then
         if ret then return true end
       else

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4031,8 +4031,10 @@ void ProtocolGame::parseKillTracker(const InputMessagePtr& msg)
     const Outfit& monsterOutfit = getOutfit(msg, true);
 
     ItemVector dropItems;
+    ItemVector lootItems;
+    std::vector<std::string> lootNames;
 
-    std::function<void(int)> parseContainer = [&](int depth) {
+    const auto parseContainer = [&](const auto& self, int depth) -> void {
         if (depth > 4) {
             msg->getU8();
             return;
@@ -4044,24 +4046,26 @@ void ProtocolGame::parseKillTracker(const InputMessagePtr& msg)
             ItemPtr item = Item::create(itemId);
 
             if (item && item->isThingTypeContainer()) {
-                parseContainer(depth + 1);
+                self(self, depth + 1);
                 dropItems.push_back(item);
                 continue;
             }
 
             const uint8_t count = msg->getU8();
             msg->getU16(); // worth
-            msg->getString(); // item name
+            const std::string itemName = msg->getString();
 
             if (item && item->getId() != 0) {
                 item->setCount(std::max<int>(1, count));
                 dropItems.push_back(item);
+                lootItems.push_back(item);
+                lootNames.push_back(itemName);
             }
         }
     };
 
-    parseContainer(1);
-    g_lua.callGlobalField("g_game", "onKillTracker", monsterName, monsterOutfit, dropItems);
+    parseContainer(parseContainer, 1);
+    g_lua.callGlobalField("g_game", "onKillTracker", monsterName, monsterOutfit, dropItems, lootItems, lootNames);
 }
 
 void ProtocolGame::parseSupplyTracker(const InputMessagePtr& msg)


### PR DESCRIPTION
## What changed

- profile compact kill-tracker decoding separately from signal callbacks
- aggregate repeated drops from the same monster instead of creating a row per kill
- coalesce Analyzer window traversal onto the UI queue
- expire hidden tracker entries correctly
- build Bosstiary cards in small cancellable batches
- move terminal clipboard access outside the keyboard signal callback
- log exact callback source and signal origin for future SlowLua warnings

## Root cause

The kill signal synchronously decoded drops, updated console output, traversed widgets, and created one UI row per monster kill. Bosstiary created all boss cards inside the network callback. These synchronous UI operations produced the reported 15–24 ms callback stalls and accumulated during hunts.

## Impact

Kill data is still processed immediately, while expensive widget work is coalesced and scheduled on the UI queue. Repeated kills update an existing recent row, preventing unbounded widget growth during long hunts.

## Validation

- all five modified files parsed successfully as Lua 5.3
- `git diff --check` passed
- changes are based directly on `main`; the unrelated configurable viewport branch is excluded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * O rastreamento de mortes agora exibe informações mais completas de saques, incluindo itens dentro de contêineres.
  * O Bosstiary renderiza criaturas em lotes, tornando a abertura e atualização da janela mais fluida.

* **Melhorias**
  * Atualizações dos analisadores de loot e drops foram otimizadas para reduzir travamentos e atualizações repetidas.
  * Cálculos de DPS, HPS, dano e cura ficaram mais consistentes em janelas curtas.
  * O atalho Ctrl+C do terminal agora copia a seleção de forma mais confiável.

* **Correções**
  * Atualizações pendentes são canceladas corretamente ao fechar ou reiniciar janelas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->