### PR TITLE
Reduce startup memory and lifecycle leaks

### DIFF
--- a/mods/client_autoreloadmodule/autoreloadmodule.lua
+++ b/mods/client_autoreloadmodule/autoreloadmodule.lua
@@ -1,17 +1,37 @@
+local reloadEvents = {}
+local otmlReloadEvent = nil
+
+local function stopReloadEvents()
+    if otmlReloadEvent then
+        removeEvent(otmlReloadEvent)
+        otmlReloadEvent = nil
+    end
+
+    for _, event in ipairs(reloadEvents) do
+        removeEvent(event)
+    end
+    reloadEvents = {}
+end
+
 function init()
     if not AUTO_RELOAD_MODULE then
         return
     end
 
-    for i, module in ipairs(g_modules.getModules()) do
-        local id = live_module_reload(module)
+    stopReloadEvents()
+
+    for _, module in ipairs(g_modules.getModules()) do
+        local event = live_module_reload(module)
+        if event then
+            reloadEvents[#reloadEvents + 1] = event
+        end
     end
 
     local otmlPath = '/data/game.otml';
     local otmlTime = g_resources.getFileTime(otmlPath)
 
     -- otml auto reload
-    cycleEvent(function()
+    otmlReloadEvent = cycleEvent(function()
         local newtime = g_resources.getFileTime(otmlPath)
         if newtime > otmlTime then
             pcolored('Reloading Game OTML')
@@ -19,6 +39,10 @@ function init()
             otmlTime = newtime
         end
     end, 1000)
+end
+
+function terminate()
+    stopReloadEvents()
 end
 
 function live_module_reload(module)

--- a/mods/client_autoreloadmodule/autoreloadmodule.otmod
+++ b/mods/client_autoreloadmodule/autoreloadmodule.otmod
@@ -7,3 +7,4 @@ Module
   sandboxed: true
   scripts: [ autoreloadmodule ]
   @onLoad: init()
+  @onUnload: terminate()

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -144,6 +144,23 @@ local tmpResetActions = {}
 local autoApplyEvent = nil
 local applyingOptions = false
 local pendingInterfaceRefreshEvents = {}
+local mapPanelRetryEvent = nil
+
+local function cancelPendingInterfaceRefreshEvents()
+  for _, event in ipairs(pendingInterfaceRefreshEvents) do
+    removeEvent(event)
+  end
+  pendingInterfaceRefreshEvents = {}
+end
+
+local function cancelOnlineInterfaceRefreshEvents()
+  if mapPanelRetryEvent then
+    removeEvent(mapPanelRetryEvent)
+    mapPanelRetryEvent = nil
+  end
+
+  cancelPendingInterfaceRefreshEvents()
+end
 
 local globalGeneralHotkey = {}
 local actionBarHotkey = {}
@@ -287,6 +304,7 @@ function init()
 end
 
 function terminate()
+  cancelOnlineInterfaceRefreshEvents()
   g_game.shouldShowLootHighlightEffect = nil
 
   ConditionsHUD:save()
@@ -396,10 +414,7 @@ local function refreshOnlineInterfaceOptions()
 end
 
 local function scheduleOnlineInterfaceOptionsRefresh()
-  for _, event in ipairs(pendingInterfaceRefreshEvents) do
-    removeEvent(event)
-  end
-  pendingInterfaceRefreshEvents = {}
+  cancelPendingInterfaceRefreshEvents()
 
   -- Retry through the login/layout settle window because interface modules finish at different ticks.
   local delays = {50, 250, 750, 1500, 3000}
@@ -415,22 +430,24 @@ end
 
 function online()
   local benchmark = g_clock.millis()
+  cancelOnlineInterfaceRefreshEvents()
   tmpResetActions = {}
   local gameMapPanel = m_interface and m_interface.getMapPanel()
   if gameMapPanel then
     gameMapPanel:setAntiAliasingMode(GameOptions:getOption("antialiasing"))
   else
-    local retryEvent
     local retries = 0
-    retryEvent = cycleEvent(function()
+    mapPanelRetryEvent = cycleEvent(function()
       local panel = m_interface and m_interface.getMapPanel()
       if panel then
         panel:setAntiAliasingMode(GameOptions:getOption("antialiasing"))
-        retryEvent:cancel()
+        removeEvent(mapPanelRetryEvent)
+        mapPanelRetryEvent = nil
       else
         retries = retries + 1
         if retries >= 10 then
-          retryEvent:cancel()
+          removeEvent(mapPanelRetryEvent)
+          mapPanelRetryEvent = nil
         end
       end
     end, 500)
@@ -449,6 +466,7 @@ function online()
 end
 
 function offline()
+  cancelOnlineInterfaceRefreshEvents()
   if presetWindow then
   presetWindow:destroy()
   end

--- a/mods/game_analyser/analyser.lua
+++ b/mods/game_analyser/analyser.lua
@@ -18,24 +18,38 @@ local analyserWindows = {
   miscButton = 'styles/misc'
 }
 
+local analyserConfigWindows = {
+  lootButton = 'styles/lootTarget',
+  impactButton = 'styles/dpshpsTarget',
+  xpButton = 'styles/xpTarget',
+  dropButton = 'styles/dropTarget'
+}
+
+function getConfigPopupWindow(buttonId)
+  local window = configPopupWindow[buttonId]
+  if window then
+    return window
+  end
+
+  local style = analyserConfigWindows[buttonId]
+  if not style then
+    return nil
+  end
+
+  window = g_ui.displayUI(style)
+  if window then
+    window:hide()
+    configPopupWindow[buttonId] = window
+  end
+  return window
+end
+
 -- objects
 function init()
   analyserMiniWindow = g_ui.loadUI('analyser', m_interface.getRightPanel())
   analyserMiniWindow:disableResize()
   analyserMiniWindow:close()
   analyserMiniWindow:setup()
-
-  configPopupWindow["lootButton"] = g_ui.displayUI('styles/lootTarget')
-  configPopupWindow["lootButton"]:hide()
-
-  configPopupWindow["impactButton"] = g_ui.displayUI('styles/dpshpsTarget')
-  configPopupWindow["impactButton"]:hide()
-
-  configPopupWindow["xpButton"] = g_ui.displayUI('styles/xpTarget')
-  configPopupWindow["xpButton"]:hide()
-
-  configPopupWindow["dropButton"] = g_ui.displayUI('styles/dropTarget')
-  configPopupWindow["dropButton"]:hide()
 
   huntingButton = analyserMiniWindow:recursiveGetChildById("huntingButton")
   lootButton = analyserMiniWindow:recursiveGetChildById("lootButton")
@@ -117,6 +131,8 @@ function init()
 end
 
 function terminate()
+  ControllerAnalyser:stopEvents()
+  PartyHuntAnalyser:stopEvent()
   LootAnalyser:cancelPendingWindowUpdate()
   DropTrackerAnalyser:terminate()
 
@@ -221,6 +237,8 @@ function onlineAnalyser()
 end
 
 function offlineAnalyser()
+  ControllerAnalyser:stopEvents()
+  PartyHuntAnalyser:stopEvent()
   HuntingAnalyser:saveConfigJson()
   ImpactAnalyser:saveConfigJson()
   InputAnalyser:saveConfigJson()

--- a/mods/game_analyser/classes/Controller.lua
+++ b/mods/game_analyser/classes/Controller.lua
@@ -13,6 +13,24 @@ if not ControllerAnalyser then
     ControllerAnalyser.__index = ControllerAnalyser
 end
 
+function ControllerAnalyser:stopEvents()
+    if ControllerAnalyser.eventGraph then
+        removeEvent(ControllerAnalyser.eventGraph)
+        ControllerAnalyser.eventGraph = nil
+    end
+    if ControllerAnalyser.event250 then
+        removeEvent(ControllerAnalyser.event250)
+        ControllerAnalyser.event250 = nil
+    end
+    if ControllerAnalyser.event1000 then
+        removeEvent(ControllerAnalyser.event1000)
+        ControllerAnalyser.event1000 = nil
+    end
+    if ControllerAnalyser.event2000 then
+        removeEvent(ControllerAnalyser.event2000)
+        ControllerAnalyser.event2000 = nil
+    end
+end
 
 function ControllerAnalyser:startEvent()
 	HuntingAnalyser.session = os.time()
@@ -24,10 +42,7 @@ function ControllerAnalyser:startEvent()
     DropTrackerAnalyser.session = os.time()
     MiscAnalyzer.session = os.time()
 
-	if ControllerAnalyser.eventGraph then ControllerAnalyser.eventGraph:cancel() end
-	if ControllerAnalyser.event250 then ControllerAnalyser.event250:cancel() end
-	if ControllerAnalyser.event1000 then ControllerAnalyser.event1000:cancel() end
-	if ControllerAnalyser.event2000 then ControllerAnalyser.event2000:cancel() end
+    ControllerAnalyser:stopEvents()
 
     ControllerAnalyser.event250 = cycleEvent(function()
         if g_game.isOnline() then

--- a/mods/game_analyser/classes/DropTrackerAnalyser.lua
+++ b/mods/game_analyser/classes/DropTrackerAnalyser.lua
@@ -327,7 +327,8 @@ function DropTrackerAnalyser:isInDropTracker(itemId)
 end
 
 function onDropTrackerExtra(mousePosition)
-	local window = configPopupWindow["dropButton"]
+	local window = getConfigPopupWindow("dropButton")
+	if not window then return end
 	window:show()
 	window:setText('Drop Tracker Configuration')
 	window.contentPanel.text:setImageSource('/images/game/analyzer/labels/loot-track')

--- a/mods/game_analyser/classes/ImpactAnalyser.lua
+++ b/mods/game_analyser/classes/ImpactAnalyser.lua
@@ -269,7 +269,8 @@ function onImpactExtra(mousePosition)
 end
 
 function ImpactAnalyser:openTargetConfig(isDps)
-	local window = configPopupWindow["impactButton"]
+	local window = getConfigPopupWindow("impactButton")
+	if not window then return end
 	window:show()
 	window:setText('Set '.. (isDps and 'DPS' or 'HPS') ..' Target')
 	window.contentPanel.dps.target:setText(ImpactAnalyser.targetDPS)

--- a/mods/game_analyser/classes/LootAnalyser.lua
+++ b/mods/game_analyser/classes/LootAnalyser.lua
@@ -262,7 +262,8 @@ function LootAnalyser:setTarget(value)
 end
 
 function LootAnalyser:openTargetConfig()
-	local window = configPopupWindow["lootButton"]
+	local window = getConfigPopupWindow("lootButton")
+	if not window then return end
 	window:show()
 	window:setText('Set Loot Target')
 	window.contentPanel.text:setImageSource('/images/game/analyzer/labels/loot')

--- a/mods/game_analyser/classes/PartyHuntAnalyser.lua
+++ b/mods/game_analyser/classes/PartyHuntAnalyser.lua
@@ -24,7 +24,15 @@ end
 
 local packetSend = false
 
+function PartyHuntAnalyser:stopEvent()
+	if PartyHuntAnalyser.event then
+		removeEvent(PartyHuntAnalyser.event)
+		PartyHuntAnalyser.event = nil
+	end
+end
+
 function PartyHuntAnalyser.create()
+	PartyHuntAnalyser:stopEvent()
 	PartyHuntAnalyser.launchTime = g_clock.millis()
 	PartyHuntAnalyser.session = 0
 
@@ -36,7 +44,6 @@ function PartyHuntAnalyser.create()
 	PartyHuntAnalyser.loot = 0
 	PartyHuntAnalyser.supplies = 0
 	PartyHuntAnalyser.balance = 0
-	PartyHuntAnalyser.event = nil
 
 	PartyHuntAnalyser.membersData = {}
 	PartyHuntAnalyser.membersName = {}
@@ -45,7 +52,7 @@ end
 
 function PartyHuntAnalyser:startEvent()
 	PartyHuntAnalyser.session = 0
-	if PartyHuntAnalyser.event then PartyHuntAnalyser.event:cancel() end
+	PartyHuntAnalyser:stopEvent()
 end
 
 function PartyHuntAnalyser:reset()
@@ -64,7 +71,7 @@ function PartyHuntAnalyser:reset()
 	PartyHuntAnalyser.membersData = {}
 	PartyHuntAnalyser.membersName = {}
 
-	if PartyHuntAnalyser.event then PartyHuntAnalyser.event:cancel() end
+	PartyHuntAnalyser:stopEvent()
 
 	local contentsPanel = PartyHuntAnalyser.window:getChildById('contentsPanel')
 	contentsPanel.party:destroyChildren()
@@ -150,7 +157,7 @@ function PartyHuntAnalyser:onPartyAnalyzer(startTime, leaderID, lootType, member
 	PartyHuntAnalyser.membersData = membersData
 	PartyHuntAnalyser.membersName = membersName
 
-	if PartyHuntAnalyser.event then PartyHuntAnalyser.event:cancel() end
+	PartyHuntAnalyser:stopEvent()
 	PartyHuntAnalyser.event = cycleEvent(function()
 		if not g_game.isOnline() then return end
 		PartyHuntAnalyser.session = PartyHuntAnalyser.session + 1
@@ -280,7 +287,7 @@ function onShieldChange(creature, shieldId)
 			PartyHuntAnalyser.leader = false
             packetSend = false
             PartyHuntAnalyser.session = 0
-            if PartyHuntAnalyser.event then PartyHuntAnalyser.event:cancel() end
+            PartyHuntAnalyser:stopEvent()
         end
     end
 end

--- a/mods/game_analyser/classes/SupplyAnalyser.lua
+++ b/mods/game_analyser/classes/SupplyAnalyser.lua
@@ -262,7 +262,8 @@ function SupplyAnalyser:setTarget(value)
 end
 
 function SupplyAnalyser:openTargetConfig()
-	local window = configPopupWindow["lootButton"]
+	local window = getConfigPopupWindow("lootButton")
+	if not window then return end
 	window:show()
 	window:setText('Set Supply Target')
 	window.contentPanel.text:setImageSource('/images/game/analyzer/labels/supply')

--- a/mods/game_analyser/classes/XPAanalyser.lua
+++ b/mods/game_analyser/classes/XPAanalyser.lua
@@ -264,7 +264,8 @@ function XPAnalyser:setGraphVisible(value)
 end
 
 function XPAnalyser:openTargetConfig()
-	local window = configPopupWindow["xpButton"]
+	local window = getConfigPopupWindow("xpButton")
+	if not window then return end
 	window:show()
 	window:setText('Set XP Per Hour Target')
 	window.contentPanel.text:setImageSource('/images/game/analyzer/labels/xp')

--- a/mods/game_store/classes/Offers.lua
+++ b/mods/game_store/classes/Offers.lua
@@ -1096,6 +1096,10 @@ function onBuyOffer(widget, id, offerType, text, offerName)
 end
 
 function onStorePurchase(message)
+	if not ensureStoreWindow() then
+		return
+	end
+
 	SucessOfferWindow:show(true)
 	StoreWindow:hide()
 	buyOfferWindow:hide()

--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -14,7 +14,8 @@ giftWindow = nil
 
 local categoryUpdateEvent = nil
 local contentUpdateEvent = nil
-local ensureStoreWindow
+-- Shared with the purchase callback in classes/Offers.lua.
+ensureStoreWindow = nil
 
 local function cancelPendingStoreUpdates(cancelRenders)
   removeEvent(categoryUpdateEvent)
@@ -610,6 +611,10 @@ end
 
 -- Hireling name change
 function onHirelingNameChange(hirelingId, creatureId)
+  if not ensureStoreWindow() then
+    return
+  end
+
   g_ui.setInputLockWidget(hirelingNameWindow)
   hirelingNameWindow:show()
   hirelingNameWindow:focus()
@@ -753,6 +758,10 @@ function onCpfChange(widget, text)
 end
 
 function onRecvPixData(pixList)
+  if not ensureStoreWindow() then
+    return
+  end
+
   if not pixWindow:isVisible() then
     pixWindow:show()
   end
@@ -821,6 +830,10 @@ function onTermConditionChange(widgetId, value)
 end
 
 function onRecvPixURL(url, token)
+  if not ensureStoreWindow() then
+    return
+  end
+
   if not pixWindow:isVisible() then
     pixWindow:show()
   end

--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -14,6 +14,7 @@ giftWindow = nil
 
 local categoryUpdateEvent = nil
 local contentUpdateEvent = nil
+local ensureStoreWindow
 
 local function cancelPendingStoreUpdates(cancelRenders)
   removeEvent(categoryUpdateEvent)
@@ -33,7 +34,7 @@ local function queueStoreUpdate(eventName, callback)
     removeEvent(categoryUpdateEvent)
     categoryUpdateEvent = scheduleEvent(function()
       categoryUpdateEvent = nil
-      if StoreWindow then
+      if ensureStoreWindow() then
         callback()
       end
     end, 1)
@@ -43,7 +44,7 @@ local function queueStoreUpdate(eventName, callback)
   removeEvent(contentUpdateEvent)
   contentUpdateEvent = scheduleEvent(function()
     contentUpdateEvent = nil
-    if StoreWindow then
+    if ensureStoreWindow() then
       callback()
     end
   end, 1)
@@ -64,7 +65,7 @@ local importFiles = {
   'styles/pixdonate'
 }
 
-local function ensureStoreWindow()
+ensureStoreWindow = function()
   if StoreWindow then
     return StoreWindow
   end
@@ -336,8 +337,6 @@ function onStoreInit(url, coinsPacketSize)
 end
 
 function onStoreCategories(categories)
-  ensureStoreWindow()
-
   queueStoreUpdate("category", function()
     if not StoreWindow:isVisible() then
       showStoreWindow()
@@ -359,16 +358,12 @@ function onCoinBalance(coins, transferableCoins, tournamentCoins)
 end
 
 function onStoreHomeOffers(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
-  ensureStoreWindow()
-
   queueStoreUpdate("content", function()
     HomeOffer:configure(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
   end)
 end
 
 function onStoreOffers(categoryName, offers, redirect, sortingType, filters, currentFilter, reasons)
-  ensureStoreWindow()
-
   queueStoreUpdate("content", function()
     Offers:configure(categoryName, offers, redirect, sortingType, filters, currentFilter, reasons)
   end)
@@ -402,6 +397,7 @@ function showError(title, errorMessage)
 end
 
 function onStoreError(errorType, message)
+  ensureStoreWindow()
   StoreWindow:hide()
   g_client.setInputLockWidget(nil)
   showError('Purchase Error', message)
@@ -424,6 +420,8 @@ function requestHistory()
 end
 
 function onStoreTransactionHistory(currentPage, pageCount, offers)
+  ensureStoreWindow()
+
   if Offers.displayPanel then
     Offers.displayPanel:destroy()
   end
@@ -473,6 +471,10 @@ function onStoreTransactionHistory(currentPage, pageCount, offers)
     end
     itemBox.description:setText(short_text(item.name, 35))
     itemBox.description.desc:setTooltip(item.name)
+  end
+
+  if not StoreWindow:isVisible() then
+    showStoreWindow()
   end
 end
 

--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -64,7 +64,11 @@ local importFiles = {
   'styles/pixdonate'
 }
 
-function init()
+local function ensureStoreWindow()
+  if StoreWindow then
+    return StoreWindow
+  end
+
   StoreWindow = g_ui.displayUI('store')
   StoreWindow:hide()
 
@@ -90,6 +94,12 @@ function init()
   pixWindow:hide()
 
   offerCheckBox = UIRadioGroup.create()
+  connect(offerCheckBox, { onSelectionChange = onSelectionOffer })
+
+  return StoreWindow
+end
+
+function init()
   connect(g_game, {
     onStoreInit = onStoreInit,
     onGameEnd = onGameEnd,
@@ -113,8 +123,6 @@ function init()
     onRecvPixURL = onRecvPixURL,
     onCharacterBazarCheckInformations = onCharacterBazarCheckInformations
   })
-
-  connect(offerCheckBox, { onSelectionChange = onSelectionOffer })
 
   if initStoreProtocol then
     initStoreProtocol()
@@ -161,8 +169,11 @@ function terminate()
     onCharacterBazarCheckInformations = onCharacterBazarCheckInformations
   })
 
-  disconnect(offerCheckBox, { onSelectionChange = onSelectionOffer })
-  offerCheckBox = nil
+  if offerCheckBox then
+    disconnect(offerCheckBox, { onSelectionChange = onSelectionOffer })
+    offerCheckBox:destroy()
+    offerCheckBox = nil
+  end
 
 
   if buyOfferWindow then
@@ -206,6 +217,17 @@ end
 function onGameEnd()
   cancelPendingStoreUpdates(true)
 
+  Offers:stopAllEvents()
+  Store:resetSession()
+  if Categories.reset then
+    Categories:reset()
+  end
+
+  if not StoreWindow then
+    g_client.setInputLockWidget(nil)
+    return
+  end
+
   if StoreWindow:isVisible() then
     StoreWindow:hide()
   end
@@ -213,12 +235,6 @@ function onGameEnd()
   if buyOfferWindow:isVisible() then
     buyOfferWindow:hide()
   end
-  Offers:stopAllEvents()
-  Store:resetSession()
-  if Categories.reset then
-    Categories:reset()
-  end
-
   if hirelingWindow:isVisible() then
     hirelingWindow:hide()
   end
@@ -252,6 +268,12 @@ end
 
 function closeStore()
   cancelPendingStoreUpdates(false)
+
+  if not StoreWindow then
+    g_client.setInputLockWidget(nil)
+    Offers:stopAllEvents()
+    return
+  end
 
   if StoreWindow:isVisible() then
     StoreWindow:hide()
@@ -289,6 +311,8 @@ local function updateCoinBalanceWidgets(refreshOffers)
 end
 
 function showStoreWindow()
+  ensureStoreWindow()
+
   StoreWindow:show(true)
   StoreWindow:raise()
   StoreWindow:focus()
@@ -312,6 +336,8 @@ function onStoreInit(url, coinsPacketSize)
 end
 
 function onStoreCategories(categories)
+  ensureStoreWindow()
+
   queueStoreUpdate("category", function()
     if not StoreWindow:isVisible() then
       showStoreWindow()
@@ -333,12 +359,16 @@ function onCoinBalance(coins, transferableCoins, tournamentCoins)
 end
 
 function onStoreHomeOffers(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
+  ensureStoreWindow()
+
   queueStoreUpdate("content", function()
     HomeOffer:configure(categoryName, offers, scrolling, homePanel, reasons, dailyOfferPrice, dailyOffers)
   end)
 end
 
 function onStoreOffers(categoryName, offers, redirect, sortingType, filters, currentFilter, reasons)
+  ensureStoreWindow()
+
   queueStoreUpdate("content", function()
     Offers:configure(categoryName, offers, redirect, sortingType, filters, currentFilter, reasons)
   end)

--- a/mods/game_wheel/wheel.lua
+++ b/mods/game_wheel/wheel.lua
@@ -101,6 +101,8 @@ function terminate()
     onResourceBalance = onResourceBalance
   })
 
+  g_client.setInputLockWidget(nil)
+
   if selectedNewPresetRadio then
     selectedNewPresetRadio:destroy()
     selectedNewPresetRadio = nil
@@ -179,7 +181,7 @@ function onGameEnd()
 
   if not wheelWindow then
     WheelOfDestiny.currentPreset = {}
-    g_ui.setInputLockWidget(nil)
+    g_client.setInputLockWidget(nil)
     return
   end
 
@@ -203,7 +205,7 @@ function onGameEnd()
   end
 
   WheelOfDestiny.currentPreset = {}
-  g_ui.setInputLockWidget(nil)
+  g_client.setInputLockWidget(nil)
 end
 
 function show()

--- a/mods/game_wheel/wheel.lua
+++ b/mods/game_wheel/wheel.lua
@@ -17,7 +17,11 @@ if not SkillwheelStringsLibrary then
   SkillwheelStringsLibrary = {}
 end
 
-function init()
+local function ensureWheelWindow()
+  if wheelWindow then
+    return wheelWindow
+  end
+
   wheelWindow = g_ui.displayUI('wheel')
   mainPanel = wheelWindow:getChildById('mainPanel')
 
@@ -41,8 +45,6 @@ function init()
   renamePresetWindow = g_ui.displayUI('styles/renamePreset')
   renamePresetWindow:hide()
 
-  loadConfigJson()
-
   selectedNewPresetRadio = UIRadioGroup.create()
   selectedNewPresetRadio:addWidget(newPresetWindow.contentPanel.useEmpty)
   selectedNewPresetRadio:addWidget(newPresetWindow.contentPanel.copyPreset)
@@ -64,11 +66,28 @@ function init()
   loadMenu('wheelMenu')
   toggleTabBarButtons('informationButton')
   hide()
+
+  return wheelWindow
+end
+
+local function onDestinyWheel(...)
+  ensureWheelWindow()
+  WheelOfDestiny.onDestinyWheel(...)
+end
+
+local function onUnlockGem(...)
+  ensureWheelWindow()
+  GemAtelier.onUnlockGem(...)
+end
+
+function init()
+  loadConfigJson()
+
   connect(g_game, {
     onGameEnd = onGameEnd,
     onGameStart = WheelOfDestiny.loadWheelPresets,
-    onDestinyWheel = WheelOfDestiny.onDestinyWheel,
-    onUnlockGem = GemAtelier.onUnlockGem,
+    onDestinyWheel = onDestinyWheel,
+    onUnlockGem = onUnlockGem,
     onResourceBalance = onResourceBalance,
   })
 end
@@ -77,18 +96,57 @@ function terminate()
   disconnect(g_game, {
     onGameEnd = onGameEnd,
     onGameStart = WheelOfDestiny.loadWheelPresets,
-    onDestinyWheel = WheelOfDestiny.onDestinyWheel,
-    onUnlockGem = GemAtelier.onUnlockGem,
+    onDestinyWheel = onDestinyWheel,
+    onUnlockGem = onUnlockGem,
     onResourceBalance = onResourceBalance
   })
+
+  if selectedNewPresetRadio then
+    selectedNewPresetRadio:destroy()
+    selectedNewPresetRadio = nil
+  end
 
   if wheelWindow then
     wheelWindow:destroy()
     wheelWindow = nil
   end
+
+  if newPresetWindow then
+    newPresetWindow:destroy()
+    newPresetWindow = nil
+  end
+
+  if renamePresetWindow then
+    renamePresetWindow:destroy()
+    renamePresetWindow = nil
+  end
+
+  if exportCodeWindow then
+    exportCodeWindow:destroy()
+    exportCodeWindow = nil
+  end
+
+  if deletePresetWindow then
+    deletePresetWindow:destroy()
+    deletePresetWindow = nil
+  end
+
+  if checkSavePresetWindow then
+    checkSavePresetWindow:destroy()
+    checkSavePresetWindow = nil
+  end
+
+  mainPanel = nil
+  wheelOfDestinyWindow = nil
+  gemAtelierWindow = nil
+  fragmentWindow = nil
+  wheelPanel = nil
+  centerReferencePoint = nil
 end
 
 function toggle()
+  ensureWheelWindow()
+
   if wheelWindow:isVisible() then
     wheelWindow:hide()
     g_client.setInputLockWidget(nil)
@@ -111,13 +169,21 @@ end
 
 function hide()
   g_client.setInputLockWidget(nil)
-  wheelWindow:hide()
+  if wheelWindow then
+    wheelWindow:hide()
+  end
 end
 
 function onGameEnd()
-  hide()
   WheelOfDestiny.saveWheelPresets()
 
+  if not wheelWindow then
+    WheelOfDestiny.currentPreset = {}
+    g_ui.setInputLockWidget(nil)
+    return
+  end
+
+  hide()
   newPresetWindow:hide()
   renamePresetWindow:hide()
 
@@ -141,6 +207,8 @@ function onGameEnd()
 end
 
 function show()
+  ensureWheelWindow()
+
   g_game.requestResource(ResourceBank)
   g_game.requestResource(ResourceInventary)
   g_game.requestResource(ResourceWheelPoints)
@@ -262,7 +330,7 @@ function toggleTabBarButtons(selectedButtonId)
 end
 
 function onResourceBalance()
-  if not wheelWindow:isVisible() then
+  if not wheelWindow or not wheelWindow:isVisible() then
     return true
   end
   local player = g_game.getLocalPlayer()

--- a/modules/client/client.lua
+++ b/modules/client/client.lua
@@ -1,5 +1,6 @@
 local musicFilename = "/sounds/startup"
 local musicChannel = nil
+local startupGameSignalsConnected = false
 
 function setMusic(filename)
   musicFilename = filename
@@ -7,6 +8,19 @@ function setMusic(filename)
   if not g_game.isOnline() and musicChannel ~= nil then
     musicChannel:stop()
     musicChannel:enqueue(musicFilename, 3)
+  end
+end
+
+local function onStartupGameStart()
+  if musicChannel ~= nil then
+    musicChannel:stop(3)
+  end
+end
+
+local function onStartupGameEnd()
+  if g_sounds ~= nil then
+    g_sounds.stopAll()
+    --musicChannel:enqueue(musicFilename, 3)
   end
 end
 
@@ -49,13 +63,13 @@ function startup()
   
   -- Play startup music (The Silver Tree, by Mattias Westlund)
   --musicChannel:enqueue(musicFilename, 3)
-  connect(g_game, { onGameStart = function() if musicChannel ~= nil then musicChannel:stop(3) end end })
-  connect(g_game, { onGameEnd = function()
-      if g_sounds ~= nil then
-        g_sounds.stopAll()
-        --musicChannel:enqueue(musicFilename, 3)
-      end
-  end })
+  if not startupGameSignalsConnected then
+    connect(g_game, {
+      onGameStart = onStartupGameStart,
+      onGameEnd = onStartupGameEnd
+    })
+    startupGameSignalsConnected = true
+  end
 end
 
 function init()
@@ -143,6 +157,15 @@ function terminate()
                       onExit = exit })
   disconnect(g_game, { onGameStart = onGameStart,
                        onGameEnd = onGameEnd })
+  if startupGameSignalsConnected then
+    disconnect(g_game, {
+      onGameStart = onStartupGameStart,
+      onGameEnd = onStartupGameEnd
+    })
+    startupGameSignalsConnected = false
+  end
+  musicChannel = nil
+
   -- save window configs
   local platformType = g_window.getPlatformType()
   local isX11 = type(platformType) == 'string' and platformType:find('X11', 1, true) == 1

--- a/modules/client_camviewer/client_camviewer.lua
+++ b/modules/client_camviewer/client_camviewer.lua
@@ -1,14 +1,46 @@
-function init()
+local function ensureCamViewerWindow()
+    if camViewerWindow then
+        return availableCamsList ~= nil
+    end
+
     camViewerWindow = g_ui.displayUI("client_camviewer")
+    if not camViewerWindow then
+        return false
+    end
+
     camViewerWindow:hide()
     availableCamsList = camViewerWindow.contentPanel:getChildById("availableCams")
+    if not availableCamsList then
+        camViewerWindow:destroy()
+        camViewerWindow = nil
+        return false
+    end
+    return true
+end
 
+function init()
     connect(g_game, {
       onRecordEnd = onRecordEnd
     })
 end
 
+function terminate()
+    disconnect(g_game, {
+      onRecordEnd = onRecordEnd
+    })
+
+    if camViewerWindow then
+        camViewerWindow:destroy()
+        camViewerWindow = nil
+    end
+    availableCamsList = nil
+end
+
 function show()
+    if not ensureCamViewerWindow() then
+        return
+    end
+
 	load()
 	camViewerWindow:show(true)
 	camViewerWindow:raise()
@@ -16,17 +48,17 @@ function show()
 end
 
 function toggle()
-	if camViewerWindow:isVisible() then
+	if camViewerWindow and camViewerWindow:isVisible() then
 		hide()
 		return
 	end
-	load()
 	show()
-	camViewerWindow:focus()
 end
 
 function hide()
-	camViewerWindow:hide()
+    if camViewerWindow then
+	    camViewerWindow:hide()
+    end
 end
 
 function onRecordEnd()
@@ -34,6 +66,10 @@ function onRecordEnd()
 end
 
 function load()
+    if not ensureCamViewerWindow() then
+        return
+    end
+
     local t = {}
     local i = 0
 

--- a/modules/game_battlepass/battlepass.lua
+++ b/modules/game_battlepass/battlepass.lua
@@ -392,8 +392,44 @@ local function setupBattlePassTabs()
     end
 end
 
-function BattlePass.init()
+local function prepareBattlePassWindowForSession()
+    if not BattlePass.window then
+        return false
+    end
+    if BattlePass.windowSessionPrepared then
+        return true
+    end
+
+    local dailyMissionsPanel = BattlePass.window:recursiveGetChildById('dailyMissionsBg')
+    dailyMissionsPanel:destroyChildren()
+    for i = 1, 2 do
+        local widget = g_ui.createWidget('DailyMissionWidget', dailyMissionsPanel)
+        local imageBackground = widget:recursiveGetChildById('dailyMissionIconImage')
+        local image = i == 1 and 'daily-free-icon' or 'daily-vip-icon'
+        imageBackground:setImageSource('/images/game/battlepass/' .. image)
+    end
+
+    local missionsPanel = BattlePass.window:recursiveGetChildById('missionsBackground')
+    missionsPanel:destroyChildren()
+    for _ = 1, 26 do
+        g_ui.createWidget('MissionWidget', missionsPanel)
+    end
+
+    BattlePass:loadPlayerPosition()
+    BattlePass.windowSessionPrepared = true
+    return true
+end
+
+function BattlePass.ensureWindow()
+    if BattlePass.window then
+        return true
+    end
+
     BattlePass.window = g_ui.displayUI('battlepass')
+    if not BattlePass.window then
+        return false
+    end
+
     BattlePass.hide()
     setupBattlePassTabs()
 
@@ -439,7 +475,10 @@ function BattlePass.init()
     if BattlePassShop then
         BattlePassShop.init(BattlePass.shopPanel)
     end
+    return true
+end
 
+function BattlePass.init()
     registerBattlePassProtocol()
 
     connect(g_game, {
@@ -460,7 +499,9 @@ function BattlePass.terminate()
     stopPendingRewardsSchedule()
     stopPlayerAnimationEvents()
 
-    g_keyboard.unbindKeyPress('Tab', toggleNextWindow, BattlePass.window)
+    if BattlePass.window then
+        g_keyboard.unbindKeyPress('Tab', toggleNextWindow, BattlePass.window)
+    end
 
     unregisterBattlePassProtocol()
 
@@ -493,6 +534,12 @@ function BattlePass.terminate()
         BattlePass.window:destroy()
         BattlePass.window = nil
     end
+    BattlePass.missionPanel = nil
+    BattlePass.progressPanel = nil
+    BattlePass.shopPanel = nil
+    BattlePass.outfitWidget = nil
+    BattlePass.scrollBarWidget = nil
+    BattlePass.windowSessionPrepared = false
 end
 
 local function readBool(msg)
@@ -730,24 +777,7 @@ online = function()
 
     -- Load battlepass config
     BattlePass:loadConfigJson()
-    BattlePass:loadPlayerPosition()
-
-    -- Reset daily mission panel
-    local dailyMissionsPanel = BattlePass.window:recursiveGetChildById('dailyMissionsBg')
-    dailyMissionsPanel:destroyChildren()
-    for i = 1, 2 do
-        local widget = g_ui.createWidget('DailyMissionWidget', dailyMissionsPanel)
-        local imageBackground = widget:recursiveGetChildById('dailyMissionIconImage')
-        local image = i == 1 and 'daily-free-icon' or 'daily-vip-icon'
-        imageBackground:setImageSource('/images/game/battlepass/' .. image)
-    end
-
-    -- Reset mission panel
-    local missionsPanel = BattlePass.window:recursiveGetChildById('missionsBackground')
-    missionsPanel:destroyChildren()
-    for i = 1, 26 do
-        g_ui.createWidget('MissionWidget', missionsPanel)
-    end
+    BattlePass.windowSessionPrepared = false
 
     if BattlePassRewards.claimRewardWindow then
         BattlePassRewards.claimRewardWindow:destroy()
@@ -757,11 +787,14 @@ online = function()
 end
 
 openBattlePass = function()
-    if BattlePass.window:isVisible() then
+    if BattlePass.window and BattlePass.window:isVisible() then
         BattlePass.hide()
     elseif not g_game.isOnline() then
         return
     else
+        if not BattlePass.ensureWindow() or not prepareBattlePassWindowForSession() then
+            return
+        end
         BattlePass.pendingOpen = true
         BattlePass.shouldShow = true
         sendToServer("getMissions")
@@ -783,9 +816,12 @@ offline = function()
     BattlePass.hide()
     BattlePass.lastRewardStep = BattlePass.currentRewardStep
     BattlePass.lastCameraPosition = getRewardPosition(BattlePass.currentRewardStep).scrollPosition
-    BattlePass.outfitWidget:setMarginLeft(165)
+    if BattlePass.outfitWidget then
+        BattlePass.outfitWidget:setMarginLeft(165)
+    end
     BattlePass:saveConfigJson()
     stopUnlockTimer()
+    BattlePass.windowSessionPrepared = false
 
     if BattlePassRewards.claimRewardWindow then
         BattlePassRewards.claimRewardWindow:destroy()
@@ -809,6 +845,9 @@ function BattlePass:showBattlePass()
 end
 
 function BattlePass.show()
+    if not BattlePass.ensureWindow() then
+        return
+    end
     BattlePass.window:show(true)
     BattlePass.window:raise()
     BattlePass.window:focus()

--- a/modules/test_html/test_html.otmod
+++ b/modules/test_html/test_html.otmod
@@ -4,7 +4,7 @@ Module
   author: Test
   version: 1
   sandboxed: true
-  autoload: true
+  autoload: false
   autoload-priority: 1000
   dependencies: [ modulelib ]
   scripts: [ test.lua ]

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -747,7 +747,8 @@ void Creature::setHealthPercent(uint8 healthPercent)
 
 void Creature::setDirection(Otc::Direction direction)
 {
-    VALIDATE(direction != Otc::InvalidDirection);
+    if (direction < Otc::North || direction > Otc::NorthWest)
+        return;
     m_direction = direction;
 }
 

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -382,6 +382,8 @@ bool Creature::canShoot(int distance)
 
 void Creature::turn(Otc::Direction direction)
 {
+    if (direction < Otc::North || direction > Otc::NorthWest)
+        return;
     setDirection(direction);
     callLuaField("onTurn", direction);
 }

--- a/src/client/healthbars.h
+++ b/src/client/healthbars.h
@@ -73,8 +73,12 @@ public:
     void addHealthBackground(const std::string& path, int offsetX, int offsetY, int barOffsetX, int barOffsetY, int height);
     void addManaBackground(const std::string& path, int offsetX, int offsetY, int barOffsetX, int barOffsetY, int height);
 
-    HealthBarPtr getHealthBar(int id) { return m_healthBars[id]; }
-    HealthBarPtr getManaBar(int id) { return m_manaBars[id]; }
+    HealthBarPtr getHealthBar(int id) {
+        return id >= 0 && static_cast<size_t>(id) < m_healthBars.size() ? m_healthBars[id] : nullptr;
+    }
+    HealthBarPtr getManaBar(int id) {
+        return id >= 0 && static_cast<size_t>(id) < m_manaBars.size() ? m_manaBars[id] : nullptr;
+    }
 
     std::string getHealthBarPath(int id);
     std::string getManaBarPath(int id);
@@ -96,4 +100,3 @@ private:
 extern HealthBars g_healthBars;
 
 #endif
-

--- a/src/client/item.h
+++ b/src/client/item.h
@@ -183,10 +183,18 @@ public:
     bool isItem() override { return true; }
 
     ItemVector getContainerItems() { return m_containerItems; }
-    ItemPtr getContainerItem(int slot) { return m_containerItems[slot]; }
-    void addContainerItemIndexed(const ItemPtr& i, int slot) { m_containerItems[slot] = i; }
+    ItemPtr getContainerItem(int slot) {
+        return slot >= 0 && static_cast<size_t>(slot) < m_containerItems.size() ? m_containerItems[slot] : nullptr;
+    }
+    void addContainerItemIndexed(const ItemPtr& i, int slot) {
+        if (slot >= 0 && static_cast<size_t>(slot) < m_containerItems.size())
+            m_containerItems[slot] = i;
+    }
     void addContainerItem(const ItemPtr& i) { m_containerItems.push_back(i); }
-    void removeContainerItem(int slot) { m_containerItems[slot] = nullptr; }
+    void removeContainerItem(int slot) {
+        if (slot >= 0 && static_cast<size_t>(slot) < m_containerItems.size())
+            m_containerItems[slot] = nullptr;
+    }
     void clearContainerItems() { m_containerItems.clear(); }
 
     void calculatePatterns(int& xPattern, int& yPattern, int& zPattern);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -637,7 +637,7 @@ void LocalPlayer::setStamina(double stamina)
 
 void LocalPlayer::setInventoryItem(Otc::InventorySlot inventory, const ItemPtr& item)
 {
-    if(inventory >= Otc::LastInventorySlot) {
+    if(inventory < Otc::InventorySlotHead || inventory >= Otc::LastInventorySlot) {
         g_logger.traceError("invalid slot");
         return;
     }

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -112,7 +112,10 @@ public:
     double getRegenerationTime() { return m_regenerationTime; }
     double getOfflineTrainingTime() { return m_offlineTrainingTime; }
     std::vector<int> getSpells() { return m_spells; }
-    ItemPtr getInventoryItem(Otc::InventorySlot inventory) { return m_inventoryItems[inventory]; }
+    ItemPtr getInventoryItem(Otc::InventorySlot inventory) {
+        return inventory >= Otc::InventorySlotHead && inventory < Otc::LastInventorySlot ?
+            m_inventoryItems[inventory] : nullptr;
+    }
     int getBlessings() { return m_blessings; }
     int getTaints() { return m_taints; }
     int getGroupType() { return m_groupType; }

--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -127,7 +127,7 @@ void Map::cleanTexts()
 
 void Map::addThing(const ThingPtr& thing, const Position& pos, int stackPos)
 {
-    if(!thing)
+    if(!thing || !pos.isMapPosition())
         return;
 
     if(thing->isItem() || thing->isCreature() || thing->isEffect()) {

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -269,7 +269,7 @@ bool Minimap::loadImage(const std::string& fileName, const Position& topLeft, fl
 
         for(int y=0;y<image->getHeight();++y) {
             for(int x=0;x<image->getWidth();++x) {
-                Color color = *(uint32*)image->getPixel(x,y);
+                Color color = stdext::readULE32(image->getPixel(x,y));
                 uint8 c = Color::to8bit(color * colorFactor);
                 int flags = 0;
 
@@ -379,7 +379,8 @@ bool Minimap::loadOtmm(const std::string& fileName)
 
             ulong len = fin->getU16();
             ulong destLen = blockSize;
-            fin->read(compressBuffer.data(), len);
+            if (len > compressBuffer.size() || fin->read(compressBuffer.data(), len) != len)
+                stdext::throw_exception("invalid compressed minimap block");
 
             // Skip blocks with Z beyond configured limit, but continue processing
             if(pos.z > g_gameConfig.getMapMaxZ())

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -379,7 +379,7 @@ bool Minimap::loadOtmm(const std::string& fileName)
 
             ulong len = fin->getU16();
             ulong destLen = blockSize;
-            if (len > compressBuffer.size() || fin->read(compressBuffer.data(), len) != len)
+            if (len > compressBuffer.size() || fin->read(compressBuffer.data(), 1, len) != len)
                 stdext::throw_exception("invalid compressed minimap block");
 
             // Skip blocks with Z beyond configured limit, but continue processing

--- a/src/client/spritemanager.cpp
+++ b/src/client/spritemanager.cpp
@@ -193,9 +193,9 @@ void SpriteManager::saveSpr64(std::string fileName)
                     }
                 }
 
-                *(uint16_t*)(buffer.data() + bufferPos) = transparent;
+                stdext::writeULE16(buffer.data() + bufferPos, static_cast<uint16_t>(transparent));
                 bufferPos += 2;
-                *(uint16_t*)(buffer.data() + bufferPos) = colored;
+                stdext::writeULE16(buffer.data() + bufferPos, static_cast<uint16_t>(colored));
                 bufferPos += 2;
 
                 i += transparent * 4;
@@ -230,7 +230,7 @@ void SpriteManager::encryptSprites(std::string fileName)
             stdext::throw_exception(stdext::format("failed to open file '%s' for write", fileName));
 
         const char otcv8Signature[] = "OTV8";
-        fin->addU32(*((uint32_t*)otcv8Signature));
+        fin->addU32(stdext::readULE32(reinterpret_cast<const uint8_t*>(otcv8Signature)));
         fin->addU32(m_signature);
         fin->addU32(m_spritesCount);
 
@@ -266,9 +266,9 @@ void SpriteManager::encryptSprites(std::string fileName)
                     }
                 }
 
-                *(uint16_t*)(buffer.data() + bufferPos) = transparent;
+                stdext::writeULE16(buffer.data() + bufferPos, static_cast<uint16_t>(transparent));
                 bufferPos += 2;
-                *(uint16_t*)(buffer.data() + bufferPos) = colored;
+                stdext::writeULE16(buffer.data() + bufferPos, static_cast<uint16_t>(colored));
                 bufferPos += 2;
 
                 i += transparent * 4;
@@ -513,6 +513,9 @@ bool SpriteManager::loadCwmSpr(std::string file)
 ImagePtr SpriteManager::getSpriteImageCasual(int id)
 {
     try {
+        if (id <= 0)
+            return nullptr;
+
         int spriteDataSize = m_baseSpriteSize * m_baseSpriteSize * 4;
 
         if (!m_sprites.empty()) {
@@ -537,13 +540,26 @@ ImagePtr SpriteManager::getSpriteImageCasual(int id)
             int writePos = 0;
 
             size_t bufferPos = 2;
-            while (bufferPos != buffer.size()) {
-                uint16_t transparentPixels = *(uint16_t*)(&buffer[bufferPos]);
+            while (bufferPos < buffer.size()) {
+                if (buffer.size() - bufferPos < 4)
+                    stdext::throw_exception("Invalid sprite data header");
+
+                uint16_t transparentPixels = stdext::readULE16(&buffer[bufferPos]);
                 bufferPos += 2;
-                uint16_t coloredPixels = *(uint16_t*)(&buffer[bufferPos]);
+                uint16_t coloredPixels = stdext::readULE16(&buffer[bufferPos]);
                 bufferPos += 2;
 
+                const int remainingPixels = (spriteDataSize - writePos) / 4;
+                if (writePos < 0 || writePos > spriteDataSize || transparentPixels > remainingPixels)
+                    stdext::throw_exception("Invalid transparent sprite run");
                 writePos += transparentPixels * 4;
+
+                const int coloredCapacity = (spriteDataSize - writePos) / 4;
+                const size_t bytesPerPixel = hasAlpha ? 4 : 3;
+                if (coloredPixels > coloredCapacity ||
+                    static_cast<size_t>(coloredPixels) > (buffer.size() - bufferPos) / bytesPerPixel)
+                    stdext::throw_exception("Invalid colored sprite run");
+
                 for (int i = 0; i < coloredPixels; ++i) {
                     pixels[writePos++] = buffer[bufferPos++];
                     pixels[writePos++] = buffer[bufferPos++];

--- a/src/client/spritemanager.cpp
+++ b/src/client/spritemanager.cpp
@@ -574,6 +574,9 @@ ImagePtr SpriteManager::getSpriteImageCasual(int id)
                 }
             }
 
+            if (writePos != spriteDataSize)
+                stdext::throw_exception("Incomplete sprite data");
+
             return image;
         }
 

--- a/src/client/thingtype.h
+++ b/src/client/thingtype.h
@@ -239,7 +239,10 @@ public:
     int getDisplacementX() { return getDisplacement().x; }
     int getDisplacementY() { return getDisplacement().y; }
     int getElevation() { return m_elevation; }
-    const Point& getBones(int direction) { return m_bones[direction]; }
+    const Point& getBones(int direction) {
+        static const Point empty;
+        return direction >= 0 && static_cast<size_t>(direction) < m_bones.size() ? m_bones[direction] : empty;
+    }
 
     int getGroundSpeed() { return m_attribs.get<uint16>(ThingAttrGround); }
     int getMaxTextLength() { return m_attribs.has(ThingAttrWritableOnce) ? m_attribs.get<uint16>(ThingAttrWritableOnce) : m_attribs.get<uint16>(ThingAttrWritable); }

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -609,6 +609,8 @@ const ItemTypePtr& ThingTypeManager::getItemType(uint16 id)
 ThingTypeList ThingTypeManager::findThingTypeByAttr(ThingAttr attr, ThingCategory category)
 {
     ThingTypeList ret;
+    if (category >= ThingLastCategory)
+        return ret;
     for(const ThingTypePtr& type : m_thingTypes[category])
         if(type->hasAttr(attr))
             ret.push_back(type);

--- a/src/client/thingtypemanager.cpp
+++ b/src/client/thingtypemanager.cpp
@@ -609,9 +609,10 @@ const ItemTypePtr& ThingTypeManager::getItemType(uint16 id)
 ThingTypeList ThingTypeManager::findThingTypeByAttr(ThingAttr attr, ThingCategory category)
 {
     ThingTypeList ret;
-    if (category >= ThingLastCategory)
+    const auto categoryIndex = static_cast<size_t>(category);
+    if (categoryIndex >= static_cast<size_t>(ThingLastCategory))
         return ret;
-    for(const ThingTypePtr& type : m_thingTypes[category])
+    for(const ThingTypePtr& type : m_thingTypes[categoryIndex])
         if(type->hasAttr(attr))
             ret.push_back(type);
     return ret;

--- a/src/client/thingtypemanager.h
+++ b/src/client/thingtypemanager.h
@@ -66,9 +66,10 @@ public:
 
     const ThingTypePtr& getThingType(uint16 id, ThingCategory category);
     const ItemTypePtr& getItemType(uint16 id);
-    ThingType* rawGetThingType(uint16 id, ThingCategory category) { 
-        VALIDATE(id < m_thingTypes[category].size());
-        return m_thingTypes[category][id].get(); 
+    ThingType* rawGetThingType(uint16 id, ThingCategory category) {
+        if (category >= ThingLastCategory || id >= m_thingTypes[category].size())
+            return m_nullThingType.get();
+        return m_thingTypes[category][id].get();
     }
     ItemType* rawGetItemType(uint16 id) { 
         VALIDATE(id < m_itemTypes.size());
@@ -90,7 +91,9 @@ public:
     bool isXmlLoaded() { return m_xmlLoaded; }
     bool isOtbLoaded() { return m_otbLoaded; }
 
-    bool isValidDatId(uint16 id, ThingCategory category) { return id >= 1 && id < m_thingTypes[category].size(); }
+    bool isValidDatId(uint16 id, ThingCategory category) {
+        return category < ThingLastCategory && id >= 1 && id < m_thingTypes[category].size();
+    }
     bool isValidOtbId(uint16 id) { return id >= 1 && id < m_itemTypes.size(); }
 
 private:

--- a/src/client/thingtypemanager.h
+++ b/src/client/thingtypemanager.h
@@ -67,9 +67,10 @@ public:
     const ThingTypePtr& getThingType(uint16 id, ThingCategory category);
     const ItemTypePtr& getItemType(uint16 id);
     ThingType* rawGetThingType(uint16 id, ThingCategory category) {
-        if (category >= ThingLastCategory || id >= m_thingTypes[category].size())
+        const auto categoryIndex = static_cast<size_t>(category);
+        if (categoryIndex >= static_cast<size_t>(ThingLastCategory) || id >= m_thingTypes[categoryIndex].size())
             return m_nullThingType.get();
-        return m_thingTypes[category][id].get();
+        return m_thingTypes[categoryIndex][id].get();
     }
     ItemType* rawGetItemType(uint16 id) { 
         VALIDATE(id < m_itemTypes.size());
@@ -92,7 +93,9 @@ public:
     bool isOtbLoaded() { return m_otbLoaded; }
 
     bool isValidDatId(uint16 id, ThingCategory category) {
-        return category < ThingLastCategory && id >= 1 && id < m_thingTypes[category].size();
+        const auto categoryIndex = static_cast<size_t>(category);
+        return categoryIndex < static_cast<size_t>(ThingLastCategory) &&
+               id >= 1 && id < m_thingTypes[categoryIndex].size();
     }
     bool isValidOtbId(uint16 id) { return id >= 1 && id < m_itemTypes.size(); }
 

--- a/src/framework/core/filestream.cpp
+++ b/src/framework/core/filestream.cpp
@@ -56,7 +56,7 @@ bool FileStream::initFromGzip(const std::string& buffer)
         return false;
     }
 
-    uint32_t fileSize = *(uint32_t*)(&buffer[buffer.size() - 4]);
+    uint32_t fileSize = stdext::readULE32(reinterpret_cast<const uint8_t*>(&buffer[buffer.size() - 4]));
     if (fileSize > 512 * 1024 * 1024 || fileSize * 2 < buffer.size()) {
         return false;
     }
@@ -70,13 +70,17 @@ bool FileStream::initFromGzip(const std::string& buffer)
         return false;
 
     m_data.grow(fileSize, true);
-    stream.next_out = &m_data[0];
-    stream.avail_out = m_data.size();
+    uint8_t emptyOutput = 0;
+    stream.next_out = fileSize > 0 ? m_data.data() : &emptyOutput;
+    stream.avail_out = fileSize > 0 ? m_data.size() : 1;
 
-    inflate(&stream, Z_SYNC_FLUSH);
+    const int result = inflate(&stream, Z_FINISH);
+    const bool valid = result == Z_STREAM_END && stream.total_out == fileSize;
 
     inflateEnd(&stream);
-    return true;
+    if (!valid)
+        m_data.clear();
+    return valid;
 }
 
 
@@ -544,4 +548,3 @@ void FileStream::throwError(const std::string& message, bool physfsError)
         completeMessage += std::string(": ") + PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode());
     stdext::throw_exception(completeMessage);
 }
-

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -325,8 +325,8 @@ bool ResourceManager::loadDataFromSelf(bool unmountIfMounted) {
     file.close();
     for (size_t i = 0, end = size - 128; i < end; ++i) {
         if (v[i] == 0x50 && v[i + 1] == 0x4b && v[i + 2] == 0x03 && v[i + 3] == 0x04 && v[i + 4] == 0x14) {
-            uint32_t compSize = *(uint32_t*)&v[i + 18];
-            uint32_t decompSize = *(uint32_t*)&v[i + 22];
+            uint32_t compSize = stdext::readULE32(&v[i + 18]);
+            uint32_t decompSize = stdext::readULE32(&v[i + 22]);
             if (compSize < 1024 * 1024 * 512 && decompSize < 1024 * 1024 * 512) {
                 data = std::make_shared<std::vector<uint8_t>>(&v[i], &v[v.size() - 1]);
                 break;
@@ -388,9 +388,18 @@ std::string ResourceManager::readFileContents(const std::string& fileName, bool 
     if(!file)
         stdext::throw_exception(stdext::format("unable to open file '%s': %s", fullPath, PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())));
 
-    int fileSize = PHYSFS_fileLength(file);
-    std::string buffer(fileSize, 0);
-    PHYSFS_readBytes(file, (void*)&buffer[0], fileSize);
+    const PHYSFS_sint64 fileSize = PHYSFS_fileLength(file);
+    constexpr PHYSFS_sint64 MAX_RESOURCE_SIZE = 512LL * 1024 * 1024;
+    if (fileSize < 0 || fileSize > MAX_RESOURCE_SIZE) {
+        PHYSFS_close(file);
+        stdext::throw_exception(stdext::format("invalid file size for '%s'", fullPath));
+    }
+
+    std::string buffer(static_cast<size_t>(fileSize), 0);
+    if (fileSize > 0 && PHYSFS_readBytes(file, buffer.data(), fileSize) != fileSize) {
+        PHYSFS_close(file);
+        stdext::throw_exception(stdext::format("unable to read file '%s'", fullPath));
+    }
     PHYSFS_close(file);
 
     if (safe) {
@@ -429,17 +438,26 @@ bool ResourceManager::isFileEncryptedOrCompressed(const std::string& fileName)
             if (dfile->body.size() < 10)
                 return false;
             fileContent = std::string(dfile->body.begin(), dfile->body.begin() + 10);
-        }
+        } else
+            return false;
     }
 
-    if (!fileContent.empty()) {
+    if (fileContent.empty()) {
         PHYSFS_File* file = PHYSFS_openRead(fullPath.c_str());
         if (!file)
             stdext::throw_exception(stdext::format("unable to open file '%s': %s", fullPath, PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode())));
 
-        int fileSize = std::min<int>(10, PHYSFS_fileLength(file));
+        const PHYSFS_sint64 fileLength = PHYSFS_fileLength(file);
+        if (fileLength < 0) {
+            PHYSFS_close(file);
+            return false;
+        }
+        const size_t fileSize = static_cast<size_t>(std::min<PHYSFS_sint64>(10, fileLength));
         fileContent.resize(fileSize);
-        PHYSFS_readBytes(file, (void*)&fileContent[0], fileSize);
+        if (fileSize > 0 && PHYSFS_readBytes(file, fileContent.data(), fileSize) != fileSize) {
+            PHYSFS_close(file);
+            return false;
+        }
         PHYSFS_close(file);
     }
 
@@ -598,9 +616,17 @@ std::string ResourceManager::fileChecksum(const std::string& path) {
     if(!file)
         return "";
 
-    int fileSize = PHYSFS_fileLength(file);
-    std::string buffer(fileSize, 0);
-    PHYSFS_readBytes(file, (void*)&buffer[0], fileSize);
+    const PHYSFS_sint64 fileSize = PHYSFS_fileLength(file);
+    constexpr PHYSFS_sint64 MAX_CHECKSUM_FILE_SIZE = 512LL * 1024 * 1024;
+    if (fileSize < 0 || fileSize > MAX_CHECKSUM_FILE_SIZE) {
+        PHYSFS_close(file);
+        return "";
+    }
+    std::string buffer(static_cast<size_t>(fileSize), 0);
+    if (fileSize > 0 && PHYSFS_readBytes(file, buffer.data(), fileSize) != fileSize) {
+        PHYSFS_close(file);
+        return "";
+    }
     PHYSFS_close(file);
 
     auto checksum = g_crypt.crc32(buffer, false);
@@ -1027,29 +1053,36 @@ void ResourceManager::encrypt(const std::string& seed) {
 #endif 
 
 bool ResourceManager::decryptBuffer(std::string& buffer) {
-    if (buffer.size() < 5)
+    if (buffer.size() < 4)
         return true;
 
     if (buffer.substr(0, 4).compare("ENC3") != 0) {
         return false;
     }
 
-    uint64_t key = *(uint64_t*)&buffer[4];
-    uint32_t compressed_size = *(uint32_t*)&buffer[12];
-    uint32_t size = *(uint32_t*)&buffer[16];
-    uint32_t adler = *(uint32_t*)&buffer[20];
+    if (buffer.size() < 24)
+        return false;
 
-    if (compressed_size < buffer.size() - 24)
+    const auto* header = reinterpret_cast<const uint8_t*>(buffer.data());
+    const uint64_t key = stdext::readULE64(header + 4);
+    const uint32_t compressed_size = stdext::readULE32(header + 12);
+    const uint32_t size = stdext::readULE32(header + 16);
+    const uint32_t adler = stdext::readULE32(header + 20);
+    constexpr uint32_t MAX_DECRYPTED_SIZE = 512 * 1024 * 1024;
+
+    if (compressed_size == 0 || compressed_size > buffer.size() - 24 || size > MAX_DECRYPTED_SIZE)
         return false;
 
     g_crypt.bdecrypt((uint8_t*)&buffer[24], compressed_size, key);
     std::string new_buffer;
     new_buffer.resize(size);
     unsigned long new_buffer_size = new_buffer.size();
-    if (uncompress((uint8_t*)new_buffer.data(), &new_buffer_size, (uint8_t*)&buffer[24], compressed_size) != Z_OK)
+    if (uncompress(reinterpret_cast<uint8_t*>(new_buffer.data()), &new_buffer_size,
+                   reinterpret_cast<uint8_t*>(&buffer[24]), compressed_size) != Z_OK ||
+        new_buffer_size != size)
         return false;
 
-    uint32_t addlerCheck = stdext::adler32((const uint8_t*)&new_buffer[0], size);
+    uint32_t addlerCheck = stdext::adler32(reinterpret_cast<const uint8_t*>(new_buffer.data()), size);
     if (adler != addlerCheck) {
         uint32_t cseed = adler ^ addlerCheck;
         if (m_customEncryption == 0) {
@@ -1070,9 +1103,9 @@ bool ResourceManager::encryptBuffer(std::string& buffer, uint32_t seed) {
         return false; // already encrypted
 
     // not random beacause it would require to update to new files each time
-    int64_t key = stdext::adler32((const uint8_t*)&buffer[0], buffer.size());
+    int64_t key = stdext::adler32(reinterpret_cast<const uint8_t*>(buffer.data()), buffer.size());
     key <<= 32;
-    key += stdext::adler32((const uint8_t*)&buffer[0], buffer.size() / 2);
+    key += stdext::adler32(reinterpret_cast<const uint8_t*>(buffer.data()), buffer.size() / 2);
 
     std::string new_buffer(24 + buffer.size() * 2, '0');
     new_buffer[0] = 'E';
@@ -1087,10 +1120,11 @@ bool ResourceManager::encryptBuffer(std::string& buffer, uint32_t seed) {
     }
     new_buffer.resize(24 + dstLen);
 
-    *(int64_t*)&new_buffer[4] = key;
-    *(uint32_t*)&new_buffer[12] = (uint32_t)dstLen;
-    *(uint32_t*)&new_buffer[16] = (uint32_t)buffer.size();
-    *(uint32_t*)&new_buffer[20] = ((uint32_t)stdext::adler32((const uint8_t*)&buffer[0], buffer.size())) ^ seed;
+    auto* header = reinterpret_cast<uint8_t*>(new_buffer.data());
+    stdext::writeULE64(header + 4, static_cast<uint64_t>(key));
+    stdext::writeULE32(header + 12, static_cast<uint32_t>(dstLen));
+    stdext::writeULE32(header + 16, static_cast<uint32_t>(buffer.size()));
+    stdext::writeULE32(header + 20, stdext::adler32(reinterpret_cast<const uint8_t*>(buffer.data()), buffer.size()) ^ seed);
 
     g_crypt.bencrypt((uint8_t*)&new_buffer[0] + 24, new_buffer.size() - 24, key);
     buffer = new_buffer;

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -1029,6 +1029,18 @@ void ResourceManager::encrypt(const std::string& seed) {
     while (!toEncrypt.empty()) {
         auto it = toEncrypt.front();
         toEncrypt.pop();
+
+        std::error_code fileSizeError;
+        const auto fileSize = std::filesystem::file_size(it, fileSizeError);
+        if (fileSizeError) {
+            g_logger.error(stdext::format("%s - unable to determine file size", it.string()));
+            continue;
+        }
+        if (fileSize > MAX_ENCRYPTED_PAYLOAD_SIZE) {
+            g_logger.error(stdext::format("%s - exceeds the 512 MiB encryption limit", it.string()));
+            continue;
+        }
+
         std::ifstream in_file(it, std::ios::binary);
         if (!in_file.is_open())
             continue;

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -48,6 +48,15 @@
 ResourceManager g_resources;
 static const std::string INIT_FILENAME = "init.lua";
 static constexpr size_t MAX_ENCRYPTED_PAYLOAD_SIZE = 512ULL * 1024 * 1024;
+static constexpr size_t ENC3_HEADER_SIZE = 24;
+
+static bool canEncryptPayload(size_t payloadSize)
+{
+    if (payloadSize > MAX_ENCRYPTED_PAYLOAD_SIZE)
+        return false;
+    return static_cast<size_t>(compressBound(static_cast<uLong>(payloadSize))) <=
+           MAX_ENCRYPTED_PAYLOAD_SIZE - ENC3_HEADER_SIZE;
+}
 
 void ResourceManager::init(const char *argv0)
 {
@@ -1038,7 +1047,7 @@ void ResourceManager::encrypt(const std::string& seed) {
             }
         }
 
-        if (buffer.size() > MAX_ENCRYPTED_PAYLOAD_SIZE) {
+        if (!canEncryptPayload(buffer.size())) {
             g_logger.error(stdext::format("%s - exceeds the 512 MiB encryption limit", it.string()));
             continue;
         }
@@ -1066,7 +1075,7 @@ bool ResourceManager::decryptBuffer(std::string& buffer) {
         return false;
     }
 
-    if (buffer.size() < 24)
+    if (buffer.size() < ENC3_HEADER_SIZE)
         return false;
 
     const auto* header = reinterpret_cast<const uint8_t*>(buffer.data());
@@ -1074,15 +1083,18 @@ bool ResourceManager::decryptBuffer(std::string& buffer) {
     const uint32_t compressed_size = stdext::readULE32(header + 12);
     const uint32_t size = stdext::readULE32(header + 16);
     const uint32_t adler = stdext::readULE32(header + 20);
-    if (compressed_size == 0 || compressed_size > buffer.size() - 24 || size > MAX_ENCRYPTED_PAYLOAD_SIZE)
+    if (compressed_size == 0 ||
+        compressed_size > MAX_ENCRYPTED_PAYLOAD_SIZE ||
+        compressed_size > buffer.size() - ENC3_HEADER_SIZE ||
+        size > MAX_ENCRYPTED_PAYLOAD_SIZE)
         return false;
 
-    g_crypt.bdecrypt((uint8_t*)&buffer[24], compressed_size, key);
+    g_crypt.bdecrypt((uint8_t*)&buffer[ENC3_HEADER_SIZE], compressed_size, key);
     std::string new_buffer;
     new_buffer.resize(size);
     unsigned long new_buffer_size = new_buffer.size();
     if (uncompress(reinterpret_cast<uint8_t*>(new_buffer.data()), &new_buffer_size,
-                   reinterpret_cast<uint8_t*>(&buffer[24]), compressed_size) != Z_OK ||
+                   reinterpret_cast<uint8_t*>(&buffer[ENC3_HEADER_SIZE]), compressed_size) != Z_OK ||
         new_buffer_size != size)
         return false;
 
@@ -1103,7 +1115,7 @@ bool ResourceManager::decryptBuffer(std::string& buffer) {
 
 #ifdef WITH_ENCRYPTION
 bool ResourceManager::encryptBuffer(std::string& buffer, uint32_t seed) {
-    if (buffer.size() > MAX_ENCRYPTED_PAYLOAD_SIZE)
+    if (!canEncryptPayload(buffer.size()))
         return false;
 
     if (buffer.size() >= 4 && buffer.substr(0, 4).compare("ENC3") == 0)
@@ -1114,18 +1126,18 @@ bool ResourceManager::encryptBuffer(std::string& buffer, uint32_t seed) {
     key <<= 32;
     key += stdext::adler32(reinterpret_cast<const uint8_t*>(buffer.data()), buffer.size() / 2);
 
-    std::string new_buffer(24 + buffer.size() * 2, '0');
+    unsigned long dstLen = compressBound(static_cast<uLong>(buffer.size()));
+    std::string new_buffer(ENC3_HEADER_SIZE + static_cast<size_t>(dstLen), '0');
     new_buffer[0] = 'E';
     new_buffer[1] = 'N';
     new_buffer[2] = 'C';
     new_buffer[3] = '3';
 
-    unsigned long dstLen = new_buffer.size() - 24;
-    if (compress((uint8_t*)&new_buffer[24], &dstLen, (const uint8_t*)buffer.data(), buffer.size()) != Z_OK) {
+    if (compress((uint8_t*)&new_buffer[ENC3_HEADER_SIZE], &dstLen, (const uint8_t*)buffer.data(), buffer.size()) != Z_OK) {
         g_logger.error("Error while compressing");
         return false;
     }
-    new_buffer.resize(24 + dstLen);
+    new_buffer.resize(ENC3_HEADER_SIZE + dstLen);
 
     auto* header = reinterpret_cast<uint8_t*>(new_buffer.data());
     stdext::writeULE64(header + 4, static_cast<uint64_t>(key));
@@ -1133,7 +1145,7 @@ bool ResourceManager::encryptBuffer(std::string& buffer, uint32_t seed) {
     stdext::writeULE32(header + 16, static_cast<uint32_t>(buffer.size()));
     stdext::writeULE32(header + 20, stdext::adler32(reinterpret_cast<const uint8_t*>(buffer.data()), buffer.size()) ^ seed);
 
-    g_crypt.bencrypt((uint8_t*)&new_buffer[0] + 24, new_buffer.size() - 24, key);
+    g_crypt.bencrypt((uint8_t*)&new_buffer[0] + ENC3_HEADER_SIZE, new_buffer.size() - ENC3_HEADER_SIZE, key);
     buffer = new_buffer;
     return true;
 }

--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -47,6 +47,7 @@
 
 ResourceManager g_resources;
 static const std::string INIT_FILENAME = "init.lua";
+static constexpr size_t MAX_ENCRYPTED_PAYLOAD_SIZE = 512ULL * 1024 * 1024;
 
 void ResourceManager::init(const char *argv0)
 {
@@ -1037,6 +1038,11 @@ void ResourceManager::encrypt(const std::string& seed) {
             }
         }
 
+        if (buffer.size() > MAX_ENCRYPTED_PAYLOAD_SIZE) {
+            g_logger.error(stdext::format("%s - exceeds the 512 MiB encryption limit", it.string()));
+            continue;
+        }
+
         if (!encryptBuffer(buffer, uintseed)) { // already encrypted
             g_logger.info(stdext::format("%s - already encrypted", it.string()));
             continue;
@@ -1068,9 +1074,7 @@ bool ResourceManager::decryptBuffer(std::string& buffer) {
     const uint32_t compressed_size = stdext::readULE32(header + 12);
     const uint32_t size = stdext::readULE32(header + 16);
     const uint32_t adler = stdext::readULE32(header + 20);
-    constexpr uint32_t MAX_DECRYPTED_SIZE = 512 * 1024 * 1024;
-
-    if (compressed_size == 0 || compressed_size > buffer.size() - 24 || size > MAX_DECRYPTED_SIZE)
+    if (compressed_size == 0 || compressed_size > buffer.size() - 24 || size > MAX_ENCRYPTED_PAYLOAD_SIZE)
         return false;
 
     g_crypt.bdecrypt((uint8_t*)&buffer[24], compressed_size, key);
@@ -1099,6 +1103,9 @@ bool ResourceManager::decryptBuffer(std::string& buffer) {
 
 #ifdef WITH_ENCRYPTION
 bool ResourceManager::encryptBuffer(std::string& buffer, uint32_t seed) {
+    if (buffer.size() > MAX_ENCRYPTED_PAYLOAD_SIZE)
+        return false;
+
     if (buffer.size() >= 4 && buffer.substr(0, 4).compare("ENC3") == 0)
         return false; // already encrypted
 

--- a/src/framework/graphics/apngloader.cpp
+++ b/src/framework/graphics/apngloader.cpp
@@ -955,8 +955,20 @@ void save_png(std::stringstream& f, unsigned int width, unsigned int height, int
     unsigned char* zbuf1     = (unsigned char*)malloc(zbuf_size);
     unsigned char* zbuf2     = (unsigned char*)malloc(zbuf_size);
 
-    if(!row_buf || !sub_row || !up_row || !avg_row || !paeth_row || !zbuf1 || !zbuf2)
+    const auto free_buffers = [&]() {
+        free(zbuf1);
+        free(zbuf2);
+        free(row_buf);
+        free(sub_row);
+        free(up_row);
+        free(avg_row);
+        free(paeth_row);
+    };
+
+    if(!row_buf || !sub_row || !up_row || !avg_row || !paeth_row || !zbuf1 || !zbuf2) {
+        free_buffers();
         return;
+    }
 
     row_buf[0]   = 0;
     sub_row[0]   = 1;
@@ -968,13 +980,20 @@ void save_png(std::stringstream& f, unsigned int width, unsigned int height, int
     zstream1.zalloc    = Z_NULL;
     zstream1.zfree     = Z_NULL;
     zstream1.opaque    = Z_NULL;
-    deflateInit2(&zstream1, 3, 8, 15, 8, Z_DEFAULT_STRATEGY);
+    if(deflateInit2(&zstream1, 3, 8, 15, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
+        free_buffers();
+        return;
+    }
 
     zstream2.data_type = Z_BINARY;
     zstream2.zalloc    = Z_NULL;
     zstream2.zfree     = Z_NULL;
     zstream2.opaque    = Z_NULL;
-    deflateInit2(&zstream2, 3, 8, 15, 8, Z_FILTERED);
+    if(deflateInit2(&zstream2, 3, 8, 15, 8, Z_FILTERED) != Z_OK) {
+        deflateEnd(&zstream1);
+        free_buffers();
+        return;
+    }
 
     int a, b, c, pa, pb, pc, p, v;
     unsigned char* prev;
@@ -1123,13 +1142,7 @@ void save_png(std::stringstream& f, unsigned int width, unsigned int height, int
 
     deflateEnd(&zstream1);
     deflateEnd(&zstream2);
-    free(zbuf1);
-    free(zbuf2);
-    free(row_buf);
-    free(sub_row);
-    free(up_row);
-    free(avg_row);
-    free(paeth_row);
+    free_buffers();
 }
 
 void free_apng(struct apng_data *apng)
@@ -1139,4 +1152,3 @@ void free_apng(struct apng_data *apng)
     if(apng->frames_delay)
         free(apng->frames_delay);
 }
-

--- a/src/framework/graphics/image.cpp
+++ b/src/framework/graphics/image.cpp
@@ -135,7 +135,7 @@ void Image::blit(const Point& dest, const ImagePtr& other)
             const int p = (y * width + x) * 4;
             if (otherPixels[p + 3] != 0) {
                 const int pos = (destinationY * destinationWidth + destinationX) * 4;
-                *(uint32_t*)&m_pixels[pos] = *(uint32_t*)&otherPixels[p];
+                memcpy(&m_pixels[pos], &otherPixels[p], 4);
             }
         }
     }

--- a/src/framework/graphics/image.h
+++ b/src/framework/graphics/image.h
@@ -56,7 +56,7 @@ public:
     }
 
     std::vector<uint8>& getPixels() { return m_pixels; }
-    uint8* getPixelData() { return &m_pixels[0]; }
+    uint8* getPixelData() { return m_pixels.data(); }
     int getPixelCount() { return m_size.area(); }
     const Size& getSize() { return m_size; }
     int getWidth() { return m_size.width(); }

--- a/src/framework/graphics/texturemanager.cpp
+++ b/src/framework/graphics/texturemanager.cpp
@@ -40,12 +40,10 @@ void TextureManager::init()
 void TextureManager::terminate()
 {
     m_textures.clear();
-    m_animatedTextures.clear();
 }
 
 void TextureManager::clearCache()
 {
-    m_animatedTextures.clear();
     m_textures.clear();
 }
 
@@ -130,7 +128,6 @@ TexturePtr TextureManager::loadTexture(std::stringstream& file, const std::strin
                 frames.emplace_back(std::make_shared<Image>(imageSize, apng.bpp, frameData));
             }
             auto animatedTexture = std::make_shared<AnimatedTexture>(imageSize, frames, framesDelay);
-            m_animatedTextures.push_back(animatedTexture);
             texture = animatedTexture;
         } else {
             auto image = std::make_shared<Image>(imageSize, apng.bpp, apng.pdata);

--- a/src/framework/graphics/texturemanager.h
+++ b/src/framework/graphics/texturemanager.h
@@ -42,7 +42,6 @@ public:
 
 private:
     std::unordered_map<std::string, TexturePtr> m_textures;
-    std::vector<AnimatedTexturePtr> m_animatedTextures;
     ScheduledEventPtr m_liveReloadEvent;
     std::list<uint> m_texturesToRelease;
 };

--- a/src/framework/http/http.cpp
+++ b/src/framework/http/http.cpp
@@ -4,6 +4,7 @@
 #include <framework/util/stats.h>
 #include <framework/core/eventdispatcher.h>
 
+#include <chrono>
 #include <future>
 
 #include "http.h"
@@ -16,9 +17,17 @@ Http g_http;
 
 void Http::init() {
     m_working = true;
-    m_thread = std::thread([this] {
-        m_ios.run();
-    });
+    m_ioRunning = true;
+    try {
+        m_thread = std::thread([this] {
+            m_ios.run();
+            m_ioRunning = false;
+        });
+    } catch (...) {
+        m_ioRunning = false;
+        m_working = false;
+        throw;
+    }
 }
 
 void Http::terminate() {
@@ -26,37 +35,58 @@ void Http::terminate() {
         return;
     m_working = false;
 #ifndef __EMSCRIPTEN__
-    if (m_thread.joinable()) {
+    bool stopBeforeJoin = false;
+    if (m_thread.joinable() && m_ioRunning) {
         auto shutdownPromise = std::make_shared<std::promise<void>>();
         auto shutdownComplete = shutdownPromise->get_future();
-        boost::asio::post(m_ios, [this, shutdownPromise] {
-            std::vector<std::shared_ptr<HttpSession>> sessions;
-            sessions.reserve(m_operations.size());
-            for (auto& op : m_operations) {
-                op.second->canceled = true;
-                if (auto session = op.second->session.lock())
-                    sessions.push_back(std::move(session));
-            }
+        try {
+            boost::asio::post(m_ios, [this, shutdownPromise] {
+                try {
+                    std::vector<std::shared_ptr<HttpSession>> sessions;
+                    sessions.reserve(m_operations.size());
+                    for (auto& op : m_operations) {
+                        op.second->canceled = true;
+                        if (auto session = op.second->session.lock())
+                            sessions.push_back(std::move(session));
+                    }
 
-            std::vector<std::shared_ptr<WebsocketSession>> websockets;
-            websockets.reserve(m_websockets.size());
-            for (auto& ws : m_websockets)
-                websockets.push_back(ws.second);
+                    std::vector<std::shared_ptr<WebsocketSession>> websockets;
+                    websockets.reserve(m_websockets.size());
+                    for (auto& ws : m_websockets)
+                        websockets.push_back(ws.second);
 
-            for (auto& session : sessions)
-                session->cancel();
-            for (auto& ws : websockets)
-                ws->close();
-
+                    for (auto& session : sessions) {
+                        try {
+                            session->cancel();
+                        } catch (...) {
+                        }
+                    }
+                    for (auto& ws : websockets) {
+                        try {
+                            ws->close();
+                        } catch (...) {
+                        }
+                    }
+                } catch (...) {
+                }
+                shutdownPromise->set_value();
+            });
+        } catch (...) {
             shutdownPromise->set_value();
-        });
-        shutdownComplete.wait();
-        m_guard.reset();
-        m_thread.join();
+            stopBeforeJoin = true;
+        }
+        if (shutdownComplete.wait_for(std::chrono::seconds(DefaultTimeout)) != std::future_status::ready)
+            stopBeforeJoin = true;
     } else {
         for (auto& op : m_operations)
             op.second->canceled = true;
+        stopBeforeJoin = true;
     }
+    m_guard.reset();
+    if (stopBeforeJoin)
+        m_ios.stop();
+    if (m_thread.joinable())
+        m_thread.join();
     m_ios.stop();
     m_websockets.clear();
 #else

--- a/src/framework/http/http.cpp
+++ b/src/framework/http/http.cpp
@@ -14,7 +14,7 @@ Http g_http;
 
 void Http::init() {
     m_working = true;
-    m_thread = std::thread([&] {
+    m_thread = std::thread([this] {
         m_ios.run();
     });
 }
@@ -60,12 +60,12 @@ int Http::get(const std::string& url, int timeout, const std::map<std::string, s
         timeout = DefaultTimeout;
     int operationId = m_operationId++;
 
-    boost::asio::post(m_ios, [&, url, timeout, operationId, headers] {
+    boost::asio::post(m_ios, [this, url, timeout, operationId, headers] {
         auto request = std::make_shared<HttpRequest>(url, headers, timeout);
         auto result = std::make_shared<HttpResult>(url, operationId);
         m_operations[operationId] = result;
 #ifndef __EMSCRIPTEN__
-        auto session = std::make_shared<HttpSession>(m_ios, url, m_userAgent, request, result, [&](HttpResult_ptr result) {
+        auto session = std::make_shared<HttpSession>(m_ios, url, m_userAgent, request, result, [this, operationId](HttpResult_ptr result) {
             bool finished = result->finished;
             g_dispatcher.addEventEx("Http::onGet", [result, finished]() {
                 if (!finished) {
@@ -94,12 +94,12 @@ int Http::post(const std::string& url, const std::string& data, int timeout, con
     }
 
     int operationId = m_operationId++;
-    boost::asio::post(m_ios, [&, url, data, timeout, operationId, headers] {
+    boost::asio::post(m_ios, [this, url, data, timeout, operationId, headers] {
         auto request = std::make_shared<HttpRequest>(url, headers, data, timeout);
         auto result = std::make_shared<HttpResult>(url, operationId);
         m_operations[operationId] = result;
 #ifndef __EMSCRIPTEN__
-        auto session = std::make_shared<HttpSession>(m_ios, url, m_userAgent, request, result, [&](HttpResult_ptr result) {
+        auto session = std::make_shared<HttpSession>(m_ios, url, m_userAgent, request, result, [this, operationId](HttpResult_ptr result) {
             bool finished = result->finished;
             g_dispatcher.addEventEx("Http::onPost", [result, finished]() {
                 if (!finished) {
@@ -123,12 +123,12 @@ int Http::download(const std::string& url, std::string path, int timeout, const 
         timeout = DefaultTimeout;
 
     int operationId = m_operationId++;
-    boost::asio::post(m_ios, [&, url, path, timeout, operationId, headers] {
+    boost::asio::post(m_ios, [this, url, path, timeout, operationId, headers] {
         auto request = std::make_shared<HttpRequest>(url, headers, timeout);
         auto result = std::make_shared<HttpResult>(url, operationId);
         m_operations[operationId] = result;
 #ifndef __EMSCRIPTEN__
-        auto session = std::make_shared<HttpSession>(m_ios, url, m_userAgent, request, result, [&, path](HttpResult_ptr result) {
+        auto session = std::make_shared<HttpSession>(m_ios, url, m_userAgent, request, result, [this, path, operationId](HttpResult_ptr result) {
             m_speed = ((result->size) * 10) / (1 + stdext::micros() - m_lastSpeedUpdate);
             m_lastSpeedUpdate = stdext::micros();
 
@@ -140,7 +140,7 @@ int Http::download(const std::string& url, std::string path, int timeout, const 
                 return;
             }
             std::string checksum = g_crypt.crc32(std::string(result->body.begin(), result->body.end()), false);
-            g_dispatcher.addEventEx("Http::onDownload", [&, result, path, checksum]() {
+            g_dispatcher.addEventEx("Http::onDownload", [this, result, path, checksum]() {
                 if (result->error.empty()) {
                     if (!path.empty() && path[0] == '/')
                         m_downloads[path.substr(1)] = result;
@@ -163,13 +163,13 @@ int Http::ws(const std::string& url, int timeout)
         timeout = DefaultTimeout;
     int operationId = m_operationId++;
 
-    boost::asio::post(m_ios, [&, url, timeout, operationId] {
+    boost::asio::post(m_ios, [this, url, timeout, operationId] {
         auto result = std::make_shared<HttpResult>();
         result->url = url;
         result->operationId = operationId;
         m_operations[operationId] = result;
 #ifndef __EMSCRIPTEN__
-        auto session = std::make_shared<WebsocketSession>(m_ios, url, m_userAgent, timeout, result, [&, result](WebsocketCallbackType type, std::string message) {
+        auto session = std::make_shared<WebsocketSession>(m_ios, url, m_userAgent, timeout, result, [this, result](WebsocketCallbackType type, std::string message) {
             g_dispatcher.addEventEx("Http::ws", [result, type, message]() {
                 if (type == WEBSOCKET_OPEN) {
                     g_lua.callGlobalField("g_http", "onWsOpen", result->operationId, message);
@@ -197,7 +197,7 @@ int Http::ws(const std::string& url, int timeout)
 bool Http::wsSend(int operationId, std::string message)
 {
 #ifndef __EMSCRIPTEN__
-    boost::asio::post(m_ios, [&, operationId, message] {
+    boost::asio::post(m_ios, [this, operationId, message] {
         auto wit = m_websockets.find(operationId);
         if (wit == m_websockets.end()) {
             return;
@@ -217,7 +217,7 @@ bool Http::wsClose(int operationId)
 
 bool Http::cancel(int id) {
 #ifndef __EMSCRIPTEN__
-    boost::asio::post(m_ios, [&, id] {
+    boost::asio::post(m_ios, [this, id] {
         auto wit = m_websockets.find(id);
         if (wit != m_websockets.end()) {
             wit->second->close();

--- a/src/framework/http/http.cpp
+++ b/src/framework/http/http.cpp
@@ -75,7 +75,7 @@ void Http::terminate() {
             shutdownPromise->set_value();
             stopBeforeJoin = true;
         }
-        if (shutdownComplete.wait_for(std::chrono::seconds(DefaultTimeout)) != std::future_status::ready)
+        if (shutdownComplete.wait_for(std::chrono::seconds(ShutdownTimeout)) != std::future_status::ready)
             stopBeforeJoin = true;
     } else {
         for (auto& op : m_operations)
@@ -87,7 +87,6 @@ void Http::terminate() {
         m_ios.stop();
     if (m_thread.joinable())
         m_thread.join();
-    m_ios.stop();
     m_websockets.clear();
 #else
     for (auto& op : m_operations)

--- a/src/framework/http/http.cpp
+++ b/src/framework/http/http.cpp
@@ -4,6 +4,8 @@
 #include <framework/util/stats.h>
 #include <framework/core/eventdispatcher.h>
 
+#include <future>
+
 #include "http.h"
 #ifndef __EMSCRIPTEN__
 #include "session.h"
@@ -25,17 +27,30 @@ void Http::terminate() {
     m_working = false;
 #ifndef __EMSCRIPTEN__
     if (m_thread.joinable()) {
-        boost::asio::post(m_ios, [this] {
-            for (auto& op : m_operations)
+        auto shutdownPromise = std::make_shared<std::promise<void>>();
+        auto shutdownComplete = shutdownPromise->get_future();
+        boost::asio::post(m_ios, [this, shutdownPromise] {
+            std::vector<std::shared_ptr<HttpSession>> sessions;
+            sessions.reserve(m_operations.size());
+            for (auto& op : m_operations) {
                 op.second->canceled = true;
+                if (auto session = op.second->session.lock())
+                    sessions.push_back(std::move(session));
+            }
 
             std::vector<std::shared_ptr<WebsocketSession>> websockets;
             websockets.reserve(m_websockets.size());
             for (auto& ws : m_websockets)
                 websockets.push_back(ws.second);
+
+            for (auto& session : sessions)
+                session->cancel();
             for (auto& ws : websockets)
                 ws->close();
+
+            shutdownPromise->set_value();
         });
+        shutdownComplete.wait();
         m_guard.reset();
         m_thread.join();
     } else {

--- a/src/framework/http/http.cpp
+++ b/src/framework/http/http.cpp
@@ -24,19 +24,35 @@ void Http::terminate() {
         return;
     m_working = false;
 #ifndef __EMSCRIPTEN__
-    for (auto& ws : m_websockets) {
-        ws.second->close();
-    }
-#endif
-    for (auto& op : m_operations) {
-        op.second->canceled = true;
-    }
-    m_guard.reset();
-    if (!m_thread.joinable()) {
-        stdext::millisleep(100);
+    if (m_thread.joinable()) {
+        boost::asio::post(m_ios, [this] {
+            for (auto& op : m_operations)
+                op.second->canceled = true;
+
+            std::vector<std::shared_ptr<WebsocketSession>> websockets;
+            websockets.reserve(m_websockets.size());
+            for (auto& ws : m_websockets)
+                websockets.push_back(ws.second);
+            for (auto& ws : websockets)
+                ws->close();
+        });
+        m_guard.reset();
+        m_thread.join();
+    } else {
+        for (auto& op : m_operations)
+            op.second->canceled = true;
     }
     m_ios.stop();
-    m_thread.join();
+    m_websockets.clear();
+#else
+    for (auto& op : m_operations)
+        op.second->canceled = true;
+    m_guard.reset();
+    m_ios.stop();
+    if (m_thread.joinable())
+        m_thread.join();
+#endif
+    m_operations.clear();
 }
 
 int Http::get(const std::string& url, int timeout, const std::map<std::string, std::string>& headers) {
@@ -167,6 +183,7 @@ int Http::ws(const std::string& url, int timeout)
             });
             if (type == WEBSOCKET_CLOSE) {
                 m_websockets.erase(result->operationId);
+                m_operations.erase(result->operationId);
             }
         });
         m_websockets[result->operationId] = session;
@@ -218,4 +235,3 @@ bool Http::cancel(int id) {
 #endif
     return true;
 }
-

--- a/src/framework/http/http.h
+++ b/src/framework/http/http.h
@@ -2,6 +2,7 @@
 #define HTTP_H
 
 #include <framework/global.h>
+#include <atomic>
 #include "result.h"
 
 class WebsocketSession;
@@ -50,6 +51,7 @@ private:
     int m_speed = 0;
     size_t m_lastSpeedUpdate = 0;
     std::thread m_thread;
+    std::atomic_bool m_ioRunning{ false };
     boost::asio::io_context m_ios;
     boost::asio::executor_work_guard<boost::asio::io_context::executor_type> m_guard;
     std::map<int, HttpResult_ptr> m_operations;

--- a/src/framework/http/http.h
+++ b/src/framework/http/http.h
@@ -46,6 +46,8 @@ public:
     }
 
 private:
+    static constexpr int ShutdownTimeout = 5;
+
     bool m_working = false;
     int m_operationId = 1;
     int m_speed = 0;

--- a/src/framework/http/session.h
+++ b/src/framework/http/session.h
@@ -25,7 +25,10 @@ public:
     };
 
     void start();
-    void cancel() { onError("canceled"); }
+    void cancel() {
+        m_resolver.cancel();
+        onError("canceled");
+    }
     
 private:
     boost::asio::io_service& m_service;

--- a/src/framework/http/websocket.cpp
+++ b/src/framework/http/websocket.cpp
@@ -69,6 +69,8 @@ void WebsocketSession::send(std::string data)
 
 
 void WebsocketSession::on_resolve(const boost::system::error_code& ec, boost::asio::ip::tcp::resolver::iterator iterator) {
+    if (m_closed)
+        return;
     if (ec)
         return onError("resolve error", ec.message());
     iterator->endpoint().port(m_port);
@@ -80,6 +82,8 @@ void WebsocketSession::on_resolve(const boost::system::error_code& ec, boost::as
 }
 
 void WebsocketSession::on_connect(const boost::system::error_code& ec) {
+    if (m_closed)
+        return;
     if (ec)
         return onError("connection error", ec.message());
 
@@ -162,6 +166,7 @@ void WebsocketSession::on_read(const boost::system::error_code& ec, size_t bytes
 
 void WebsocketSession::close() {
     m_timer.cancel();
+    m_resolver.cancel();
     if (!m_closed) {
         m_closed = true;
         m_callback(WEBSOCKET_CLOSE, "");

--- a/src/framework/http/websocket.h
+++ b/src/framework/http/websocket.h
@@ -45,9 +45,9 @@ private:
     HttpResult_ptr m_result;
     boost::asio::steady_timer m_timer;
     int m_timeout;
-    bool m_closed;
+    bool m_closed = true;
     std::string m_domain;
-    int m_port;
+    int m_port = 0;
 
     std::shared_ptr<boost::beast::websocket::stream<boost::beast::tcp_stream>> m_socket;
     std::shared_ptr<boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>>> m_ssl;

--- a/src/framework/net/inputmessage.cpp
+++ b/src/framework/net/inputmessage.cpp
@@ -38,12 +38,34 @@ void InputMessage::reset()
 
 void InputMessage::setBuffer(const std::string& buffer)
 {
-    int len = buffer.size();
+    const size_t len = buffer.size();
     checkWrite(MAX_HEADER_SIZE + len);
-    memcpy(m_buffer + MAX_HEADER_SIZE, buffer.c_str(), len);
+    memcpy(m_buffer + MAX_HEADER_SIZE, buffer.data(), len);
     m_readPos = MAX_HEADER_SIZE;
     m_headerPos = MAX_HEADER_SIZE;
-    m_messageSize = len;
+    m_messageSize = static_cast<uint32>(len);
+}
+
+void InputMessage::skipBytes(uint32 bytes)
+{
+    checkRead(bytes);
+    m_readPos += bytes;
+}
+
+void InputMessage::setReadPos(uint32 readPos)
+{
+    if (readPos < m_headerPos || readPos > BUFFER_MAXSIZE ||
+        readPos - m_headerPos > m_messageSize)
+        throw stdext::exception("InputMessage invalid read position");
+    m_readPos = readPos;
+}
+
+void InputMessage::setMessageSize(uint32 size)
+{
+    if (size > BUFFER_MAXSIZE - m_headerPos ||
+        m_readPos < m_headerPos || m_readPos - m_headerPos > size)
+        throw stdext::exception("InputMessage invalid message size");
+    m_messageSize = size;
 }
 
 uint8 InputMessage::getU8()
@@ -103,7 +125,7 @@ bool InputMessage::decryptRsa(int size)
 
 void InputMessage::fillBuffer(uint8 *buffer, uint32 size)
 {
-    checkWrite(m_readPos + size);
+    checkWrite(static_cast<size_t>(m_readPos) + size);
     memcpy(m_buffer + m_readPos, buffer, size);
     m_messageSize += size;
 }
@@ -122,21 +144,24 @@ bool InputMessage::readChecksum()
     return receivedCheck == checksum;
 }
 
-bool InputMessage::canRead(int bytes)
+bool InputMessage::canRead(uint32 bytes)
 {
-    if((m_readPos - m_headerPos + bytes > m_messageSize) || (m_readPos + bytes > BUFFER_MAXSIZE))
+    if (m_readPos < m_headerPos || m_readPos > BUFFER_MAXSIZE)
         return false;
-    return true;
+    const uint32 consumed = m_readPos - m_headerPos;
+    return consumed <= m_messageSize &&
+           bytes <= m_messageSize - consumed &&
+           bytes <= BUFFER_MAXSIZE - m_readPos;
 }
-void InputMessage::checkRead(int bytes)
+void InputMessage::checkRead(uint32 bytes)
 {
     if(!canRead(bytes))
         throw stdext::exception("InputMessage eof reached");
 }
 
-void InputMessage::checkWrite(int bytes)
+void InputMessage::checkWrite(size_t endPos)
 {
-    if(bytes > BUFFER_MAXSIZE)
+    if(endPos > BUFFER_MAXSIZE)
         throw stdext::exception("InputMessage max buffer size reached");
 }
 

--- a/src/framework/net/inputmessage.h
+++ b/src/framework/net/inputmessage.h
@@ -41,8 +41,8 @@ public:
     std::string getBuffer() { return std::string((char*)m_buffer + m_headerPos, m_messageSize); }
     std::string getBodyBuffer() { return std::string((char*)m_buffer + MAX_HEADER_SIZE, m_messageSize - getHeaderSize()); }
 
-    void skipBytes(uint32 bytes) { m_readPos += bytes; }
-    void setReadPos(uint32 readPos) { m_readPos = readPos; }
+    void skipBytes(uint32 bytes);
+    void setReadPos(uint32 readPos);
     uint8 getU8();
     uint16 getU16();
     uint32 getU32();
@@ -71,7 +71,7 @@ protected:
     void fillBuffer(uint8 *buffer, uint32 size);
 
     void setHeaderSize(uint32 size);
-    void setMessageSize(uint32 size) { m_messageSize = size; }
+    void setMessageSize(uint32 size);
 
     uint8* getReadBuffer() { return m_buffer + m_readPos; }
     uint8* getHeaderBuffer() { return m_buffer + m_headerPos; }
@@ -85,9 +85,9 @@ protected:
     friend class Protocol;
 
 private:
-    bool canRead(int bytes);
-    void checkRead(int bytes);
-    void checkWrite(int bytes);
+    bool canRead(uint32 bytes);
+    void checkRead(uint32 bytes);
+    void checkWrite(size_t endPos);
 
     uint32 m_headerPos;
     uint32 m_readPos;

--- a/src/framework/net/outputmessage.cpp
+++ b/src/framework/net/outputmessage.cpp
@@ -37,12 +37,28 @@ void OutputMessage::reset()
 
 void OutputMessage::setBuffer(const std::string& buffer)
 {
-    int len = buffer.size();
+    const size_t len = buffer.size();
+    if (len > BUFFER_MAXSIZE - MAX_HEADER_SIZE)
+        throw stdext::exception("OutputMessage max buffer size reached");
     reset();
-    checkWrite(len);
-    memcpy((char*)(m_buffer + m_writePos), buffer.c_str(), len);
-    m_writePos += len;
-    m_messageSize += len;
+    checkWrite(static_cast<uint32>(len));
+    memcpy(m_buffer + m_writePos, buffer.data(), len);
+    m_writePos += static_cast<uint32>(len);
+    m_messageSize += static_cast<uint32>(len);
+}
+
+void OutputMessage::setWritePos(uint32 writePos)
+{
+    if (writePos < MAX_HEADER_SIZE || writePos > BUFFER_MAXSIZE)
+        throw stdext::exception("OutputMessage invalid write position");
+    m_writePos = writePos;
+}
+
+void OutputMessage::setMessageSize(uint32 messageSize)
+{
+    if (messageSize > BUFFER_MAXSIZE - m_headerPos)
+        throw stdext::exception("OutputMessage invalid message size");
+    m_messageSize = messageSize;
 }
 
 void OutputMessage::addU8(uint8 value)
@@ -150,14 +166,12 @@ void OutputMessage::writeMessageSize(bool bigSize)
     m_messageSize += (bigSize ? 4 : 2);
 }
 
-bool OutputMessage::canWrite(int bytes)
+bool OutputMessage::canWrite(uint32 bytes)
 {
-    if(m_writePos + bytes > BUFFER_MAXSIZE)
-        return false;
-    return true;
+    return m_writePos <= BUFFER_MAXSIZE && bytes <= BUFFER_MAXSIZE - m_writePos;
 }
 
-void OutputMessage::checkWrite(int bytes)
+void OutputMessage::checkWrite(uint32 bytes)
 {
     if(!canWrite(bytes))
         throw stdext::exception("OutputMessage max buffer size reached");

--- a/src/framework/net/outputmessage.h
+++ b/src/framework/net/outputmessage.h
@@ -32,7 +32,7 @@ class OutputMessage : public LuaObject
 public:
     enum {
         BUFFER_MAXSIZE = 327680,
-        MAX_STRING_LENGTH = 65536,
+        MAX_STRING_LENGTH = 65535,
         MAX_HEADER_SIZE = 12
     };
 
@@ -56,8 +56,8 @@ public:
     uint32 getWritePos() { return m_writePos; }
     uint32 getMessageSize() { return m_messageSize; }
 
-    void setWritePos(uint32 writePos) { m_writePos = writePos; }
-    void setMessageSize(uint32 messageSize) { m_messageSize = messageSize; }
+    void setWritePos(uint32 writePos);
+    void setMessageSize(uint32 messageSize);
 
 protected:
     uint8* getWriteBuffer() { return m_buffer + m_writePos; }
@@ -72,8 +72,8 @@ protected:
     friend class PacketPlayer;
 
 private:
-    bool canWrite(int bytes);
-    void checkWrite(int bytes);
+    bool canWrite(uint32 bytes);
+    void checkWrite(uint32 bytes);
 
     uint32 m_headerPos;
     uint32 m_writePos;

--- a/src/framework/proxy/proxy.cpp
+++ b/src/framework/proxy/proxy.cpp
@@ -21,11 +21,9 @@ void ProxyManager::terminate()
     m_working = false;
     clear();
     m_guard.reset();
-    if (!m_thread.joinable()) {
-        stdext::millisleep(100);
-        m_io.stop();
-    }
-    m_thread.join();
+    if (m_thread.joinable())
+        m_thread.join();
+    m_io.stop();
 }
 
 void ProxyManager::clear()

--- a/src/framework/proxy/proxy_client.cpp
+++ b/src/framework/proxy/proxy_client.cpp
@@ -152,8 +152,8 @@ void Proxy::ping()
     // 2 byte size + 4 byte session (0 so it's ping) + 4 byte packet num (0) + 4 byte last recived packet num + 4 byte local ping
     auto packet = std::make_shared<ProxyPacket>(18, 0);
     packet->at(0) = 16; // size = 12
-    *(uint32_t*)(&packet->data()[10]) = UID;
-    *(uint32_t*)(&packet->data()[14]) = m_ping;
+    stdext::writeULE32(&packet->data()[10], UID);
+    stdext::writeULE32(&packet->data()[14], m_ping);
     send(packet);
 }
 
@@ -170,8 +170,8 @@ void Proxy::addSession(uint32_t id, int port)
 {
     auto packet = std::make_shared<ProxyPacket>(14, 0);
     packet->at(0) = 12; // size = 12
-    *(uint32_t*)(&(packet->data()[2])) = id;
-    *(uint32_t*)(&(packet->data()[10])) = port;
+    stdext::writeULE32(&packet->data()[2], id);
+    stdext::writeULE32(&packet->data()[10], port);
     send(packet);
     m_sessions += 1;
 }
@@ -180,8 +180,8 @@ void Proxy::removeSession(uint32_t id)
 {
     auto packet = std::make_shared<ProxyPacket>(14, 0);
     packet->at(0) = 12; // size = 12
-    *(uint32_t*)(&(packet->data()[2])) = id;
-    *(uint32_t*)(&(packet->data()[6])) = 0xFFFFFFFF;
+    stdext::writeULE32(&packet->data()[2], id);
+    stdext::writeULE32(&packet->data()[6], 0xFFFFFFFF);
     send(packet);
     m_sessions -= 1;
 }
@@ -203,7 +203,7 @@ void Proxy::onHeader(const boost::system::error_code& ec, std::size_t bytes_tran
     m_packetsRecived += 1;
     m_bytesRecived += bytes_transferred;
 
-    uint16_t packetSize = *(uint16_t*)m_buffer;
+    uint16_t packetSize = stdext::readULE16(m_buffer);
     if (packetSize < 12 || packetSize > BUFFER_SIZE) {
 #ifdef PROXY_DEBUG
         std::clog << "[Proxy " << m_host << "] onHeader wrong packet size " << packetSize << std::endl;
@@ -224,9 +224,9 @@ void Proxy::onPacket(const boost::system::error_code& ec, std::size_t bytes_tran
     }
     m_bytesRecived += bytes_transferred;
 
-    uint32_t sessionId = *(uint32_t*)(&m_buffer[0]);
-    uint32_t packetId = *(uint32_t*)(&m_buffer[4]);
-    uint32_t lastRecivedPacketId = *(uint32_t*)(&m_buffer[8]);
+    uint32_t sessionId = stdext::readULE32(&m_buffer[0]);
+    uint32_t packetId = stdext::readULE32(&m_buffer[4]);
+    uint32_t lastRecivedPacketId = stdext::readULE32(&m_buffer[8]);
 
     if (sessionId == 0) {
         readHeader();
@@ -253,7 +253,7 @@ void Proxy::onPacket(const boost::system::error_code& ec, std::size_t bytes_tran
         return disconnect();
     }
 
-    uint16_t packetSize = *(uint16_t*)(&m_buffer[12]);
+    uint16_t packetSize = stdext::readULE16(&m_buffer[12]);
     if (14u + packetSize > bytes_transferred) {
 #ifdef PROXY_DEBUG
         std::clog << "[Proxy " << m_host << "] onPacket truncated inner packet, size: " << packetSize << " transferred: " << bytes_transferred << std::endl;
@@ -487,7 +487,7 @@ void Session::onHeader(const boost::system::error_code& ec, std::size_t bytes_tr
         return terminate();
     }
 
-    uint16_t packetSize = *(uint16_t*)(m_buffer);
+    uint16_t packetSize = stdext::readULE16(m_buffer);
     if (packetSize > 1024 && m_outputPacketId == 1) {
         return readTibia12Header();
     }
@@ -532,10 +532,10 @@ void Session::onPacket(const ProxyPacketPtr& packet)
         uint32_t packetId = m_outputPacketId++;
         auto newPacket = std::make_shared<ProxyPacket>(packet->size() + 14);
 
-        *(uint16_t*)(&(newPacket->data()[0])) = (uint16_t)packet->size() + 12;
-        *(uint32_t*)(&(newPacket->data()[2])) = m_id;
-        *(uint32_t*)(&(newPacket->data()[6])) = packetId;
-        *(uint32_t*)(&(newPacket->data()[10])) = m_inputPacketId - 1;
+        stdext::writeULE16(&newPacket->data()[0], static_cast<uint16_t>(packet->size() + 12));
+        stdext::writeULE32(&newPacket->data()[2], m_id);
+        stdext::writeULE32(&newPacket->data()[6], packetId);
+        stdext::writeULE32(&newPacket->data()[10], m_inputPacketId - 1);
         std::copy(packet->begin(), packet->end(), newPacket->begin() + 14);
 
         m_proxySendQueue[packetId] = newPacket;

--- a/src/framework/stdext/packed_storage.h
+++ b/src/framework/stdext/packed_storage.h
@@ -25,6 +25,8 @@
 
 #include "types.h"
 #include "packed_any.h"
+#include <limits>
+#include <stdexcept>
 
 namespace stdext {
 
@@ -41,7 +43,27 @@ class packed_storage {
 
 public:
     packed_storage() : m_values(nullptr), m_size(0) { }
-    ~packed_storage() { if(m_values) delete[] m_values; }
+    packed_storage(const packed_storage& other) : m_values(nullptr), m_size(other.m_size) {
+        if(m_size > 0) {
+            m_values = new value_pair[m_size];
+            std::copy(other.m_values, other.m_values + m_size, m_values);
+        }
+    }
+    packed_storage(packed_storage&& other) noexcept : m_values(other.m_values), m_size(other.m_size) {
+        other.m_values = nullptr;
+        other.m_size = 0;
+    }
+    ~packed_storage() { delete[] m_values; }
+
+    packed_storage& operator=(packed_storage other) {
+        swap(other);
+        return *this;
+    }
+
+    void swap(packed_storage& other) noexcept {
+        std::swap(m_values, other.m_values);
+        std::swap(m_size, other.m_size);
+    }
 
     template<typename T>
     void set(Key id, const T& value) {
@@ -51,6 +73,8 @@ public:
                 return;
             }
         }
+        if(m_size == std::numeric_limits<SizeType>::max())
+            throw std::length_error("packed_storage capacity exceeded");
         auto tmp = new value_pair[m_size+1];
         if(m_size > 0) {
             std::copy(m_values, m_values + m_size, tmp);
@@ -61,15 +85,19 @@ public:
     }
 
     bool remove(Key id) {
+        if(m_size == 0)
+            return false;
         auto begin = m_values;
         auto end = m_values + m_size;
         auto it = std::find_if(begin, end, [=](const value_pair& pair) -> bool { return pair.id == id; } );
         if(it == end)
             return false;
         int pos = it - begin;
-        auto tmp = new value_pair[m_size-1];
-        std::copy(begin, begin + pos, tmp);
-        std::copy(begin + pos + 1, end, tmp + pos);
+        value_pair* tmp = m_size > 1 ? new value_pair[m_size-1] : nullptr;
+        if (tmp) {
+            std::copy(begin, begin + pos, tmp);
+            std::copy(begin + pos + 1, end, tmp + pos);
+        }
         delete[] m_values;
         m_values = tmp;
         m_size--;
@@ -92,8 +120,7 @@ public:
     }
 
     void clear() {
-        if(m_values)
-            delete [] m_values;
+        delete [] m_values;
         m_values = nullptr;
         m_size = 0;
     }

--- a/src/framework/util/databuffer.h
+++ b/src/framework/util/databuffer.h
@@ -41,7 +41,8 @@ public:
         m_size = d.m_size;
         m_capacity = std::max<uint>(64, d.m_size * 2);
         m_buffer = new T[m_capacity];
-        memcpy(m_buffer, d.m_buffer, sizeof(T) * m_size);
+        if (m_size > 0)
+            std::copy(d.m_buffer, d.m_buffer + m_size, m_buffer);
     }
     DataBuffer& operator=(const DataBuffer<T>& d) = delete;
 
@@ -66,9 +67,9 @@ public:
     inline void reserve(uint n) {
         if(n > m_capacity) {
             T *buffer = new T[n];
-            memcpy(buffer, m_buffer, m_size * sizeof(T));
-            if(m_buffer)
-                delete[] m_buffer;
+            if (m_size > 0)
+                std::copy(m_buffer, m_buffer + m_size, buffer);
+            delete[] m_buffer;
             m_buffer = buffer;
             m_capacity = n;
         }
@@ -87,7 +88,7 @@ public:
         if(n <= m_size)
             return;
         if(n > m_capacity) {
-            uint newcapacity = m_capacity;
+            uint newcapacity = m_capacity > 0 ? m_capacity : 64;
             if (precise) {
                 newcapacity = n;
             } else {

--- a/src/framework/util/stats.cpp
+++ b/src/framework/util/stats.cpp
@@ -10,8 +10,10 @@
 Stats g_stats;
 
 void Stats::add(int type, Stat* stat) {
-    if (type < 0 || type > STATS_LAST)
+    if (type < 0 || type > STATS_LAST) {
+        delete stat;
         return;
+    }
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto it = stats[type].data.emplace(stat->description, StatsData(0, 0, stat->extraDescription)).first;
@@ -81,6 +83,8 @@ void Stats::clearAll() {
     std::lock_guard<std::mutex> lock(m_mutex);
     for (int i = 0; i <= STATS_LAST; ++i) {
         stats[i].data.clear();
+        for (Stat* stat : stats[i].slow)
+            delete stat;
         stats[i].slow.clear();
     }
     resetSleepTime();


### PR DESCRIPTION
## What changed

- defer Battle Pass, Wheel of Destiny, Store, Cam Viewer, and analyser popup UI creation until first use
- cancel analyser, settings, and autoreload events during offline/unload lifecycle transitions
- replace anonymous startup signal handlers with named, disconnectable callbacks
- disable the production autoload of the HTML test module
- clear retained UI references during module termination

## Why

Several large hidden UI trees were created during startup even when their features were never opened. Repeating lifecycle events and signal callbacks could also remain active across reloads or game sessions.

## Impact

In the same 12-second login-screen smoke test, private memory decreased from about 1,348 MiB to 1,078 MiB, a reduction of roughly 270 MiB (20%). Feature UI is still initialized automatically on first use.

## Validation

- parsed all 15 changed Lua files with LuaJIT syntax rules
- `git diff --check`
- built `vc23/otclient.sln` with `OpenGL|x64`
- startup smoke test confirmed a responsive process with no Lua errors in the startup log

Full in-game 8.60 validation requires extracted `things/860/Tibia.dat` and `Tibia.spr`, which are not present in the checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Inicialização sob demanda e preparação mais consistente das interfaces do Battle Pass, loja, roda do destino e visualizador de câmera.
  * Auto-reload aprimorado, com limpeza adequada ao descarregar módulos.

* **Correções**
  * Popups, eventos, retries e atualizações assíncronas agora são encerrados com mais segurança.
  * Sons e bloqueios de interface são liberados corretamente durante o ciclo de vida.
  * Validações reforçadas para entradas inválidas, arquivos, recursos, sprites, mensagens de rede e dados corrompidos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers construction of several large UI trees and adds lifecycle cleanup for retained events, callbacks, and widgets.
- Lazily initializes the store, Battle Pass, Wheel of Destiny, Cam Viewer, and analyser configuration popups.
- Cancels scheduled analyser, settings, autoreload, and session events during offline or unload transitions.
- Adds defensive validation around resource, network, image, sprite, and container data handling.
- Disables production autoload of the HTML test module.

<h3>Confidence Score: 2/5</h3>

This PR is not safe to merge until all early store callbacks initialize the deferred UI and the outstanding Battle Pass protocol-handler failure is resolved.

Store responses can still reach callbacks that dereference windows before first use, while Battle Pass missions and rewards can reach handlers that access an absent deferred window and discard the response after a caught Lua error.

**Files Needing Attention:** mods/game_store/store.lua, mods/game_store/classes/Offers.lua, modules/game_battlepass/battlepass.lua

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| mods/game_store/store.lua | Defers store UI creation and fixes two early callbacks, but other connected response callbacks still access absent windows. |
| modules/game_battlepass/battlepass.lua | Defers Battle Pass UI creation, while missions and rewards protocol paths still assume its widgets already exist. |
| mods/game_wheel/wheel.lua | Adds on-demand wheel creation and clears retained window and panel references during termination. |
| mods/game_analyser/analyser.lua | Lazily creates configuration popups and stops analyser events during offline and termination transitions. |
| modules/client_camviewer/client_camviewer.lua | Defers Cam Viewer construction and disconnects its game signal during termination. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Module initialization] --> B[Register protocol and lifecycle callbacks]
  B --> C{Feature opened?}
  C -- Yes --> D[Create deferred UI]
  C -- No --> E[Keep UI absent]
  E --> F[Server response]
  F --> G{Callback ensures UI?}
  G -- Yes --> H[Create UI and process response]
  G -- No --> I[Nil widget access and dropped response]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
mods/game_store/store.lua:68
**Store responses access absent UI**

When a purchase, hireling-name, Pix-data, or Pix-URL response arrives before the store is first opened, its callback accesses windows that are created only by `ensureStoreWindow` without invoking that initializer, causing a nil-access Lua error and preventing the response from being displayed or completed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(core): tighten bounds and shutdown"](https://github.com/mateuzkl/astraclient/commit/5a5916e6c1183ef5cd2be924cf36fd6edb873b8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48178055)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->