### PR TITLE
Render native zone weather

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -345,8 +345,9 @@ GamePackedPlayerInventory = 140
 GameAstraQuiverCountU16 = 141
 GameAstraOutfitStoreMode = 142
 GameAstraItemMetadata = 143
+GameZoneWeather = 144
 
-LastGameFeature = 144
+LastGameFeature = 145
 
 TextColors = {
   red        = '#F55E5E',

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -62,6 +62,8 @@ set(client_SOURCES ${client_SOURCES}
     ${CMAKE_CURRENT_LIST_DIR}/houses.h
     ${CMAKE_CURRENT_LIST_DIR}/towns.cpp
     ${CMAKE_CURRENT_LIST_DIR}/towns.h
+    ${CMAKE_CURRENT_LIST_DIR}/weathermanager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/weathermanager.h
     ${CMAKE_CURRENT_LIST_DIR}/creatures.cpp
     ${CMAKE_CURRENT_LIST_DIR}/creatures.h
 

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -507,8 +507,9 @@ namespace Otc
         GameAstraQuiverCountU16 = 141,
         GameAstraOutfitStoreMode = 142,
         GameAstraItemMetadata = 143,
+        GameZoneWeather = 144,
 
-        LastGameFeature = 144
+        LastGameFeature = 145
     };
 
     enum PathFindResult {

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -22,6 +22,7 @@
 
 #include "game.h"
 #include "localplayer.h"
+#include "weathermanager.h"
 #include "map.h"
 #include "tile.h"
 #include "creature.h"
@@ -136,6 +137,7 @@ void Game::terminate()
 
 void Game::resetGameStates()
 {
+    g_weatherManager.clear();
     m_online = false;
     m_denyBotCall = false;
     m_dead = false;

--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -70,6 +70,8 @@ namespace Proto {
         // otclient ONLY
         GameServerExtendedOpcode            = 50,
         GameServerProgressBar               = 59,
+        // Reserved for native ZoneId weather negotiated by GameZoneWeather.
+        GameServerZoneWeather               = 60,
 
         // NOTE: add any custom opcodes in this range
         // OTClientV8 64-79

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -344,6 +344,7 @@ private:
     void parseExtendedOpcode(const InputMessagePtr& msg);
     void parseChangeMapAwareRange(const InputMessagePtr& msg);
     void parseProgressBar(const InputMessagePtr& msg);
+    void parseZoneWeather(const InputMessagePtr& msg);
     void parseFeatures(const InputMessagePtr& msg);
     void parseCreaturesMark(const InputMessagePtr& msg);
     void parseNewCancelWalk(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -41,6 +41,7 @@
 #include "effect.h"
 #include "missile.h"
 #include "tile.h"
+#include "weathermanager.h"
 #include "luavaluecasts_client.h"
 #include <framework/core/eventdispatcher.h>
 #include <framework/util/extras.h>
@@ -676,6 +677,9 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
                 break;
             case Proto::GameServerProgressBar:
                 parseProgressBar(msg);
+                break;
+            case Proto::GameServerZoneWeather:
+                parseZoneWeather(msg);
                 break;
             case Proto::GameServerFeatures:
                 parseFeatures(msg);
@@ -4397,6 +4401,47 @@ void ProtocolGame::parseProgressBar(const InputMessagePtr& msg)
         creature->setProgressBar(duration, ltr);
     else
         g_logger.traceError(stdext::format("could not get creature with id %d", id));
+}
+
+void ProtocolGame::parseZoneWeather(const InputMessagePtr& msg)
+{
+    constexpr int WEATHER_PAYLOAD_SIZE = 7;
+    constexpr uint8 WEATHER_PACKET_VERSION = 1;
+    if (msg->getUnreadSize() < WEATHER_PAYLOAD_SIZE) {
+        stdext::throw_exception("truncated zone weather packet");
+    }
+
+    const uint8 packetVersion = msg->getU8();
+    const uint8 rawWeatherType = msg->getU8();
+    const uint8 intensity = msg->getU8();
+    const auto decodeSignedByte = [](uint8 value) -> int8 {
+        return value <= 127 ? static_cast<int8>(value) : static_cast<int8>(static_cast<int16>(value) - 256);
+    };
+    const int8 windX = decodeSignedByte(msg->getU8());
+    const int8 windY = decodeSignedByte(msg->getU8());
+    const uint16 transitionMs = msg->getU16();
+
+    if (packetVersion != WEATHER_PACKET_VERSION || !g_game.getFeature(Otc::GameZoneWeather)) {
+        g_weatherManager.clear();
+        return;
+    }
+
+    WeatherState state;
+    if (rawWeatherType <= static_cast<uint8>(WeatherType::Sand)) {
+        state.type = static_cast<WeatherType>(rawWeatherType);
+    } else {
+        state.type = WeatherType::None;
+    }
+    state.intensity = std::min<uint8>(intensity, 100);
+    state.windX = windX;
+    state.windY = windY;
+    state.transitionMs = transitionMs;
+    if (state.type == WeatherType::None) {
+        state.intensity = 0;
+        state.windX = 0;
+        state.windY = 0;
+    }
+    g_weatherManager.setWeather(state);
 }
 
 void ProtocolGame::parseFeatures(const InputMessagePtr& msg)

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4414,11 +4414,8 @@ void ProtocolGame::parseZoneWeather(const InputMessagePtr& msg)
     const uint8 packetVersion = msg->getU8();
     const uint8 rawWeatherType = msg->getU8();
     const uint8 intensity = msg->getU8();
-    const auto decodeSignedByte = [](uint8 value) -> int8 {
-        return value <= 127 ? static_cast<int8>(value) : static_cast<int8>(static_cast<int16>(value) - 256);
-    };
-    const int8 windX = decodeSignedByte(msg->getU8());
-    const int8 windY = decodeSignedByte(msg->getU8());
+    const int8 windX = static_cast<int8>(msg->getU8());
+    const int8 windY = static_cast<int8>(msg->getU8());
     const uint16 transitionMs = msg->getU16();
 
     if (packetVersion != WEATHER_PACKET_VERSION || !g_game.getFeature(Otc::GameZoneWeather)) {

--- a/src/client/uimap.cpp
+++ b/src/client/uimap.cpp
@@ -52,7 +52,6 @@ UIMap::UIMap()
 
 UIMap::~UIMap()
 {
-    g_weatherManager.clear();
     g_map.removeMapView(m_mapView);
 }
 

--- a/src/client/uimap.cpp
+++ b/src/client/uimap.cpp
@@ -32,6 +32,7 @@
 #include <framework/input/mouse.h>
 #include <framework/platform/platformwindow.h>
 #include "localplayer.h"
+#include "weathermanager.h"
 
 UIMap::UIMap()
 {
@@ -51,6 +52,7 @@ UIMap::UIMap()
 
 UIMap::~UIMap()
 {
+    g_weatherManager.clear();
     g_map.removeMapView(m_mapView);
 }
 
@@ -80,6 +82,7 @@ void UIMap::drawSelf(Fw::DrawPane drawPane)
         m_mapView->drawMapBackground(m_mapRect, getTile(m_mousePosition));
     } else if (drawPane == Fw::MapForegroundPane) {
         m_mapView->drawMapForeground(m_mapRect);
+        g_weatherManager.draw(m_mapRect);
     }
 }
 

--- a/src/client/weathermanager.cpp
+++ b/src/client/weathermanager.cpp
@@ -128,7 +128,7 @@ void WeatherManager::update(uint64 nowMs)
         if (m_transitionDurationMs == 0) {
             m_currentIntensity = m_transitionTargetIntensity;
         } else {
-            m_transitionElapsedMs = std::min<uint64>(m_transitionElapsedMs + deltaMs, m_transitionDurationMs);
+            m_transitionElapsedMs = std::min<uint64>(m_transitionElapsedMs + elapsedMs, m_transitionDurationMs);
             const float progress = static_cast<float>(m_transitionElapsedMs) / m_transitionDurationMs;
             m_currentIntensity = m_transitionStartIntensity +
                 (m_transitionTargetIntensity - m_transitionStartIntensity) * progress;
@@ -166,7 +166,7 @@ void WeatherManager::updateParticles(float deltaSeconds, size_t activeCount)
                 particle.y = wrapUnit(particle.y + (0.08f + particle.speed * 0.14f + windY * 0.025f) * deltaSeconds);
                 break;
             case WeatherType::Sand: {
-                const float direction = std::abs(windX) < 0.01f ? 1.0f : windX;
+                const float direction = m_activeState.windX == 0 ? 1.0f : windX;
                 particle.x = wrapUnit(particle.x + (direction * (0.32f + particle.speed * 0.24f)) * deltaSeconds);
                 particle.y = wrapUnit(particle.y + (particle.drift * 0.015f + windY * 0.025f) * deltaSeconds);
                 break;

--- a/src/client/weathermanager.cpp
+++ b/src/client/weathermanager.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2010-2017 OTClient <https://github.com/edubart/otclient>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+
+#include "weathermanager.h"
+
+#include <framework/core/clock.h>
+#include <framework/graphics/drawqueue.h>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+WeatherManager g_weatherManager;
+
+namespace {
+
+constexpr uint8 MAX_INTENSITY = 100;
+constexpr float MIN_VISIBLE_INTENSITY = 0.01f;
+constexpr uint64 MAX_FRAME_DELTA_MS = 250;
+
+float wrapUnit(float value)
+{
+    value -= std::floor(value);
+    return value < 0.0f ? value + 1.0f : value;
+}
+
+float randomUnit(uint32& state)
+{
+    state = state * 1664525u + 1013904223u;
+    return static_cast<float>(state & 0x00FFFFFFu) / static_cast<float>(0x01000000u);
+}
+
+} // namespace
+
+WeatherManager::WeatherManager()
+{
+    initializeParticles();
+}
+
+void WeatherManager::initializeParticles()
+{
+    uint32 randomState = 0xA57A860u;
+    for (Particle& particle : m_particles) {
+        particle.x = randomUnit(randomState);
+        particle.y = randomUnit(randomState);
+        particle.speed = 0.35f + randomUnit(randomState) * 0.75f;
+        particle.drift = randomUnit(randomState) * 2.0f - 1.0f;
+        particle.size = 1.0f + randomUnit(randomState) * 2.0f;
+        particle.phase = randomUnit(randomState) * 6.28318530718f;
+    }
+}
+
+void WeatherManager::beginIntensityTransition(float target, uint16 durationMs)
+{
+    m_transitionStartIntensity = m_currentIntensity;
+    m_transitionTargetIntensity = std::clamp(target, 0.0f, static_cast<float>(MAX_INTENSITY));
+    m_transitionElapsedMs = 0;
+    m_transitionDurationMs = durationMs;
+
+    if (durationMs == 0) {
+        m_currentIntensity = m_transitionTargetIntensity;
+        finishTypeTransitionIfNeeded();
+    }
+}
+
+void WeatherManager::setWeather(WeatherState state)
+{
+    if (state.type > WeatherType::Sand) {
+        state = {};
+    }
+    state.intensity = std::min<uint8>(state.intensity, MAX_INTENSITY);
+    if (state.type == WeatherType::None) {
+        state.intensity = 0;
+        state.windX = 0;
+        state.windY = 0;
+    }
+
+    if (m_activeState.type == WeatherType::None || m_currentIntensity <= MIN_VISIBLE_INTENSITY ||
+        state.type == m_activeState.type) {
+        m_activeState = state;
+        m_hasPendingState = false;
+        beginIntensityTransition(static_cast<float>(state.intensity), state.transitionMs);
+        return;
+    }
+
+    // Fade the active type to zero first. Only the latest requested state is
+    // retained, so rapid changes never accumulate multiple particle pools.
+    m_pendingState = state;
+    m_hasPendingState = true;
+    beginIntensityTransition(0.0f, state.transitionMs);
+}
+
+void WeatherManager::finishTypeTransitionIfNeeded()
+{
+    if (!m_hasPendingState || m_currentIntensity > MIN_VISIBLE_INTENSITY) {
+        return;
+    }
+
+    m_activeState = m_pendingState;
+    m_hasPendingState = false;
+    m_currentIntensity = 0.0f;
+    beginIntensityTransition(static_cast<float>(m_activeState.intensity), m_activeState.transitionMs);
+}
+
+void WeatherManager::update(uint64 nowMs)
+{
+    if (m_lastUpdateMs == 0) {
+        m_lastUpdateMs = nowMs;
+        return;
+    }
+
+    const uint64 elapsedMs = nowMs >= m_lastUpdateMs ? nowMs - m_lastUpdateMs : 0;
+    const uint64 deltaMs = std::min<uint64>(elapsedMs, MAX_FRAME_DELTA_MS);
+    m_lastUpdateMs = nowMs;
+
+    if (m_currentIntensity != m_transitionTargetIntensity) {
+        if (m_transitionDurationMs == 0) {
+            m_currentIntensity = m_transitionTargetIntensity;
+        } else {
+            m_transitionElapsedMs = std::min<uint64>(m_transitionElapsedMs + deltaMs, m_transitionDurationMs);
+            const float progress = static_cast<float>(m_transitionElapsedMs) / m_transitionDurationMs;
+            m_currentIntensity = m_transitionStartIntensity +
+                (m_transitionTargetIntensity - m_transitionStartIntensity) * progress;
+        }
+
+        if (m_transitionElapsedMs >= m_transitionDurationMs || m_transitionDurationMs == 0) {
+            m_currentIntensity = m_transitionTargetIntensity;
+            finishTypeTransitionIfNeeded();
+        }
+    }
+
+    const size_t activeCount = std::min<size_t>(m_particles.size(), static_cast<size_t>(std::lround(
+        m_currentIntensity * static_cast<float>(m_particles.size()) / MAX_INTENSITY)));
+    updateParticles(static_cast<float>(deltaMs) / 1000.0f, activeCount);
+}
+
+void WeatherManager::updateParticles(float deltaSeconds, size_t activeCount)
+{
+    if (deltaSeconds <= 0.0f || activeCount == 0 || m_activeState.type == WeatherType::None) {
+        return;
+    }
+
+    const float windX = static_cast<float>(m_activeState.windX) / 127.0f;
+    const float windY = static_cast<float>(m_activeState.windY) / 127.0f;
+    for (size_t index = 0; index < activeCount; ++index) {
+        Particle& particle = m_particles[index];
+        switch (m_activeState.type) {
+            case WeatherType::Rain:
+                particle.x = wrapUnit(particle.x + windX * deltaSeconds * 0.20f);
+                particle.y = wrapUnit(particle.y + (0.55f + particle.speed + windY * 0.12f) * deltaSeconds);
+                break;
+            case WeatherType::Snow:
+                particle.phase += deltaSeconds * (0.8f + particle.speed);
+                particle.x = wrapUnit(particle.x + (windX * 0.08f + std::sin(particle.phase) * 0.015f) * deltaSeconds);
+                particle.y = wrapUnit(particle.y + (0.08f + particle.speed * 0.14f + windY * 0.025f) * deltaSeconds);
+                break;
+            case WeatherType::Sand: {
+                const float direction = std::abs(windX) < 0.01f ? 1.0f : windX;
+                particle.x = wrapUnit(particle.x + (direction * (0.32f + particle.speed * 0.24f)) * deltaSeconds);
+                particle.y = wrapUnit(particle.y + (particle.drift * 0.015f + windY * 0.025f) * deltaSeconds);
+                break;
+            }
+            case WeatherType::None:
+                break;
+        }
+    }
+}
+
+void WeatherManager::draw(const Rect& mapRect)
+{
+    update(g_clock.millis());
+    if (mapRect.isEmpty() || m_activeState.type == WeatherType::None ||
+        m_currentIntensity <= MIN_VISIBLE_INTENSITY) {
+        return;
+    }
+
+    const size_t activeCount = std::min<size_t>(m_particles.size(), static_cast<size_t>(std::lround(
+        m_currentIntensity * static_cast<float>(m_particles.size()) / MAX_INTENSITY)));
+    if (activeCount == 0) {
+        return;
+    }
+
+    const size_t drawQueueStart = g_drawQueue->size();
+    const int left = mapRect.left();
+    const int top = mapRect.top();
+    const int width = std::max(1, mapRect.width());
+    const int height = std::max(1, mapRect.height());
+
+    for (size_t index = 0; index < activeCount; ++index) {
+        const Particle& particle = m_particles[index];
+        const int x = left + static_cast<int>(particle.x * width);
+        const int y = top + static_cast<int>(particle.y * height);
+
+        switch (m_activeState.type) {
+            case WeatherType::Rain: {
+                const int slant = static_cast<int>(m_activeState.windX / 18);
+                const int length = 6 + static_cast<int>(particle.size * 2.0f);
+                g_drawQueue->addLine({ Point(x, y), Point(x + slant, y + length) }, 1, Color(150, 195, 255, 185));
+                break;
+            }
+            case WeatherType::Snow: {
+                const int size = std::clamp(static_cast<int>(std::lround(particle.size)), 1, 3);
+                g_drawQueue->addFilledRect(Rect(Point(x, y), Size(size, size)), Color(235, 245, 255, 205));
+                break;
+            }
+            case WeatherType::Sand: {
+                const int length = 3 + static_cast<int>(particle.size * 2.0f);
+                g_drawQueue->addFilledRect(Rect(Point(x, y), Size(length, 1)), Color(205, 169, 96, 145));
+                break;
+            }
+            case WeatherType::None:
+                break;
+        }
+    }
+
+    g_drawQueue->setClip(drawQueueStart, mapRect);
+}
+
+void WeatherManager::clear()
+{
+    m_activeState = {};
+    m_pendingState = {};
+    m_hasPendingState = false;
+    m_currentIntensity = 0.0f;
+    m_transitionStartIntensity = 0.0f;
+    m_transitionTargetIntensity = 0.0f;
+    m_transitionElapsedMs = 0;
+    m_transitionDurationMs = 0;
+    resetView();
+}
+
+void WeatherManager::resetView()
+{
+    m_lastUpdateMs = 0;
+    initializeParticles();
+}

--- a/src/client/weathermanager.h
+++ b/src/client/weathermanager.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2010-2017 OTClient <https://github.com/edubart/otclient>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+
+#ifndef WEATHER_MANAGER_H
+#define WEATHER_MANAGER_H
+
+#include "global.h"
+
+#include <array>
+
+enum class WeatherType : uint8 {
+    None = 0,
+    Rain = 1,
+    Snow = 2,
+    Sand = 3
+};
+
+struct WeatherState {
+    WeatherType type = WeatherType::None;
+    uint8 intensity = 0;
+    int8 windX = 0;
+    int8 windY = 0;
+    uint16 transitionMs = 0;
+};
+
+class WeatherManager final
+{
+public:
+    static constexpr size_t MAX_PARTICLES = 256;
+
+    WeatherManager();
+
+    void setWeather(WeatherState state);
+    void draw(const Rect& mapRect);
+    void clear();
+
+    size_t getParticleCapacity() const { return m_particles.size(); }
+
+private:
+    struct Particle {
+        float x = 0.0f;
+        float y = 0.0f;
+        float speed = 0.0f;
+        float drift = 0.0f;
+        float size = 0.0f;
+        float phase = 0.0f;
+    };
+
+    void initializeParticles();
+    void beginIntensityTransition(float target, uint16 durationMs);
+    void update(uint64 nowMs);
+    void updateParticles(float deltaSeconds, size_t activeCount);
+    void finishTypeTransitionIfNeeded();
+    void resetView();
+
+    std::array<Particle, MAX_PARTICLES> m_particles{};
+    WeatherState m_activeState{};
+    WeatherState m_pendingState{};
+    bool m_hasPendingState = false;
+
+    float m_currentIntensity = 0.0f;
+    float m_transitionStartIntensity = 0.0f;
+    float m_transitionTargetIntensity = 0.0f;
+    uint64 m_transitionElapsedMs = 0;
+    uint16 m_transitionDurationMs = 0;
+    uint64 m_lastUpdateMs = 0;
+};
+
+extern WeatherManager g_weatherManager;
+
+#endif // WEATHER_MANAGER_H

--- a/vc23/otclient.vcxproj
+++ b/vc23/otclient.vcxproj
@@ -504,6 +504,7 @@
     <ClCompile Include="..\src\client\thingtypemanager.cpp" />
     <ClCompile Include="..\src\client\tile.cpp" />
     <ClCompile Include="..\src\client\towns.cpp" />
+    <ClCompile Include="..\src\client\weathermanager.cpp" />
     <ClCompile Include="..\src\client\uicreature.cpp" />
     <ClCompile Include="..\src\client\uigraph.cpp" />
     <ClCompile Include="..\src\client\uigrid.cpp" />
@@ -675,6 +676,7 @@
     <ClInclude Include="..\src\client\thingtypemanager.h" />
     <ClInclude Include="..\src\client\tile.h" />
     <ClInclude Include="..\src\client\towns.h" />
+    <ClInclude Include="..\src\client\weathermanager.h" />
     <ClInclude Include="..\src\client\uicreature.h" />
     <ClInclude Include="..\src\client\uigraph.h" />
     <ClInclude Include="..\src\client\uigrid.h" />

--- a/vc23/otclient.vcxproj.filters
+++ b/vc23/otclient.vcxproj.filters
@@ -459,6 +459,9 @@
     <ClCompile Include="..\src\client\towns.cpp">
       <Filter>Source Files\client</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\client\weathermanager.cpp">
+      <Filter>Source Files\client</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\client\uicreature.cpp">
       <Filter>Source Files\client</Filter>
     </ClCompile>
@@ -1035,6 +1038,9 @@
       <Filter>Header Files\client</Filter>
     </ClInclude>
     <ClInclude Include="..\src\client\towns.h">
+      <Filter>Header Files\client</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\client\weathermanager.h">
       <Filter>Header Files\client</Filter>
     </ClInclude>
     <ClInclude Include="..\src\client\uicreature.h">


### PR DESCRIPTION
## What changed

- add the negotiated Zone Weather game feature and packet parser
- render bounded rain, snow, and sand particles over the map
- support intensity, wind, transitions, and state reset
- include the renderer in CMake and Visual Studio builds

## Why

The client needs a lightweight native renderer for server-driven map ZoneId weather without Lua polling or duplicated timers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado suporte a efeitos climáticos no mapa, incluindo chuva, neve e areia.
  * O clima agora pode variar em intensidade, direção do vento e duração de transição.
  * Efeitos climáticos são atualizados e limpos automaticamente ao iniciar ou encerrar uma sessão.
* **Correções**
  * Pacotes climáticos inválidos ou incompatíveis são ignorados com segurança.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->