### PR TITLE
feat: port login casts module

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -15,7 +15,11 @@ Services = {
 
 -- Servers accept http login url, websocket login url or ip:port:version
 Servers = {
-  LocalTestServ = "127.0.0.1:7171:860"
+  LocalTestServ = {
+    name = "LocalTestServ",
+    loginLink = "http://127.0.0.1/login.php",
+    clientServicesLink = "http://127.0.0.1/login.php"
+  }
 }
 
 --Server = "ws://127.0.0.1:3000/"

--- a/init.lua
+++ b/init.lua
@@ -17,6 +17,9 @@ Services = {
 Servers = {
   LocalTestServ = {
     name = "LocalTestServ",
+    host = "127.0.0.1",
+    port = 7171,
+    version = 860,
     loginLink = "http://127.0.0.1/login.php",
     clientServicesLink = "http://127.0.0.1/login.php"
   }

--- a/init.lua
+++ b/init.lua
@@ -13,15 +13,13 @@ Services = {
   status = ""
 }
 
--- Servers accept http login url, websocket login url or ip:port:version
+-- Direct connection to the TFS login server (no HTTP service required).
 Servers = {
   LocalTestServ = {
     name = "LocalTestServ",
     host = "127.0.0.1",
     port = 7171,
-    version = 860,
-    loginLink = "http://127.0.0.1/login.php",
-    clientServicesLink = "http://127.0.0.1/login.php"
+    version = 860
   }
 }
 

--- a/modules/client_background/background.lua
+++ b/modules/client_background/background.lua
@@ -140,6 +140,7 @@ function terminate()
   removeEvent(hintsUpdateEvent)
   removeEvent(hintsImgUpdateEvent)
   removeEvent(scheduleUpdateEvent)
+  if Cast then Cast.terminate() end
   background:destroy()
 
   Background = nil
@@ -148,6 +149,7 @@ end
 function onGameStart()
   local benchmark = g_clock.millis()
   hide()
+  if Cast then Cast.onGameStart() end
   consoleln("Background loaded in " .. (g_clock.millis() - benchmark) / 1000 .. " seconds.")
 end
 
@@ -182,6 +184,8 @@ function updateStatus(serverInfo)
       serverInfo = Servers[1]
     end
   end
+
+  if Cast then Cast.updateStatus(serverInfo) end
 
   miniWindowBoosted = background.loadAfter.boostedScroll
   if not miniWindowBoosted then return end
@@ -312,7 +316,7 @@ function updateCountdown()
     countdownWindow:setVisible(false)
     local informationScroll = background.loadAfter.informationScroll
     if informationScroll then
-      informationScroll:setMarginRight(124)
+      informationScroll:setMarginRight(224)
     end
     return
   end

--- a/modules/client_background/background.lua
+++ b/modules/client_background/background.lua
@@ -160,6 +160,7 @@ end
 function show()
   background:show()
   applyBoostedInfo()
+  if Cast then Cast.updateStatus() end
 end
 
 function getBackground()

--- a/modules/client_background/background.otmod
+++ b/modules/client_background/background.otmod
@@ -4,6 +4,6 @@ Module
   author: edubart
   website: https://github.com/Mateuzkl/AstraClient
   sandboxed: true
-  scripts: [ background, schedule ]
+  scripts: [ background, schedule, casts ]
   @onLoad: init()
   @onUnload: terminate()

--- a/modules/client_background/background.otui
+++ b/modules/client_background/background.otui
@@ -290,6 +290,50 @@ UIWidget
         margin-right: 45
         text-auto-resize: true
     Panel
+      id: castScroll
+      draggable: false
+      size: 200 117
+      anchors.bottom: parent.bottom
+      anchors.left: prev.right
+      image-source: /images/ui/popupwindow
+      image-border: 4
+      margin-left: 1
+      Label
+        !text: tr('Casts')
+        text-auto-resize: true
+        font: $var-cip-font
+        color: #909090
+        margin-top: 1
+        anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+      Label
+        id: castCount
+        !text: tr('0 Players Casting')
+        anchors.top: parent.top
+        anchors.horizontalCenter: parent.horizontalCenter
+        margin-top: 30
+        font: $var-cip-font
+        color: $var-text-cip-color
+        text-auto-resize: true
+      Label
+        id: viewerCount
+        !text: tr('0 Viewers')
+        anchors.top: prev.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        margin-top: 6
+        font: $var-cip-font
+        color: #909090
+        text-auto-resize: true
+      Button
+        id: watchButton
+        !text: tr('Watch')
+        size: 90 22
+        anchors.bottom: parent.bottom
+        anchors.horizontalCenter: parent.horizontalCenter
+        margin-bottom: 12
+        font: cipsoftFont
+        @onClick: modules.client_background.openCastList()
+    Panel
       id: openingScroll
       draggable: false
       size: 180 117

--- a/modules/client_background/castlist.otui
+++ b/modules/client_background/castlist.otui
@@ -1,0 +1,109 @@
+CastListRow < UIWidget
+  height: 20
+  focusable: true
+  background-color: alpha
+
+  UIWidget
+    id: lock
+    size: 8 12
+    anchors.left: parent.left
+    anchors.verticalCenter: parent.verticalCenter
+    margin-left: 5
+    image-source: /images/game/actionbar/locked
+    phantom: true
+    visible: false
+
+  Label
+    id: name
+    anchors.left: parent.left
+    anchors.verticalCenter: parent.verticalCenter
+    margin-left: 18
+    font: $var-cip-font
+    color: $var-text-cip-color
+    text-align: left
+    text-auto-resize: true
+    phantom: true
+
+  Label
+    id: viewers
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    margin-right: 10
+    font: $var-cip-font
+    color: #909090
+    text-align: right
+    text-auto-resize: true
+    phantom: true
+
+  $focus:
+    background-color: #585858
+
+MainWindow
+  id: castWindow
+  !text: tr('Watch a Cast')
+  font: $var-cip-font
+  size: 320 380
+  @onEscape: modules.client_background.closeCastList()
+  @onEnter: modules.client_background.watchSelectedCast()
+
+  // Bottom-up anchor chain (buttons -> separator -> info label) so nothing overlaps;
+  // the list flexes to fill whatever height is left above the info label.
+  Button
+    id: cancelButton
+    !text: tr('Cancel')
+    size: 64 22
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    font: cipsoftFont
+    @onClick: modules.client_background.closeCastList()
+
+  Button
+    id: watchButton
+    !text: tr('Watch')
+    size: 64 22
+    anchors.right: cancelButton.left
+    anchors.bottom: parent.bottom
+    margin-right: 8
+    font: cipsoftFont
+    @onClick: modules.client_background.watchSelectedCast()
+
+  HorizontalSeparator
+    id: castSeparator
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: watchButton.top
+    margin-bottom: 8
+
+  Label
+    id: infoLabel
+    !text: tr('No one is casting right now.')
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: castSeparator.top
+    margin-bottom: 6
+    height: 14
+    font: $var-cip-font
+    color: #909090
+    text-align: left
+
+  VerticalScrollBar
+    id: castListScrollBar
+    anchors.top: parent.top
+    anchors.bottom: infoLabel.top
+    anchors.right: parent.right
+    margin-bottom: 6
+    step: 20
+    pixels-scroll: true
+
+  TextList
+    id: castList
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: castListScrollBar.left
+    anchors.bottom: infoLabel.top
+    margin-bottom: 6
+    padding: 1
+    focusable: false
+    background-color: #404040
+    vertical-scrollbar: castListScrollBar
+    auto-focus: first

--- a/modules/client_background/castpassword.otui
+++ b/modules/client_background/castpassword.otui
@@ -1,0 +1,57 @@
+MainWindow
+  id: castPassword
+  !text: tr('Cast Password')
+  font: $var-cip-font
+  size: 340 158
+
+  Label
+    id: messageLabel
+    !text: tr('This cast is password-protected.')
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    font: $var-cip-font
+    color: $var-text-cip-color
+    text-auto-resize: true
+    text-wrap: true
+
+  Label
+    id: caster
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    margin-top: 4
+    font: $var-cip-font
+    color: #909090
+    text-auto-resize: true
+
+  PasswordTextEdit
+    id: passwordEnter
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    margin-top: 10
+    padding-left: 4
+
+  HorizontalSeparator
+    anchors.top: prev.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    margin-top: 12
+
+  Button
+    id: cancelButton
+    anchors.bottom: parent.bottom
+    anchors.right: parent.right
+    !text: tr('Cancel')
+    size: 55 22
+    font: cipsoftFont
+
+  Button
+    id: okButton
+    anchors.bottom: parent.bottom
+    anchors.right: prev.left
+    margin-right: 8
+    !text: tr('Ok')
+    size: 55 22
+    font: cipsoftFont

--- a/modules/client_background/casts.lua
+++ b/modules/client_background/casts.lua
@@ -21,6 +21,7 @@ local castWindow
 local passwordWindow
 local castProtocol
 local castRequestId = 0
+local expectedCastCancelError = false
 
 local CastRequestPassword = '__astra_casts_v1__'
 local CastRefreshInterval = 30000
@@ -123,7 +124,22 @@ function Cast.terminate()
   removeEvent(castStatusEvent)
   castStatusEvent = nil
   cancelCastRequest()
+  if Cast.watching then
+    expectedCastCancelError = true
+    pcall(function() g_game.cancelLogin() end)
+  end
+  Cast.watching = nil
+  if Cast.loadBox then
+    Cast.loadBox:destroy()
+    Cast.loadBox = nil
+  end
   Cast.closeList()
+end
+
+-- A new game login must never inherit the one-shot cancellation state from a
+-- previous cast connection.
+function clearExpectedCastCancelError()
+  expectedCastCancelError = false
 end
 
 -- Reach the login form (client_entergame) so the cast overlay can hide/show it. Kept as a
@@ -268,6 +284,7 @@ function Cast.connect(castInfo, password)
     return
   end
 
+  expectedCastCancelError = false
   Cast.watching = castInfo
   Cast.closeList()
 
@@ -279,11 +296,8 @@ function Cast.connect(castInfo, password)
   connect(Cast.loadBox, {
     onCancel = function()
       Cast.loadBox = nil
-      -- Mark dismissal time before canceling so handleCastLoginError recognizes the
-      -- expected cancelLogin error and suppresses the reconnect window.
-      Cast.dismissedAt = g_clock.millis()
+      expectedCastCancelError = true
       pcall(function() g_game.cancelLogin() end)
-      -- Clear watching state after cancelLogin triggers its error callback.
       Cast.watching = nil
       openCastList()
     end
@@ -305,19 +319,24 @@ end
 -- Called from characterlist.lua's onGameLoginError / onGameConnectionError BEFORE its
 -- own handling. Returns true when we consumed the error (a cast-watch was in flight),
 -- so the character-list flow is skipped and we bounce back to the cast list instead.
-function handleCastLoginError(message)
-  if not Cast.watching then
-    -- The server rejects with disconnectClient: the 0x14 error arrives first, then the
-    -- socket closes -> a follow-up onConnectionError (EOF). Swallow that trailing event
-    -- silently so the character-list flow doesn't pop a "reconnecting" window on top of
-    -- the dialog we just showed.
-    if Cast.dismissedAt and (g_clock.millis() - Cast.dismissedAt) < 3000 then
+function handleCastLoginError(message, code)
+  if expectedCastCancelError then
+    local errorText = tostring(message or ''):lower()
+    local isExpectedCancel = code == 2 or code == 125 or code == 995 or errorText == ''
+      or errorText:find('operation canceled', 1, true)
+      or errorText:find('operation cancelled', 1, true)
+    expectedCastCancelError = false
+    if isExpectedCancel then
       return true
     end
+  end
+
+  if not Cast.watching then
     return false
   end
   Cast.watching = nil
-  Cast.dismissedAt = g_clock.millis()
+  -- A server rejection is followed by one harmless EOF from the same cast socket.
+  expectedCastCancelError = true
   if Cast.loadBox then
     Cast.loadBox:destroy()
     Cast.loadBox = nil

--- a/modules/client_background/casts.lua
+++ b/modules/client_background/casts.lua
@@ -1,16 +1,14 @@
 -- Live cast (livestream) discovery for the login screen.
 --
 -- The game server's "livestream" system lets anyone watch a broadcasting player by
--- connecting with account "cast", password = the cast's password (empty for open
+-- connecting with an empty account, password = the cast's password (empty for open
 -- casts) and characterName = the caster's name. The client reuses the normal
--- g_game.loginWorld path for that -- with GameSessionKey the login packet carries
--- only the session key ("cast\n<password>") + character name, which is exactly how
--- the server routes the connection to castViewerLogin (see classes/login.lua).
+-- g_game.loginWorld path for that. The empty account is exactly how this TFS routes
+-- the connection to ProtocolGame::spectate().
 --
--- The active-cast list and aggregate counts come from the AAC status endpoint
--- (POST clientServicesLink {type="casts"}), the same channel used for the boosted
--- creature. Passwords are validated server-side on connect; the endpoint only tells
--- us whether a cast is protected (haspassword), never the password itself.
+-- The active-cast list and aggregate counts come straight from the TFS login
+-- protocol. Passwords are validated server-side on connect; the list packet only
+-- tells us whether a cast is protected (haspassword), never the password itself.
 
 Cast = Cast or {}
 Cast.list = {}
@@ -21,6 +19,11 @@ Cast.loadBox = nil
 local castStatusEvent
 local castWindow
 local passwordWindow
+local castProtocol
+local castRequestId = 0
+
+local CastRequestPassword = '__astra_casts_v1__'
+local CastRefreshInterval = 30000
 
 -- Resolve the castScroll widget on the login panel. nil before the UI loads, after
 -- teardown, or once in game.
@@ -37,45 +40,89 @@ local function setCounts(casters, viewers)
   box.viewerCount:setText(string.format('%d %s', viewers, viewers == 1 and 'Viewer' or 'Viewers'))
 end
 
--- Poll the AAC for the current cast list + counts. Mirrors background.lua's
--- updateStatus: resolves the current server's clientServicesLink, refreshes every
--- 30s, and no-ops while in game.
+local function cancelCastRequest()
+  castRequestId = castRequestId + 1
+  if castProtocol then
+    pcall(function() castProtocol:cancelLogin() end)
+    castProtocol = nil
+  end
+end
+
+local function getLoginEndpoint(serverInfo)
+  if type(serverInfo) ~= 'table' then return nil end
+  local host = type(serverInfo.host) == 'string' and serverInfo.host or nil
+  local port = tonumber(serverInfo.port)
+  if not host or host:len() == 0 or not port or port <= 0 then return nil end
+  return host, port
+end
+
+-- Ask the TFS login port for the current cast list, then refresh every 30 seconds.
+-- The response also carries the game-world address and port used by Watch.
 function Cast.updateStatus(serverInfo)
   removeEvent(castStatusEvent)
   castStatusEvent = nil
 
+  cancelCastRequest()
+  if serverInfo and serverInfo ~= Cast.serverInfo then
+    Cast.list = {}
+    setCounts(0, 0)
+    if castWindow then Cast.populateList() end
+  end
   if serverInfo then Cast.serverInfo = serverInfo end
   serverInfo = Cast.serverInfo
 
   if not castBox() then return end
   if g_game.isOnline() then return end
-  if not serverInfo or type(serverInfo.clientServicesLink) ~= 'string' or serverInfo.clientServicesLink:len() < 4 then
-    return
+  local host, port = getLoginEndpoint(serverInfo)
+  if not host then return end
+
+  local requestId = castRequestId
+  castStatusEvent = scheduleEvent(function() Cast.updateStatus() end, CastRefreshInterval)
+
+  local version = tonumber(serverInfo.version)
+  if version then
+    g_game.setClientVersion(version)
+    g_game.setProtocolVersion(g_game.getClientProtocolVersion(version))
   end
+  g_game.chooseRsa(host)
 
-  local url = serverInfo.clientServicesLink
-  castStatusEvent = scheduleEvent(function() Cast.updateStatus() end, 30000)
+  local protocol = ProtocolLogin.create()
+  castProtocol = protocol
+  protocol.onCastList = function(_, casts, totalViewers)
+    if requestId ~= castRequestId or castProtocol ~= protocol then return end
+    castProtocol = nil
 
-  HTTP.postJSON(url, {type = "casts"}, function(data, err)
-    if err then
-      -- Silent: the box just keeps its last values. The reschedule above retries.
-      return
-    end
-    if not data or type(data) ~= 'table' then return end
-    if not data.casts or type(data.casts) ~= 'table' then return end
-    Cast.list = data.casts
-    setCounts(tonumber(data.totalcasters) or #Cast.list, tonumber(data.totalviewers) or 0)
+    Cast.list = type(casts) == 'table' and casts or {}
+    table.sort(Cast.list, function(a, b)
+      return tostring(a.name or ''):lower() < tostring(b.name or ''):lower()
+    end)
+    setCounts(#Cast.list, tonumber(totalViewers) or 0)
     -- Keep an open list window in sync with fresh data.
     if castWindow then
       Cast.populateList()
     end
+  end
+  protocol.onLoginError = function()
+    if requestId == castRequestId and castProtocol == protocol then
+      -- Silent: the panel keeps its last values and the timer retries.
+      castProtocol = nil
+    end
+  end
+
+  local ok, err = pcall(function()
+    protocol:login(host, port, '', CastRequestPassword, '', false)
   end)
+  if not ok then
+    if castProtocol == protocol then castProtocol = nil end
+    g_logger.warning('Could not request the Astra cast list: ' .. tostring(err))
+  end
 end
 
--- Remove the poll timer (called from background.lua terminate()).
+-- Remove the refresh timer and any in-flight login connection.
 function Cast.terminate()
   removeEvent(castStatusEvent)
   castStatusEvent = nil
+  cancelCastRequest()
   Cast.closeList()
 end
 
@@ -211,9 +258,9 @@ function Cast.promptPassword(castInfo)
   passwordWindow.cancelButton.onClick = doCancel
 end
 
--- Connect to the game server as a livestream viewer. account "cast" + the cast
--- password; the caster name is the "character". handleCastLoginError() below turns a
--- rejection into a friendly dialog.
+-- Connect to the game server as a livestream viewer. An empty account selects the
+-- server's cast route; the caster name is the "character" and password is optional.
+-- handleCastLoginError() below turns a rejection into a friendly dialog.
 function Cast.connect(castInfo, password)
   if g_game.isOnline() then return end
   if not castInfo.host or not tonumber(castInfo.port) then
@@ -242,11 +289,9 @@ function Cast.connect(castInfo, password)
     end
   })
 
-  local sessionKey = "cast\n" .. password
-
   local ok, err = pcall(function()
-    g_game.loginWorld("cast", password, castInfo.world or 'Cast',
-      castInfo.host, tonumber(castInfo.port), castInfo.name, "", sessionKey, nil)
+    g_game.loginWorld("", password, castInfo.world or 'Cast',
+      castInfo.host, tonumber(castInfo.port), castInfo.name, "", "", nil)
   end)
   if not ok then
     g_logger.error("Cast connect failed: " .. tostring(err))
@@ -280,7 +325,7 @@ function handleCastLoginError(message)
 
   message = tostring(message or "")
   local backToList = function() openCastList() end
-  if message:find("Incorrect password") then
+  if message:find("Incorrect password") or message:find("Wrong password") then
     displayInfoBox(tr('Wrong Password'), tr('The password you entered is incorrect.'), backToList)
   else
     local text = (message ~= "") and message or tr('The livestream is no longer available.')
@@ -292,6 +337,9 @@ end
 -- On a successful watch the client enters the game as a viewer; drop our transient
 -- state and any leftover UI. Called from background.lua onGameStart.
 function Cast.onGameStart()
+  removeEvent(castStatusEvent)
+  castStatusEvent = nil
+  cancelCastRequest()
   Cast.watching = nil
   if Cast.loadBox then
     Cast.loadBox:destroy()

--- a/modules/client_background/casts.lua
+++ b/modules/client_background/casts.lua
@@ -1,0 +1,296 @@
+-- Live cast (livestream) discovery for the login screen.
+--
+-- The game server's "livestream" system lets anyone watch a broadcasting player by
+-- connecting with account "cast", password = the cast's password (empty for open
+-- casts) and characterName = the caster's name. The client reuses the normal
+-- g_game.loginWorld path for that -- with GameSessionKey the login packet carries
+-- only the session key ("cast\n<password>") + character name, which is exactly how
+-- the server routes the connection to castViewerLogin (see classes/login.lua).
+--
+-- The active-cast list and aggregate counts come from the AAC status endpoint
+-- (POST clientServicesLink {type="casts"}), the same channel used for the boosted
+-- creature. Passwords are validated server-side on connect; the endpoint only tells
+-- us whether a cast is protected (haspassword), never the password itself.
+
+Cast = Cast or {}
+Cast.list = {}
+Cast.serverInfo = nil
+Cast.watching = nil
+Cast.loadBox = nil
+
+local castStatusEvent
+local castWindow
+local passwordWindow
+
+-- Resolve the castScroll widget on the login panel. nil before the UI loads, after
+-- teardown, or once in game.
+local function castBox()
+  local bg = getBackground and getBackground() or nil
+  if not bg or not bg.loadAfter then return nil end
+  return bg.loadAfter.castScroll
+end
+
+local function setCounts(casters, viewers)
+  local box = castBox()
+  if not box then return end
+  box.castCount:setText(string.format('%d %s', casters, casters == 1 and 'Player Casting' or 'Players Casting'))
+  box.viewerCount:setText(string.format('%d %s', viewers, viewers == 1 and 'Viewer' or 'Viewers'))
+end
+
+-- Poll the AAC for the current cast list + counts. Mirrors background.lua's
+-- updateStatus: resolves the current server's clientServicesLink, refreshes every
+-- 30s, and no-ops while in game.
+function Cast.updateStatus(serverInfo)
+  removeEvent(castStatusEvent)
+  castStatusEvent = nil
+
+  if serverInfo then Cast.serverInfo = serverInfo end
+  serverInfo = Cast.serverInfo
+
+  if not castBox() then return end
+  if g_game.isOnline() then return end
+  if not serverInfo or type(serverInfo.clientServicesLink) ~= 'string' or serverInfo.clientServicesLink:len() < 4 then
+    return
+  end
+
+  local url = serverInfo.clientServicesLink
+  castStatusEvent = scheduleEvent(function() Cast.updateStatus() end, 30000)
+
+  HTTP.postJSON(url, {type = "casts"}, function(data, err)
+    if err then
+      -- Silent: the box just keeps its last values. The reschedule above retries.
+      return
+    end
+    if not data then return end
+    Cast.list = data.casts or {}
+    setCounts(tonumber(data.totalcasters) or #Cast.list, tonumber(data.totalviewers) or 0)
+    -- Keep an open list window in sync with fresh data.
+    if castWindow then
+      Cast.populateList()
+    end
+  end)
+end
+
+-- Remove the poll timer (called from background.lua terminate()).
+function Cast.terminate()
+  removeEvent(castStatusEvent)
+  castStatusEvent = nil
+  Cast.closeList()
+end
+
+-- Reach the login form (client_entergame) so the cast overlay can hide/show it. Kept as a
+-- thin accessor so both openCastList and closeCastList agree on how to find it.
+local function loginBox()
+  return modules.client_entergame and modules.client_entergame.EnterGame or nil
+end
+
+-- Open the cast list window (Watch button). Refresh first when we have no data yet;
+-- the poll callback repopulates the window once it arrives.
+function openCastList()
+  if g_game.isOnline() then return end
+
+  -- Get the "Journey Onwards" login form out of the way while the cast list is up. It used
+  -- to stay visible behind the list and, after picking a cast, behind the "Connecting..."
+  -- modal. keepFields=true so the player's typed email/password survive the round trip.
+  local eg = loginBox()
+  if eg then eg.hide(true) end
+
+  if castWindow then
+    castWindow:destroy()
+    castWindow = nil
+  end
+  castWindow = g_ui.displayUI('castlist')
+
+  if #Cast.list == 0 then
+    Cast.updateStatus()
+  end
+  Cast.populateList()
+
+  castWindow:raise()
+  castWindow:focus()
+end
+
+-- OTUI @onClick/@onEscape handlers run in the real global env, not the module
+-- sandbox, so castlist.otui reaches these via modules.client_background.* (the module
+-- table) rather than the sandbox-global `Cast`. Thin wrappers over the Cast methods.
+function watchSelectedCast()
+  Cast.watchSelected()
+end
+
+function closeCastList()
+  Cast.closeList()
+  -- Cancelling out of the cast list returns to the login form that openCastList hid.
+  -- Skip while a watch is mid-flight (loadBox/watching set) or already in a game, so we
+  -- never flash the login form behind the "Connecting..." modal or over the game.
+  if not g_game.isOnline() and not Cast.loadBox and not Cast.watching then
+    local eg = loginBox()
+    if eg then eg.show() end
+  end
+end
+
+function Cast.closeList()
+  if passwordWindow then
+    passwordWindow:destroy()
+    passwordWindow = nil
+  end
+  if castWindow then
+    castWindow:destroy()
+    castWindow = nil
+  end
+end
+
+function Cast.populateList()
+  if not castWindow then return end
+  local list = castWindow:getChildById('castList')
+  list:destroyChildren()
+  for _, cast in ipairs(Cast.list) do
+    local row = g_ui.createWidget('CastListRow', list)
+    row.castInfo = cast
+    local viewers = tonumber(cast.viewers) or 0
+    row:getChildById('name'):setText(cast.name or '?')
+    row:getChildById('viewers'):setText(viewers == 1 and tr('1 viewer') or tr('%d viewers', viewers))
+    row:getChildById('lock'):setVisible(cast.haspassword and true or false)
+    connect(row, { onDoubleClick = function() Cast.watchSelected() return true end })
+  end
+
+  local info = castWindow:getChildById('infoLabel')
+  if info then
+    if #Cast.list == 0 then
+      info:setText(tr('No one is casting right now.'))
+    else
+      info:setText(tr('%d cast(s) live', #Cast.list))
+    end
+  end
+end
+
+function Cast.watchSelected()
+  if not castWindow then return end
+  local list = castWindow:getChildById('castList')
+  local sel = list:getFocusedChild()
+  if not sel or not sel.castInfo then
+    displayErrorBox(tr('Watch Cast'), tr('Select a cast to watch.'))
+    return
+  end
+  Cast.watch(sel.castInfo)
+end
+
+function Cast.watch(castInfo)
+  if castInfo.haspassword then
+    Cast.promptPassword(castInfo)
+  else
+    Cast.connect(castInfo, "")
+  end
+end
+
+-- Password prompt for protected casts. Ok -> connect with the typed password,
+-- Cancel -> back to the list.
+function Cast.promptPassword(castInfo)
+  if passwordWindow then
+    passwordWindow:destroy()
+    passwordWindow = nil
+  end
+  passwordWindow = g_ui.displayUI('castpassword')
+  passwordWindow.caster:setText(tr('Cast: %s', castInfo.name or '?'))
+  local edit = passwordWindow.passwordEnter
+  edit:focus()
+
+  local doConnect = function()
+    local pw = edit:getText()
+    passwordWindow:destroy()
+    passwordWindow = nil
+    Cast.connect(castInfo, pw)
+  end
+  local doCancel = function()
+    passwordWindow:destroy()
+    passwordWindow = nil
+  end
+  passwordWindow.onEnter = doConnect
+  passwordWindow.onEscape = doCancel
+  passwordWindow.okButton.onClick = doConnect
+  passwordWindow.cancelButton.onClick = doCancel
+end
+
+-- Connect to the game server as a livestream viewer. account "cast" + the cast
+-- password; the caster name is the "character". handleCastLoginError() below turns a
+-- rejection into a friendly dialog.
+function Cast.connect(castInfo, password)
+  if g_game.isOnline() then return end
+  if not castInfo.host or not tonumber(castInfo.port) then
+    displayErrorBox(tr('Watch Cast'), tr('This cast has no reachable server.'))
+    return
+  end
+
+  Cast.watching = castInfo
+  Cast.closeList()
+
+  if Cast.loadBox then
+    Cast.loadBox:destroy()
+    Cast.loadBox = nil
+  end
+  Cast.loadBox = displayCancelBox(tr('Please wait'), tr('Connecting to livestream...'))
+  connect(Cast.loadBox, {
+    onCancel = function()
+      Cast.loadBox = nil
+      Cast.watching = nil
+      pcall(function() g_game.cancelLogin() end)
+      openCastList()
+    end
+  })
+
+  local sessionKey = "cast\n" .. password
+
+  local ok, err = pcall(function()
+    g_game.loginWorld("cast", password, castInfo.world or 'Cast',
+      castInfo.host, tonumber(castInfo.port), castInfo.name, "", sessionKey, nil)
+  end)
+  if not ok then
+    g_logger.error("Cast connect failed: " .. tostring(err))
+    Cast.watching = nil
+    if Cast.loadBox then Cast.loadBox:destroy() Cast.loadBox = nil end
+    displayErrorBox(tr('Watch Cast'), tr('Could not connect to the livestream.'))
+    openCastList()
+  end
+end
+
+-- Called from characterlist.lua's onGameLoginError / onGameConnectionError BEFORE its
+-- own handling. Returns true when we consumed the error (a cast-watch was in flight),
+-- so the character-list flow is skipped and we bounce back to the cast list instead.
+function handleCastLoginError(message)
+  if not Cast.watching then
+    -- The server rejects with disconnectClient: the 0x14 error arrives first, then the
+    -- socket closes -> a follow-up onConnectionError (EOF). Swallow that trailing event
+    -- silently so the character-list flow doesn't pop a "reconnecting" window on top of
+    -- the dialog we just showed.
+    if Cast.dismissedAt and (g_clock.millis() - Cast.dismissedAt) < 3000 then
+      return true
+    end
+    return false
+  end
+  Cast.watching = nil
+  Cast.dismissedAt = g_clock.millis()
+  if Cast.loadBox then
+    Cast.loadBox:destroy()
+    Cast.loadBox = nil
+  end
+
+  message = tostring(message or "")
+  local backToList = function() openCastList() end
+  if message:find("Incorrect password") then
+    displayInfoBox(tr('Wrong Password'), tr('The password you entered is incorrect.'), backToList)
+  else
+    local text = (message ~= "") and message or tr('The livestream is no longer available.')
+    displayInfoBox(tr('Cast Unavailable'), text, backToList)
+  end
+  return true
+end
+
+-- On a successful watch the client enters the game as a viewer; drop our transient
+-- state and any leftover UI. Called from background.lua onGameStart.
+function Cast.onGameStart()
+  Cast.watching = nil
+  if Cast.loadBox then
+    Cast.loadBox:destroy()
+    Cast.loadBox = nil
+  end
+  Cast.closeList()
+end

--- a/modules/client_background/casts.lua
+++ b/modules/client_background/casts.lua
@@ -61,8 +61,9 @@ function Cast.updateStatus(serverInfo)
       -- Silent: the box just keeps its last values. The reschedule above retries.
       return
     end
-    if not data then return end
-    Cast.list = data.casts or {}
+    if not data or type(data) ~= 'table' then return end
+    if not data.casts or type(data.casts) ~= 'table' then return end
+    Cast.list = data.casts
     setCounts(tonumber(data.totalcasters) or #Cast.list, tonumber(data.totalviewers) or 0)
     -- Keep an open list window in sync with fresh data.
     if castWindow then
@@ -231,8 +232,12 @@ function Cast.connect(castInfo, password)
   connect(Cast.loadBox, {
     onCancel = function()
       Cast.loadBox = nil
-      Cast.watching = nil
+      -- Mark dismissal time before canceling so handleCastLoginError recognizes the
+      -- expected cancelLogin error and suppresses the reconnect window.
+      Cast.dismissedAt = g_clock.millis()
       pcall(function() g_game.cancelLogin() end)
+      -- Clear watching state after cancelLogin triggers its error callback.
+      Cast.watching = nil
       openCastList()
     end
   })

--- a/modules/client_entergame/characterlist.lua
+++ b/modules/client_entergame/characterlist.lua
@@ -161,6 +161,11 @@ local function onLoginWait(message, time)
 end
 
 function onGameLoginError(message)
+  if modules.client_background and modules.client_background.handleCastLoginError
+     and modules.client_background.handleCastLoginError(message) then
+    return
+  end
+
   consoleln("[+] CharacterList.onGameLoginError()", message)
   CharacterList.destroyLoadBox()
 
@@ -249,6 +254,11 @@ function onGameLoginToken(unknown)
 end
 
 function onGameConnectionError(message, code)
+  if modules.client_background and modules.client_background.handleCastLoginError
+     and modules.client_background.handleCastLoginError(message) then
+    return
+  end
+
   CharacterList.destroyLoadBox()
   if errorBox and code ~= 2 then
     errorBox:destroy()

--- a/modules/client_entergame/characterlist.lua
+++ b/modules/client_entergame/characterlist.lua
@@ -255,7 +255,7 @@ end
 
 function onGameConnectionError(message, code)
   if modules.client_background and modules.client_background.handleCastLoginError
-     and modules.client_background.handleCastLoginError(message) then
+     and modules.client_background.handleCastLoginError(message, code) then
     return
   end
 

--- a/modules/client_entergame/classes/login.lua
+++ b/modules/client_entergame/classes/login.lua
@@ -103,6 +103,10 @@ function LoginEvent:tryLogin()
         end
     end
 
+    if modules.client_background and modules.client_background.clearExpectedCastCancelError then
+        modules.client_background.clearExpectedCastCancelError()
+    end
+
     local ok, err = pcall(function()
         g_game.loginWorld(
             G.account,

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -95,9 +95,15 @@ local function normalizeServers()
   local normalized = {}
   for name, server in pairs(Servers) do
     if type(server) == 'table' then
+      if not server.name then server.name = tostring(name) end
       if not server.googleLogin then
         server.googleLogin = server.clientServicesLink or server.loginLink
       end
+      if not server.host then server.host = "" end
+      if not server.port then server.port = 7171 end
+      if not server.version then server.version = GameInfo.version end
+      if not server.clientServicesLink then server.clientServicesLink = Services and Services.status or "" end
+      if not server.hintsJson then server.hintsJson = "" end
       table.insert(normalized, server)
     elseif type(server) == 'string' then
       local params = server:split(':')

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -102,6 +102,9 @@ local function normalizeServers()
       if not server.host then server.host = "" end
       if not server.port then server.port = 7171 end
       if not server.version then server.version = GameInfo.version end
+      if not server.loginLink and server.host ~= "" then
+        server.loginLink = string.format('%s:%d:%d', server.host, server.port, server.version)
+      end
       if not server.clientServicesLink then server.clientServicesLink = Services and Services.status or "" end
       if not server.hintsJson then server.hintsJson = "" end
       table.insert(normalized, server)

--- a/modules/client_entergame/entergame.lua
+++ b/modules/client_entergame/entergame.lua
@@ -96,9 +96,6 @@ local function normalizeServers()
   for name, server in pairs(Servers) do
     if type(server) == 'table' then
       if not server.name then server.name = tostring(name) end
-      if not server.googleLogin then
-        server.googleLogin = server.clientServicesLink or server.loginLink
-      end
       if not server.host then server.host = "" end
       if not server.port then server.port = 7171 end
       if not server.version then server.version = GameInfo.version end
@@ -106,6 +103,9 @@ local function normalizeServers()
         server.loginLink = string.format('%s:%d:%d', server.host, server.port, server.version)
       end
       if not server.clientServicesLink then server.clientServicesLink = Services and Services.status or "" end
+      if not server.googleLogin or server.googleLogin == "" then
+        server.googleLogin = server.clientServicesLink ~= "" and server.clientServicesLink or server.loginLink
+      end
       if not server.hintsJson then server.hintsJson = "" end
       table.insert(normalized, server)
     elseif type(server) == 'string' then

--- a/modules/gamelib/protocollogin.lua
+++ b/modules/gamelib/protocollogin.lua
@@ -12,6 +12,10 @@ LoginServerCharacterList = 100
 LoginServerExtendedCharacterList = 101
 LoginServerProxyList = 110
 LoginServerAstraBoostedInfo = 0xA1
+LoginServerAstraCastList = 0xA2
+
+local AstraCastListVersion = 1
+local AstraCastListLimit = 255
 
 local AstraClientMarker = "A"
 
@@ -236,6 +240,8 @@ function ProtocolLogin:onRecv(msg)
         table.insert(proxies, {host=host, port=port, priority=priority})
       end
       signalcall(self.onProxyList, self, proxies)
+    elseif opcode == LoginServerAstraCastList then
+      self:parseAstraCastList(msg)
     else
       self:parseOpcode(opcode, msg)
     end
@@ -396,6 +402,55 @@ function ProtocolLogin:parseExtendedCharacterList(msg)
   local account = msg:getTable()
   local otui = msg:getString()
   signalcall(self.onCharacterList, self, characters, account, otui)
+end
+
+-- Direct login-server response used by the Astra login screen. It deliberately
+-- contains no cast passwords: only the protected flag and the game-world endpoint.
+function ProtocolLogin:parseAstraCastList(msg)
+  local ok, response = pcall(function()
+    local version = msg:getU8()
+    if version ~= AstraCastListVersion then
+      error(string.format('unsupported cast list version: %d', version))
+    end
+
+    local world = msg:getString()
+    local host = iptostring(msg:getU32())
+    local port = msg:getU16()
+    local count = msg:getU16()
+    local totalViewers = msg:getU32()
+
+    if count > AstraCastListLimit then
+      error(string.format('cast list is too large: %d', count))
+    end
+    if port == 0 then
+      error('cast game-world port is invalid')
+    end
+
+    local casts = {}
+    for i = 1, count do
+      casts[i] = {
+        name = msg:getString(),
+        viewers = msg:getU16(),
+        haspassword = bit32.band(msg:getU8(), 1) ~= 0,
+        world = world,
+        host = host,
+        port = port
+      }
+    end
+
+    return {
+      casts = casts,
+      totalViewers = totalViewers
+    }
+  end)
+
+  if not ok then
+    signalcall(self.onLoginError, self, tr('Invalid cast list received from the server.'))
+    g_logger.warning('Invalid Astra cast list packet: ' .. tostring(response))
+    return
+  end
+
+  signalcall(self.onCastList, self, response.casts, response.totalViewers)
 end
 
 function ProtocolLogin:parseOpcode(opcode, msg)


### PR DESCRIPTION
Ports the Casts/spectators system to AstraClient, including the UI panel, password protection popups, endpoint updates, and login hook error handling. Configured local services endpoint to point to localhost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado painel “Casts” na tela de login, com contadores (casting/viewers) e botão para abrir a lista.
  * Introduzida tela para listar casts (“Watch a Cast”) e assistir selecionando um item.
  * Suporte a casts protegidos por senha, exibindo confirmação de senha antes de assistir.

* **Melhorias**
  * Atualização automática do status de casts durante o ciclo do cliente e sincronização com a interface aberta.
  * Tratamento de erros de conexão/entrada agora considera fluxo de “watch”, exibindo mensagens específicas.
  * Normalização de configurações de servidores para reduzir exigência de campos completos.
  * Ajustes visuais no painel de informações (margem do contador/scroll) quando o countdown está desabilitado.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->