### PR TITLE
Fix Bestiary search progress

### DIFF
--- a/mods/game_cyclopedia/classes/bestiary.lua
+++ b/mods/game_cyclopedia/classes/bestiary.lua
@@ -823,17 +823,9 @@ function Bestiary.onSearch()
 
   local text = widget:getText():lower()
 
-  local list = {}
-  for raceId, monsterInfo in pairs(getCyclopediaMonsterList()) do
-    local name = monsterInfo[1]:lower()
-    if string.find(name, string.escape(text)) then
-      list[#list + 1] = raceId
-    end
-  end
-
   widget:clearText()
   monsterListPage = 1
-  g_game.bestiarySearch(list)
+  g_game.bestiarySearch(text)
 end
 
 function Bestiary.setupBackTrackerButton()

--- a/mods/game_cyclopedia/cyclopediaprotocol.lua
+++ b/mods/game_cyclopedia/cyclopediaprotocol.lua
@@ -7,6 +7,9 @@ local OPCODE_CHARM = 0x3E
 local OPCODE_TRACKER = 0x3F
 local OPCODE_SEND = 0x39
 
+local BESTIARY_SEARCH_PREFIX = "__search__:"
+local MAX_BESTIARY_CATEGORY_LENGTH = 80
+
 local RESP_MESSAGE = 0
 local RESP_BESTIARY_DATA = 1
 local RESP_BESTIARY_OVERVIEW = 2
@@ -434,12 +437,14 @@ function CyclopediaProtocol.tracker(raceId)
   sendMessage(msg)
 end
 
-function CyclopediaProtocol.search(list)
-  local monsters = {}
-  for _, raceId in pairs(list or {}) do
-    monsters[#monsters + 1] = { raceId, 1, 0 }
-  end
-  signalcall(g_game.updateBestiaryOverview, "Search", monsters, 0)
+function CyclopediaProtocol.search(query)
+  query = tostring(query or ""):sub(1, MAX_BESTIARY_CATEGORY_LENGTH - #BESTIARY_SEARCH_PREFIX)
+
+  local msg = OutputMessage.create()
+  msg:addU8(OPCODE_CATEGORY)
+  msg:addU8(0)
+  msg:addString(BESTIARY_SEARCH_PREFIX .. query)
+  sendMessage(msg)
 end
 
 function initCyclopediaProtocol()

--- a/mods/game_cyclopedia/cyclopediaprotocol.lua
+++ b/mods/game_cyclopedia/cyclopediaprotocol.lua
@@ -10,6 +10,26 @@ local OPCODE_SEND = 0x39
 local BESTIARY_SEARCH_PREFIX = "__search__:"
 local MAX_BESTIARY_CATEGORY_LENGTH = 80
 
+local function truncateUtf8(value, maxBytes)
+  if #value <= maxBytes then
+    return value
+  end
+
+  local sequenceStart = maxBytes
+  while sequenceStart > 0 do
+    local byte = value:byte(sequenceStart)
+    if byte < 0x80 or byte >= 0xC0 then
+      break
+    end
+    sequenceStart = sequenceStart - 1
+  end
+
+  local lead = value:byte(sequenceStart)
+  local sequenceLength = lead >= 0xF0 and 4 or lead >= 0xE0 and 3 or lead >= 0xC0 and 2 or 1
+  local boundary = sequenceStart + sequenceLength - 1 <= maxBytes and maxBytes or sequenceStart - 1
+  return value:sub(1, boundary)
+end
+
 local RESP_MESSAGE = 0
 local RESP_BESTIARY_DATA = 1
 local RESP_BESTIARY_OVERVIEW = 2
@@ -438,7 +458,7 @@ function CyclopediaProtocol.tracker(raceId)
 end
 
 function CyclopediaProtocol.search(query)
-  query = tostring(query or ""):sub(1, MAX_BESTIARY_CATEGORY_LENGTH - #BESTIARY_SEARCH_PREFIX)
+  query = truncateUtf8(tostring(query or ""), MAX_BESTIARY_CATEGORY_LENGTH - #BESTIARY_SEARCH_PREFIX)
 
   local msg = OutputMessage.create()
   msg:addU8(OPCODE_CATEGORY)

--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -70,7 +70,9 @@ function UIMiniWindow:close()
   end
 
   if self:getId():find("PartyWindow") then
-    modules.game_sidebuttons.setButtonVisible("partyWidget", false)
+    if modules.game_sidebuttons then
+      modules.game_sidebuttons.setButtonVisible("partyWidget", false)
+    end
   elseif self:getId() == "lockerSearchWindow" then
     modules.game_search_locker.toggleSearchFocus()
   end

--- a/modules/corelib/ui/uiminiwindow.lua
+++ b/modules/corelib/ui/uiminiwindow.lua
@@ -69,11 +69,7 @@ function UIMiniWindow:close()
       end
   end
 
-  if self:getId():find("container") then
-    g_game.doThing(false)
-    g_game.close(self.container)
-    g_game.doThing(true)
-  elseif self:getId():find("PartyWindow") then
+  if self:getId():find("PartyWindow") then
     modules.game_sidebuttons.setButtonVisible("partyWidget", false)
   elseif self:getId() == "lockerSearchWindow" then
     modules.game_search_locker.toggleSearchFocus()

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -894,6 +894,8 @@ function onSpellsChange(player, list)
 			spellListData[tostring(spellId)] = spell
 		end
 	end
+
+	onUpdateActionBarStatus()
 end
 
 function onSpellModification(spells)
@@ -2520,11 +2522,7 @@ function playerCanUseSpell(spellData)
 		return false
 	end
 
-	if spellData.special and not spellModification[tostring(spellData.id)] then
-		return false
-	end
-
-	if spellData.needLearn and not spellListData[tostring(spellData.id)] then
+	if (spellData.needLearn or spellData.special) and not spellListData[tostring(spellData.id)] then
 		return false
 	end
 
@@ -3263,7 +3261,7 @@ end
 
 local function playerCanUseSpellLocal(spellData)
 	if not g_game.isOnline() or not spellData then return false end
-	if spellData.needLearn and not spellListData[tostring(spellData.id)] then return false end
+	if (spellData.needLearn or spellData.special) and not spellListData[tostring(spellData.id)] then return false end
 	if spellData.mana and player and player:getMana() < spellData.mana then return false end
 	if spellData.level and player and player:getLevel() < spellData.level then return false end
 	if spellData.soul and player and player:getSoul() < spellData.soul then return false end

--- a/modules/game_cooldown/cooldown.lua
+++ b/modules/game_cooldown/cooldown.lua
@@ -80,11 +80,10 @@ function loadIcon(iconId)
   if g_resources.fileExists(spellSettings .. ".png") then
     icon:setImageSource(spellSettings)
     icon:setImageClip(Spells.getImageClipSmall(spellId, 'Default'))
-    icon:setTooltip(spellName .. " (" .. (spell.exhaustion / 1000) .. " sec. cooldown)")
   else
     icon = nil
   end
-  return icon
+  return icon, spellName
 end
 
 function offline()
@@ -147,7 +146,7 @@ function isCooldownIconActive(iconId)
 end
 
 function onSpellCooldown(iconId, duration)
-  local icon = loadIcon(iconId)
+  local icon, spellName = loadIcon(iconId)
   if not icon then
     return
   end
@@ -165,10 +164,17 @@ function onSpellCooldown(iconId, duration)
   else
     progressRect:setPercent(0)
   end
-  local spell, profile, spellName = Spells.getSpellByIcon(iconId)
-  progressRect:setTooltip(spellName)
 
+  local cooldownEndsAt = g_clock.millis() + duration
+  local lastRemainingSeconds
   local updateFunc = function()
+    local remainingSeconds = math.max(0, math.ceil((cooldownEndsAt - g_clock.millis()) / 1000))
+    if remainingSeconds ~= lastRemainingSeconds then
+      local tooltip = spellName .. " (" .. remainingSeconds .. " sec. cooldown)"
+      icon:setTooltip(tooltip)
+      progressRect:setTooltip(tooltip)
+      lastRemainingSeconds = remainingSeconds
+    end
     updateCooldown(progressRect, duration)
   end
   local finishFunc = function()

--- a/modules/game_cooldown/cooldown.lua
+++ b/modules/game_cooldown/cooldown.lua
@@ -178,6 +178,8 @@ function onSpellCooldown(iconId, duration)
     updateCooldown(progressRect, duration)
   end
   local finishFunc = function()
+    icon:removeTooltip()
+    progressRect:removeTooltip()
     removeCooldown(progressRect)
     cooldown[iconId] = false
   end

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -2096,8 +2096,11 @@ void ProtocolGame::parsePlayerInfo(const InputMessagePtr& msg)
 
     int spellCount = msg->getU16();
     std::vector<int> spells;
+    spells.reserve(spellCount);
     for (int i = 0; i < spellCount; ++i)
-        spells.push_back(msg->getU8()); // spell id
+        spells.push_back(msg->getU16()); // custom spell ids exceed 255
+
+    msg->getU8(); // magic shield active
 
     m_localPlayer->setPremium(premium);
     m_localPlayer->setVocation(vocation);

--- a/src/client/spritemanager.cpp
+++ b/src/client/spritemanager.cpp
@@ -39,6 +39,8 @@ namespace
 {
 constexpr int MinScaleFactor = 1;
 constexpr int MaxScaleFactor = 4;
+constexpr size_t MaxImageCacheEntries = 2000;
+constexpr size_t MaxImageCacheBytes = 32 * 1024 * 1024;
 }
 
 SpriteManager::SpriteManager()
@@ -339,15 +341,32 @@ ImagePtr SpriteManager::getSpriteImage(int id)
     }
 
     auto it = m_imageCache.find(id);
-    if (it != m_imageCache.end())
-        return it->second;
+    if (it != m_imageCache.end()) {
+        m_imageCacheLru.splice(m_imageCacheLru.begin(), m_imageCacheLru, it->second.lruIt);
+        return it->second.image;
+    }
 
     ImagePtr baseSprite = getSpriteImageCasual(id);
     ImagePtr scaledSprite = upscaleSprite(baseSprite, m_scaleFactor);
     if (!scaledSprite)
         return baseSprite;
 
-    m_imageCache[id] = scaledSprite;
+    const size_t imageBytes = static_cast<size_t>(scaledSprite->getPixelCount()) * scaledSprite->getBpp();
+    while (!m_imageCacheLru.empty() &&
+           (m_imageCache.size() >= MaxImageCacheEntries || m_imageCacheBytes + imageBytes > MaxImageCacheBytes)) {
+        const int oldestId = m_imageCacheLru.back();
+        m_imageCacheLru.pop_back();
+
+        auto oldest = m_imageCache.find(oldestId);
+        if (oldest != m_imageCache.end()) {
+            m_imageCacheBytes -= oldest->second.bytes;
+            m_imageCache.erase(oldest);
+        }
+    }
+
+    m_imageCacheLru.push_front(id);
+    m_imageCache.emplace(id, ImageCacheEntry{ scaledSprite, imageBytes, m_imageCacheLru.begin() });
+    m_imageCacheBytes += imageBytes;
     return scaledSprite;
 }
 
@@ -370,6 +389,8 @@ void SpriteManager::setScaleFactor(int factor)
 void SpriteManager::clearImageCache()
 {
     m_imageCache.clear();
+    m_imageCacheLru.clear();
+    m_imageCacheBytes = 0;
 }
 
 void SpriteManager::updateSpriteSize()

--- a/src/client/spritemanager.h
+++ b/src/client/spritemanager.h
@@ -26,6 +26,7 @@
 #include "const.h"
 #include <framework/core/declarations.h>
 #include <framework/graphics/declarations.h>
+#include <list>
 
 //@bindsingleton g_sprites
 class SpriteManager
@@ -58,6 +59,13 @@ public:
     int getScaleFactor() { return m_scaleFactor; }
 
 private:
+    struct ImageCacheEntry
+    {
+        ImagePtr image;
+        size_t bytes = 0;
+        std::list<int>::iterator lruIt;
+    };
+
     bool loadCasualSpr(std::string file);
     bool loadCwmSpr(std::string file);
 
@@ -78,7 +86,9 @@ private:
     FileStreamPtr m_spritesFile;
     std::vector<std::vector<uint8_t>> m_sprites;
     std::unordered_map<uint32, std::string> m_cachedData;
-    std::unordered_map<int, ImagePtr> m_imageCache;
+    std::unordered_map<int, ImageCacheEntry> m_imageCache;
+    std::list<int> m_imageCacheLru;
+    size_t m_imageCacheBytes = 0;
 };
 
 extern SpriteManager g_sprites;


### PR DESCRIPTION
## Summary

- Send Bestiary search queries to the server instead of rebuilding results locally.
- Reuse the normal Bestiary overview response so searched creatures retain their real progress and outfit.
- Truncate search payloads at a valid UTF-8 boundary while respecting the 80-byte category limit.

## Root cause

The client assigned every locally matched creature progress level `1`, making unlocked entries appear undiscovered in search results. Its byte-based query truncation could also split a multibyte UTF-8 character and send an invalid search string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * A busca do Bestiário agora aceita texto diretamente e é processada pelo servidor.
  * A lista de feitiços suporta identificadores maiores.

* **Correções**
  * A barra de ações atualiza imediatamente após mudanças nos feitiços disponíveis.
  * A validação de feitiços especiais e que exigem aprendizado foi ajustada.
  * Tooltips de recarga exibem o tempo restante com maior precisão.
  * O fechamento da janela de grupo foi corrigido.

* **Desempenho**
  * O gerenciamento de imagens agora limita quantidade e uso de memória em cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves Bestiary search to the server while preserving accurate creature progress and safely limiting UTF-8 query payloads.
- Replaces locally synthesized search results with the normal Bestiary overview response.
- Truncates prefixed search categories to the 80-byte protocol limit without splitting valid UTF-8 sequences.
- Refreshes action-bar spell availability and supports wider custom spell identifiers.
- Improves cooldown tooltips, party-window cleanup, and scaled-sprite cache bounds.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported UTF-8 truncation defect is fixed: the query is limited to the available bytes after the search prefix, and truncation backs up to a complete UTF-8 sequence before serialization; no blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| mods/game_cyclopedia/classes/bestiary.lua | Sends normalized search text to the protocol layer instead of constructing inaccurate local results. |
| mods/game_cyclopedia/cyclopediaprotocol.lua | Encodes server-side Bestiary searches and preserves valid UTF-8 while enforcing the category byte limit. |
| modules/game_actionbar/actionbar.lua | Refreshes action-bar state after spell updates and consistently checks learned special spells. |
| modules/game_cooldown/cooldown.lua | Updates cooldown tooltips with calculated remaining time and clears them on completion. |
| src/client/protocolgameparse.cpp | Parses wider custom spell identifiers and consumes the following magic-shield field. |
| src/client/spritemanager.cpp | Adds entry- and memory-bounded LRU eviction to the scaled-image cache. |
| src/client/spritemanager.h | Defines the cache metadata, LRU list, and byte accounting required by bounded image caching. |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(ui): clean cooldown and party state"](https://github.com/mateuzkl/astraclient/commit/78b81d54588f7d584f6474990bd0b0ecce8756d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47315182)</sub>

<!-- /greptile_comment -->