### PR TITLE
Reduce Bosstiary and Store Lua callback stalls

### DIFF
--- a/mods/game_cyclopedia/classes/bosstiary.lua
+++ b/mods/game_cyclopedia/classes/bosstiary.lua
@@ -183,42 +183,45 @@ function Bosstiary.onBosstiaryBaseData(killData, rewardData)
 end
 
 function Bosstiary.onBosstiaryWindowData(data)
-	-- Init fields
-	local rootWidget = g_ui.getRootWidget()
-	bosstiaryMonsterPanel = rootWidget:recursiveGetChildById('bosstiaryMonsterPanel')
-	pageCounter = rootWidget:recursiveGetChildById('pageCount')
-	previousButton = rootWidget:recursiveGetChildById('backListButton')
-	nextButton = rootWidget:recursiveGetChildById('nextListButton')
-	searchField = rootWidget:recursiveGetChildById('searchBosstiary')
 	windowDataGeneration = windowDataGeneration + 1
 	local generation = windowDataGeneration
-	if rawBosstiaryData then
-		-- already opened
-		local activeSearch = searchField and searchField:getText() or nil
-		creatureRenderGeneration = creatureRenderGeneration + 1
-		rawBosstiaryData = data
-		scheduleEvent(function()
-			if generation == windowDataGeneration then
-				Bosstiary.configureBossList(rawBosstiaryData, activeSearch)
-				bosstiaryCurrentPage = math.max(1, math.min(bosstiaryCurrentPage, #bosstiaryCreatures))
-				Bosstiary.showCreatures()
-				Bosstiary.updateTracker()
-			end
-		end, 1)
-		return
-	end
-
+	local alreadyOpened = rawBosstiaryData ~= nil
 	creatureRenderGeneration = creatureRenderGeneration + 1
 	rawBosstiaryData = data
-	sortFields = {}
+	if not alreadyOpened then
+		sortFields = {}
+	end
 
-	-- Building the filters and boss cards in the network signal callback used to
-	-- block one frame. Start the work on the UI queue; showCreatures renders the
-	-- cards in small batches below.
 	scheduleEvent(function()
 		if generation ~= windowDataGeneration then
 			return
 		end
+
+		local panel = VisibleCyclopediaPanel
+		if not panel or panel:isDestroyed() then
+			Bosstiary.updateTracker()
+			return
+		end
+
+		bosstiaryMonsterPanel = panel:recursiveGetChildById('bosstiaryMonsterPanel')
+		pageCounter = panel:recursiveGetChildById('pageCount')
+		previousButton = panel:recursiveGetChildById('backListButton')
+		nextButton = panel:recursiveGetChildById('nextListButton')
+		searchField = panel:recursiveGetChildById('searchBosstiary')
+		if not bosstiaryMonsterPanel or not pageCounter or not previousButton or not nextButton then
+			Bosstiary.updateTracker()
+			return
+		end
+
+		if alreadyOpened then
+			local activeSearch = searchField and searchField:getText() or nil
+			Bosstiary.configureBossList(rawBosstiaryData, activeSearch)
+			bosstiaryCurrentPage = math.max(1, math.min(bosstiaryCurrentPage, #bosstiaryCreatures))
+			Bosstiary.showCreatures()
+			Bosstiary.updateTracker()
+			return
+		end
+
 		Bosstiary.initSortFields()
 		if redirectText ~= nil then
 			Bosstiary.onSearch(redirectText)
@@ -227,21 +230,16 @@ function Bosstiary.onBosstiaryWindowData(data)
 			Bosstiary.configureBossList(rawBosstiaryData)
 			Bosstiary.showCreatures()
 		end
-	end, 1)
 
-	cyclopediaWindow.optionsPanel:focus()
-	if VisibleCyclopediaPanel then
-    	VisibleCyclopediaPanel:focus()
-	end
-
-	if searchField then
-		searchField:focus()
-	end
-	scheduleEvent(function()
-		if generation == windowDataGeneration then
-			Bosstiary.updateTracker()
+		if cyclopediaWindow then
+			cyclopediaWindow.optionsPanel:focus()
 		end
-	end, 16)
+		panel:focus()
+		if searchField then
+			searchField:focus()
+		end
+		Bosstiary.updateTracker()
+	end, 1)
 end
 
 function Bosstiary.updateTracker()
@@ -276,7 +274,8 @@ function Bosstiary.showBosstiaryPage(index)
 end
 
 function Bosstiary.initSortFields()
-	local inforBox = g_ui.getRootWidget():recursiveGetChildById('infoCheckBox')
+	local panel = VisibleCyclopediaPanel or cyclopediaWindow or g_ui.getRootWidget()
+	local inforBox = panel:recursiveGetChildById('infoCheckBox')
   if not inforBox then
     return
   end

--- a/mods/game_store/classes/Categories.lua
+++ b/mods/game_store/classes/Categories.lua
@@ -9,6 +9,8 @@ if not Categories then
 	Categories.name = ''
 	Categories.signature = nil
 	Categories.widgets = {}
+	Categories.renderEvent = nil
+	Categories.renderGeneration = 0
 end
 
 local function getCategoriesSignature(categories)
@@ -24,14 +26,22 @@ local function getCategoriesSignature(categories)
 	return table.concat(parts, "\30")
 end
 
+function Categories:cancelRender()
+	removeEvent(Categories.renderEvent)
+	Categories.renderEvent = nil
+	Categories.renderGeneration = Categories.renderGeneration + 1
+end
+
 function Categories:configure(categories)
 	local categoryPanel = StoreWindow.categories
 	local signature = getCategoriesSignature(categories)
-	if Categories.signature == signature and #categoryPanel:getChildren() > 0 then
+	if Categories.signature == signature and not Categories.renderEvent and #categoryPanel:getChildren() > 0 then
 		return
 	end
 
-	local startedAt = g_clock.millis()
+	Categories:cancelRender()
+	local generation = Categories.renderGeneration
+	local setupStartedAt = g_clock.millis()
 	for i, child in pairs(categoryPanel:getChildren()) do
 		child:destroy()
 	end
@@ -42,78 +52,90 @@ function Categories:configure(categories)
 		[0] = {name = "Home", icon = "/images/store/icon-store-home"},
 	}
 
-	local createdCategory = {"Home"}
+	local createdCategories = {Home = true}
+	local categoryByName = {Home = Categories.categoryTable[0]}
 
-	for i, category in pairs(categories) do
+	for _, category in ipairs(categories) do
 		if #category.parent == 0 then
-			for i = 1, #Categories.categoryTable do
-				if Categories.categoryTable[i].name == category.name then
-					Categories.categoryTable[i].icon = category.icon
-					break
-				end
-			end
-
-			if not table.contains(createdCategory, category.name) then
-				createdCategory[#createdCategory + 1] = category.name
-				Categories.categoryTable[#Categories.categoryTable + 1] = {name = category.name, icon = category.icon}
+			local existing = categoryByName[category.name]
+			if existing then
+				existing.icon = category.icon
+			elseif not createdCategories[category.name] then
+				local entry = {name = category.name, icon = category.icon}
+				createdCategories[category.name] = true
+				categoryByName[category.name] = entry
+				Categories.categoryTable[#Categories.categoryTable + 1] = entry
 			end
 		else
-			local created = false
-			for i = 1, #Categories.categoryTable do
-				if Categories.categoryTable[i].name == category.parent then
-					if not Categories.categoryTable[i].childs then
-						Categories.categoryTable[i].childs = {}
-					end
-
-					if not table.contains(createdCategory, category.name) then
-						createdCategory[#createdCategory + 1] = category.name
-						Categories.categoryTable[i].childs[#Categories.categoryTable[i].childs + 1] = {name = category.name, icon = category.icon}
-					end
-					created = true
-				end
+			local parent = categoryByName[category.parent]
+			if parent and not createdCategories[category.name] then
+				parent.childs = parent.childs or {}
+				createdCategories[category.name] = true
+				parent.childs[#parent.childs + 1] = {name = category.name, icon = category.icon}
 			end
 		end
 	end
 
 	Categories.categoryTable[#Categories.categoryTable + 1] = {name = "Search", icon = "/images/store/icon-store-search-result", disabled = true}
+	Store:profileStep("Categories setup", setupStartedAt)
 
-	for id, cat in pairs(Categories.categoryTable) do
-		local widget = g_ui.createWidget('TreeItem', categoryPanel)
-		widget:setId(id)
-		Categories.widgets[id] = widget
-		widget.mainButton.text:setText(cat.name)
-		if cat.childs and #cat.childs > 0 then
-			widget.mainButton.scroll:setVisible(true)
-		else
-			widget.mainButton.scroll:setHeight(0)
+	local id = 0
+	local function renderNextBatch()
+		if generation ~= Categories.renderGeneration or categoryPanel:isDestroyed() then
+			return
 		end
 
-		if cat.disabled then
-			widget:setVisible(false)
-		end
-
-		if g_resources.fileExists(cat.icon) or table.contains({"Home", "Search"}, cat.name) then
-			widget.mainButton.icon:setImageSource(cat.icon)
-		else
-			local currentWidget = widget.mainButton.icon
-			currentWidget.currentImageRequest = Store.currentRequest
-			Store.imageRequests[Store.currentRequest] = currentWidget
-			Store.currentRequest = Store.currentRequest + 1
-
-			currentWidget:insertLuaCall("onDestroy")
-			currentWidget.onDestroy = function()
-				Store.imageRequests[currentWidget.currentImageRequest] = nil
+		local batchStartedAt = g_clock.millis()
+		local lastId = math.min(id + 2, #Categories.categoryTable)
+		while id <= lastId do
+			local cat = Categories.categoryTable[id]
+			local widget = g_ui.createWidget('TreeItem', categoryPanel)
+			widget:setId(id)
+			Categories.widgets[id] = widget
+			widget.mainButton.text:setText(cat.name)
+			if cat.childs and #cat.childs > 0 then
+				widget.mainButton.scroll:setVisible(true)
+			else
+				widget.mainButton.scroll:setHeight(0)
 			end
 
-			Store:downloadImage(currentWidget.currentImageRequest, "13/"..cat.icon)
+			if cat.disabled then
+				widget:setVisible(false)
+			end
+
+			if g_resources.fileExists(cat.icon) or table.contains({"Home", "Search"}, cat.name) then
+				widget.mainButton.icon:setImageSource(cat.icon)
+			else
+				local currentWidget = widget.mainButton.icon
+				currentWidget.currentImageRequest = Store.currentRequest
+				Store.imageRequests[Store.currentRequest] = currentWidget
+				Store.currentRequest = Store.currentRequest + 1
+
+				currentWidget:insertLuaCall("onDestroy")
+				currentWidget.onDestroy = function()
+					Store.imageRequests[currentWidget.currentImageRequest] = nil
+				end
+
+				Store:downloadImage(currentWidget.currentImageRequest, "13/"..cat.icon)
+			end
+
+			widget.mainButton.onClick = function()
+				Categories:onSelectCategory(widget.mainButton)
+			end
+			id = id + 1
 		end
 
-		widget.mainButton.onClick = function()
-			Categories:onSelectCategory(widget.mainButton)
+		Store:profileStep("Categories widget batch", batchStartedAt)
+		if id <= #Categories.categoryTable then
+			Categories.renderEvent = scheduleEvent(renderNextBatch, 1)
+			return
 		end
+
+		Categories.renderEvent = nil
+		Categories.signature = signature
 	end
-	Categories.signature = signature
-	Store:profileStep("Categories:configure", startedAt)
+
+	renderNextBatch()
 end
 
 
@@ -231,6 +253,7 @@ function Categories:setupSearch(disabled)
 end
 
 function Categories:reset()
+	Categories:cancelRender()
 	Categories.signature = nil
 	Categories.widgets = {}
 	Categories.selectButton = nil

--- a/mods/game_store/classes/Home.lua
+++ b/mods/game_store/classes/Home.lua
@@ -10,6 +10,14 @@ if not HomeOffer then
 	HomeOffer.lastid = 0
 	HomeOffer.dailyReroll = 0
 	HomeOffer.dailyRerollWindow = nil
+	HomeOffer.renderEvent = nil
+	HomeOffer.renderGeneration = 0
+end
+
+function HomeOffer:cancelRender()
+	removeEvent(HomeOffer.renderEvent)
+	HomeOffer.renderEvent = nil
+	HomeOffer.renderGeneration = HomeOffer.renderGeneration + 1
 end
 
 local function timerEvent(widget, endTime)
@@ -34,7 +42,7 @@ local function timerEvent(widget, endTime)
 end
 
 function HomeOffer:configure(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
-	local startedAt = g_clock.millis()
+	local setupStartedAt = g_clock.millis()
 	if Offers.displayPanel then
 		Offers.displayPanel:destroy()
 	end
@@ -62,40 +70,43 @@ function HomeOffer:configure(categoryName, offers, scrolling, homePanel, reasons
 
 	Offers.reasons = reasons
 
-	HomeOffer:createOffers()
 	HomeOffer.lastid = 0
-	HomeOffer:configurePanels()
-	if #HomeOffer.homePanel > 1 then
-		Offers.displayPanel.prevBanner:setVisible(true)
-		Offers.displayPanel.nextBanner:setVisible(true)
-		HomeOffer:startBannerCycle()
-	end
+	HomeOffer:createOffers(function()
+		local completionStartedAt = g_clock.millis()
+		HomeOffer:configurePanels()
+		if #HomeOffer.homePanel > 1 then
+			Offers.displayPanel.prevBanner:setVisible(true)
+			Offers.displayPanel.nextBanner:setVisible(true)
+			HomeOffer:startBannerCycle()
+		end
 
-	if table.empty(HomeOffer.dailyOffers) then
-		Offers.dailyPanel:setVisible(false)
-		Offers.displayPanel.mainOffers:setHeight(328)
-		highlightWidget:setVisible(false)
-		Store:profileStep("HomeOffer:configure", startedAt)
-		return
-	end
+		if table.empty(HomeOffer.dailyOffers) then
+			Offers.dailyPanel:setVisible(false)
+			Offers.displayPanel.mainOffers:setHeight(328)
+			highlightWidget:setVisible(false)
+			Store:profileStep("HomeOffer completion", completionStartedAt)
+			return
+		end
 
-	local endTime = dailyOffers[1].expireTime
-	removeEvent(HomeOffer.timerEvent)
-	timerEvent(Offers.dailyPanel.timerLabel, endTime)
+		local endTime = dailyOffers[1].expireTime
+		removeEvent(HomeOffer.timerEvent)
+		timerEvent(Offers.dailyPanel.timerLabel, endTime)
 
-	HomeOffer:createDailyOffers()
+		HomeOffer:createDailyOffers()
 
-	local rerollButton = StoreWindow.contentPanel:recursiveGetChildById('discountRerollButton')
-	if not rerollButton then
-		Store:profileStep("HomeOffer:configure", startedAt)
-		return
-	end
+		local rerollButton = StoreWindow.contentPanel:recursiveGetChildById('discountRerollButton')
+		if not rerollButton then
+			Store:profileStep("HomeOffer completion", completionStartedAt)
+			return
+		end
 
-	rerollButton.onClick = function(self) HomeOffer:onRerollDailyOffer(self) end
+		rerollButton.onClick = function(self) HomeOffer:onRerollDailyOffer(self) end
 
-	rerollButton:setEnabled(Store.transferableCoins >= dailyOfferPrice)
-	rerollButton:setTooltip(string.format("Reroll offers for %d Astra Coins", dailyOfferPrice))
-	Store:profileStep("HomeOffer:configure", startedAt)
+		rerollButton:setEnabled(Store.transferableCoins >= dailyOfferPrice)
+		rerollButton:setTooltip(string.format("Reroll offers for %d Astra Coins", dailyOfferPrice))
+		Store:profileStep("HomeOffer completion", completionStartedAt)
+	end)
+	Store:profileStep("HomeOffer setup", setupStartedAt)
 end
 
 local function getOfferUI(offer)
@@ -141,10 +152,12 @@ function HomeOffer:onRerollDailyOffer(button)
 	g_client.setInputLockWidget(HomeOffer.dailyRerollWindow)
 end
 
-function HomeOffer:createOffers()
-	local startedAt = g_clock.millis()
+function HomeOffer:createOffers(onComplete)
+	HomeOffer:cancelRender()
+	local generation = HomeOffer.renderGeneration
 	Offers.displayPanel.mainOffers.offersPanel:destroyChildren()
-	for _, offer in ipairs(HomeOffer.offers) do
+	local renderer = coroutine.create(function()
+		for index, offer in ipairs(HomeOffer.offers) do
 		local widget = g_ui.createWidget(getOfferUI(offer), Offers.displayPanel.mainOffers.offersPanel)
 
 		-- Setup dimensions
@@ -290,8 +303,39 @@ function HomeOffer:createOffers()
 
 			count = count + 1
 		end
+			if index % 2 == 0 then
+				coroutine.yield()
+			end
+		end
+	end)
+
+	local function renderNextBatch()
+		if generation ~= HomeOffer.renderGeneration or not Offers.displayPanel or Offers.displayPanel:isDestroyed() then
+			return
+		end
+
+		local batchStartedAt = g_clock.millis()
+		local ok, renderError = coroutine.resume(renderer)
+		if not ok then
+			HomeOffer.renderEvent = nil
+			error(renderError)
+		end
+		Store:profileStep("HomeOffer widget batch", batchStartedAt)
+
+		if coroutine.status(renderer) ~= "dead" then
+			HomeOffer.renderEvent = scheduleEvent(renderNextBatch, 1)
+			return
+		end
+
+		HomeOffer.renderEvent = scheduleEvent(function()
+			HomeOffer.renderEvent = nil
+			if generation == HomeOffer.renderGeneration and onComplete then
+				onComplete()
+			end
+		end, 1)
 	end
-	Store:profileStep("HomeOffer:createOffers", startedAt)
+
+	renderNextBatch()
 end
 
 function HomeOffer:createDailyOffers()

--- a/mods/game_store/classes/Home.lua
+++ b/mods/game_store/classes/Home.lua
@@ -156,8 +156,7 @@ function HomeOffer:createOffers(onComplete)
 	HomeOffer:cancelRender()
 	local generation = HomeOffer.renderGeneration
 	Offers.displayPanel.mainOffers.offersPanel:destroyChildren()
-	local renderer = coroutine.create(function()
-		for index, offer in ipairs(HomeOffer.offers) do
+	local function createOffer(offer)
 		local widget = g_ui.createWidget(getOfferUI(offer), Offers.displayPanel.mainOffers.offersPanel)
 
 		-- Setup dimensions
@@ -303,11 +302,9 @@ function HomeOffer:createOffers(onComplete)
 
 			count = count + 1
 		end
-			if index % 2 == 0 then
-				coroutine.yield()
-			end
-		end
-	end)
+	end
+
+	local nextOfferIndex = 1
 
 	local function renderNextBatch()
 		if generation ~= HomeOffer.renderGeneration or not Offers.displayPanel or Offers.displayPanel:isDestroyed() then
@@ -315,14 +312,16 @@ function HomeOffer:createOffers(onComplete)
 		end
 
 		local batchStartedAt = g_clock.millis()
-		local ok, renderError = coroutine.resume(renderer)
-		if not ok then
-			HomeOffer.renderEvent = nil
-			error(renderError)
+		local createdInBatch = 0
+		while nextOfferIndex <= #HomeOffer.offers and createdInBatch < 2 do
+			local offer = HomeOffer.offers[nextOfferIndex]
+			nextOfferIndex = nextOfferIndex + 1
+			createOffer(offer)
+			createdInBatch = createdInBatch + 1
 		end
 		Store:profileStep("HomeOffer widget batch", batchStartedAt)
 
-		if coroutine.status(renderer) ~= "dead" then
+		if nextOfferIndex <= #HomeOffer.offers then
 			HomeOffer.renderEvent = scheduleEvent(renderNextBatch, 1)
 			return
 		end

--- a/mods/game_store/classes/Offers.lua
+++ b/mods/game_store/classes/Offers.lua
@@ -253,6 +253,9 @@ local function findSubOfferById(offerId)
 end
 
 function Offers:stopAllEvents()
+	if HomeOffer.cancelRender then
+		HomeOffer:cancelRender()
+	end
 	removeEvent(HomeOffer.event)
 	removeEvent(HomeOffer.timerEvent)
 	removeEvent(Offers.event)

--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -12,6 +12,43 @@ OFFERTYPE = nil
 
 giftWindow = nil
 
+local categoryUpdateEvent = nil
+local contentUpdateEvent = nil
+
+local function cancelPendingStoreUpdates(cancelRenders)
+  removeEvent(categoryUpdateEvent)
+  removeEvent(contentUpdateEvent)
+  categoryUpdateEvent = nil
+  contentUpdateEvent = nil
+  if cancelRenders and Categories and Categories.cancelRender then
+    Categories:cancelRender()
+  end
+  if cancelRenders and HomeOffer and HomeOffer.cancelRender then
+    HomeOffer:cancelRender()
+  end
+end
+
+local function queueStoreUpdate(eventName, callback)
+  if eventName == "category" then
+    removeEvent(categoryUpdateEvent)
+    categoryUpdateEvent = scheduleEvent(function()
+      categoryUpdateEvent = nil
+      if StoreWindow then
+        callback()
+      end
+    end, 1)
+    return
+  end
+
+  removeEvent(contentUpdateEvent)
+  contentUpdateEvent = scheduleEvent(function()
+    contentUpdateEvent = nil
+    if StoreWindow then
+      callback()
+    end
+  end, 1)
+end
+
 local importFiles = {
   'styles/buttons',
   'styles/home',
@@ -85,6 +122,8 @@ function init()
 end
 
 function terminate()
+  cancelPendingStoreUpdates(true)
+
   if terminateStoreProtocol then
     terminateStoreProtocol()
   end
@@ -165,6 +204,8 @@ end
 
 -- Setup Store
 function onGameEnd()
+  cancelPendingStoreUpdates(true)
+
   if StoreWindow:isVisible() then
     StoreWindow:hide()
   end
@@ -210,6 +251,8 @@ function onGameEnd()
 end
 
 function closeStore()
+  cancelPendingStoreUpdates(false)
+
   if StoreWindow:isVisible() then
     StoreWindow:hide()
   end
@@ -269,13 +312,13 @@ function onStoreInit(url, coinsPacketSize)
 end
 
 function onStoreCategories(categories)
-  local startedAt = g_clock.millis()
-  if not StoreWindow:isVisible() then
-    showStoreWindow()
-  end
+  queueStoreUpdate("category", function()
+    if not StoreWindow:isVisible() then
+      showStoreWindow()
+    end
 
-  Categories:configure(categories)
-  Store:profileStep("onStoreCategories", startedAt)
+    Categories:configure(categories)
+  end)
 end
 
 function onCoinBalance(coins, transferableCoins, tournamentCoins)
@@ -290,11 +333,15 @@ function onCoinBalance(coins, transferableCoins, tournamentCoins)
 end
 
 function onStoreHomeOffers(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
-  HomeOffer:configure(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
+  queueStoreUpdate("content", function()
+    HomeOffer:configure(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
+  end)
 end
 
 function onStoreOffers(categoryName, offers, redirect, sortingType, filters, currentFilter, reasons)
-  Offers:configure(categoryName, offers, redirect, sortingType, filters, currentFilter, reasons)
+  queueStoreUpdate("content", function()
+    Offers:configure(categoryName, offers, redirect, sortingType, filters, currentFilter, reasons)
+  end)
 end
 
 function onSelectionOffer(widget, selectedWidget)
@@ -515,8 +562,10 @@ function onEnterSearch()
 end
 
 function onStoreSearchOffers(categoryName, offers, unknow, reasons)
-  Categories:setupSearch(false)
-  Offers:configure(categoryName, offers, 0, 0, {}, '', reasons)
+  queueStoreUpdate("content", function()
+    Categories:setupSearch(false)
+    Offers:configure(categoryName, offers, 0, 0, {}, '', reasons)
+  end)
 end
 
 function openBaazarWindow()

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -6,6 +6,9 @@ local enterGame
 local logpass
 local twofactor
 local protocolLogin
+local loginEvent
+local characterListEvent
+local settingsSaveEvent
 
 local customServerSelectorPanel
 local serverSelectorPanel
@@ -126,7 +129,7 @@ local function getGoogleLoginUrl(server)
   return url:gsub('/+$', '')
 end
 
-local function onCharacterList(protocol, characters, account, otui)
+local function finishCharacterList(characters, account, otui)
   if rememberEmailBox:isChecked() then
     local account = g_crypt.encrypt(G.account)
     g_settings.set('account', account)
@@ -164,7 +167,23 @@ local function onCharacterList(protocol, characters, account, otui)
   CharacterList.create(characters, account, otui)
   CharacterList.show()
 
-  g_settings.save()
+  if settingsSaveEvent then
+    removeEvent(settingsSaveEvent)
+  end
+  settingsSaveEvent = scheduleEvent(function()
+    settingsSaveEvent = nil
+    g_settings.save()
+  end, 1)
+end
+
+local function onCharacterList(protocol, characters, account, otui)
+  if characterListEvent then
+    removeEvent(characterListEvent)
+  end
+  characterListEvent = scheduleEvent(function()
+    characterListEvent = nil
+    finishCharacterList(characters, account, otui)
+  end, 1)
 end
 
 local function onUpdateNeeded(protocol, signature)
@@ -522,6 +541,19 @@ end
 function EnterGame.terminate()
   if not enterGame then return end
 
+  if loginEvent then
+    removeEvent(loginEvent)
+    loginEvent = nil
+  end
+  if characterListEvent then
+    removeEvent(characterListEvent)
+    characterListEvent = nil
+  end
+  if settingsSaveEvent then
+    removeEvent(settingsSaveEvent)
+    settingsSaveEvent = nil
+  end
+
   keybindChangeChar:deactive(gameRootPanel)
   g_keyboard.unbindKeyDown("Ctrl+Alt+T", enterGame)
 
@@ -620,7 +652,7 @@ function EnterGame.onServerChange()
   end
 end
 
-function EnterGame.doLogin(account, password, token, host, gtoken)
+local function performLogin(account, password, token, host, gtoken)
   if g_game.isOnline() then
     local errorBox = displayErrorBox(tr('Login Error'), tr('Cannot login while already in game.'))
     connect(errorBox, { onOk = EnterGame.show })
@@ -659,8 +691,6 @@ function EnterGame.doLogin(account, password, token, host, gtoken)
   g_settings.set('server', G.server)
   g_settings.set('client-version', G.clientVersion)
   g_settings.set('hiddenEmail', enterGame.accountNameTextEdit:isTextHidden() and 1 or 0)
-
-  g_settings.save()
 
   local server_params = G.host:split(":")
   if G.host:lower():find("http") ~= nil then
@@ -737,6 +767,17 @@ function EnterGame.doLogin(account, password, token, host, gtoken)
     local thingsError = ensureThingsLoaded() or tr('Please place the Tibia 8.60 asset files in data/things/860 (Tibia.dat and Tibia.spr).')
     return EnterGame.onError(thingsError)
   end
+end
+
+function EnterGame.doLogin(account, password, token, host, gtoken)
+  if loginEvent then
+    return
+  end
+
+  loginEvent = scheduleEvent(function()
+    loginEvent = nil
+    performLogin(account, password, token, host, gtoken)
+  end, 1)
 end
 
 function EnterGame.doLoginHttp()


### PR DESCRIPTION
## Summary
- defer Bosstiary UI work out of the protocol signal callback
- scope Bosstiary widget lookup to the visible Cyclopedia panel
- queue Store protocol UI updates with cancellation on close, logout, and unload
- build Store categories and Home offers in bounded batches
- replace repeated category scans with indexed lookup tables

## Root cause
Protocol signal callbacks were traversing the full UI tree and synchronously creating every category and Home offer widget. Recorded callbacks took about 7 ms in Bosstiary, 30 ms in Store categories, and 17 ms in Store Home offers.

## Validation
- `git diff --check`
- loaded all Lua modules twice with the existing `otclient_dx_x64.exe`; no Lua syntax or startup errors
- no AstraClient rebuild was performed, as requested

The Store keeps per-batch developer profiling so oversized batches remain visible in runtime logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * Abertura e atualização do Bosstiary ficaram mais estáveis, preservando busca, paginação, contadores e foco da interface.
  * A Store agora carrega categorias e ofertas gradualmente, mantendo a interface mais responsiva durante atualizações.
  * Atualizações antigas são canceladas ao fechar a loja ou encerrar a sessão, evitando alterações indevidas na tela.
  * Itens desativados permanecem ocultos corretamente, e imagens são liberadas após o uso.
  * A renderização de ofertas e categorias é interrompida e reiniciada quando necessário, reduzindo inconsistências visuais.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->