### PR TITLE
Port classic 8.6 hotkeys manager

### DIFF
--- a/mods/client_settings/classes/custom-hotkeys.lua
+++ b/mods/client_settings/classes/custom-hotkeys.lua
@@ -3,6 +3,8 @@ CustomHotkeys.__index = CustomHotkeys
 
 -- Common vars
 local assignCache = nil
+local CLASSIC_HOTKEY_WARNING_COLOR = "#ff9854"
+local CLASSIC_HOTKEY_WARNING_TOOLTIP = tr("Blocked by classic Hotkeys Manager")
 local UseColors = {
     ["UseOnYourself"] = {color = "#b0ffb0", text = "(use object on yourself)"},
     ["UseOnTarget"] = {color = "#ffb0b0", text = "(use object on target)"},
@@ -115,16 +117,21 @@ function CustomHotkeys.createList(save)
       widget:setBackgroundColor(background)
       widget.background = background
 
-      if #widget.hotkey > 0 and not (modules.game_hotkeys and
-          modules.game_hotkeys.isHotkeyUsedByManager and
-          modules.game_hotkeys.isHotkeyUsedByManager(widget.hotkey)) then
+      local primaryBlocked = #widget.hotkey > 0 and isKeyClaimedByHotkeyManager(widget.hotkey)
+      if primaryBlocked then
+        widget.primary:setColor(CLASSIC_HOTKEY_WARNING_COLOR)
+        widget.primary:setTooltip(CLASSIC_HOTKEY_WARNING_TOOLTIP)
+      elseif #widget.hotkey > 0 then
         g_keyboard.bindKeyPress(widget.hotkey, function() onExecuteAction(widget) end, gameRootPanel)
         g_keyboard.bindKeyDown(widget.hotkey, function() onExecuteAction(widget) end, gameRootPanel)
       end
 
-      if widget.secondaryHotkey and #widget.secondaryHotkey > 0 and not
-          (modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
-          modules.game_hotkeys.isHotkeyUsedByManager(widget.secondaryHotkey)) then
+      local secondaryBlocked = widget.secondaryHotkey and #widget.secondaryHotkey > 0 and
+        isKeyClaimedByHotkeyManager(widget.secondaryHotkey)
+      if secondaryBlocked then
+        widget.secondary:setColor(CLASSIC_HOTKEY_WARNING_COLOR)
+        widget.secondary:setTooltip(CLASSIC_HOTKEY_WARNING_TOOLTIP)
+      elseif widget.secondaryHotkey and #widget.secondaryHotkey > 0 then
         g_keyboard.bindKeyPress(widget.secondaryHotkey, function() onExecuteAction(widget) end, gameRootPanel)
         g_keyboard.bindKeyDown(widget.secondaryHotkey, function() onExecuteAction(widget) end, gameRootPanel)
       end

--- a/mods/client_settings/classes/custom-hotkeys.lua
+++ b/mods/client_settings/classes/custom-hotkeys.lua
@@ -115,12 +115,16 @@ function CustomHotkeys.createList(save)
       widget:setBackgroundColor(background)
       widget.background = background
 
-      if #widget.hotkey > 0 then
+      if #widget.hotkey > 0 and not (modules.game_hotkeys and
+          modules.game_hotkeys.isHotkeyUsedByManager and
+          modules.game_hotkeys.isHotkeyUsedByManager(widget.hotkey)) then
         g_keyboard.bindKeyPress(widget.hotkey, function() onExecuteAction(widget) end, gameRootPanel)
         g_keyboard.bindKeyDown(widget.hotkey, function() onExecuteAction(widget) end, gameRootPanel)
       end
 
-      if widget.secondaryHotkey and #widget.secondaryHotkey > 0 then
+      if widget.secondaryHotkey and #widget.secondaryHotkey > 0 and not
+          (modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
+          modules.game_hotkeys.isHotkeyUsedByManager(widget.secondaryHotkey)) then
         g_keyboard.bindKeyPress(widget.secondaryHotkey, function() onExecuteAction(widget) end, gameRootPanel)
         g_keyboard.bindKeyDown(widget.secondaryHotkey, function() onExecuteAction(widget) end, gameRootPanel)
       end
@@ -847,6 +851,9 @@ function CustomHotkeys.updateWidget(widget, text, isSecondary)
   end
 
   if text ~= '' then
+    if modules.game_hotkeys and modules.game_hotkeys.removeHotkeyByCombo then
+      modules.game_hotkeys.removeHotkeyByCombo(text)
+    end
     g_keyboard.bindKeyPress(text, function() onExecuteAction(widget) end, m_interface.getRootPanel())
     g_keyboard.bindKeyDown(text, function() onExecuteAction(widget) end, m_interface.getRootPanel())
   end

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -588,9 +588,6 @@ function closeOptions()
   g_client.setInputLockWidget(nil)
   TempOptions:resetAllOptions()
   tmpResetActions = {}
-
-  -- Force update options upon close
-  KeyBinds:setupAndReset(Options.currentHotkeySetName, (Options.isChatOnEnabled and "chatOn" or "chatOff"))
 end
 
 function openOptions(self, redirectId)

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -145,6 +145,7 @@ local autoApplyEvent = nil
 local applyingOptions = false
 local pendingInterfaceRefreshEvents = {}
 local mapPanelRetryEvent = nil
+local hotkeyProfileChangeEvent = nil
 
 local function cancelPendingInterfaceRefreshEvents()
   for _, event in ipairs(pendingInterfaceRefreshEvents) do
@@ -160,6 +161,13 @@ local function cancelOnlineInterfaceRefreshEvents()
   end
 
   cancelPendingInterfaceRefreshEvents()
+end
+
+local function cancelHotkeyProfileChangeEvent()
+  if hotkeyProfileChangeEvent then
+    removeEvent(hotkeyProfileChangeEvent)
+    hotkeyProfileChangeEvent = nil
+  end
 end
 
 local globalGeneralHotkey = {}
@@ -305,6 +313,7 @@ end
 
 function terminate()
   cancelOnlineInterfaceRefreshEvents()
+  cancelHotkeyProfileChangeEvent()
   g_game.shouldShowLootHighlightEffect = nil
 
   ConditionsHUD:save()
@@ -467,6 +476,7 @@ end
 
 function offline()
   cancelOnlineInterfaceRefreshEvents()
+  cancelHotkeyProfileChangeEvent()
   if presetWindow then
   presetWindow:destroy()
   end
@@ -1486,9 +1496,17 @@ function getSelectedHotkeyChatType()
   return Options.isChatOnEnabled and "chatOn" or "chatOff"
 end
 
-function changeActiveHotkeyProfile(profileName, syncCombos)
+local function selectActiveHotkeyProfile(profileName, syncCombos)
+  local classicHotkeys = modules.game_hotkeys
+  if classicHotkeys and classicHotkeys.prepareProfileChange then
+    classicHotkeys.prepareProfileChange()
+  end
+
   if not Options.changeHotkeyProfile(profileName) then
-    return false
+    if classicHotkeys and classicHotkeys.finishProfileChange then
+      classicHotkeys.finishProfileChange()
+    end
+    return false, classicHotkeys
   end
 
   if syncCombos ~= false then
@@ -1505,16 +1523,64 @@ function changeActiveHotkeyProfile(profileName, syncCombos)
     lastFocusHK = nil
   end
 
+  return true, classicHotkeys
+end
+
+local function finishClassicHotkeyProfile(classicHotkeys)
+  if classicHotkeys and classicHotkeys.finishProfileChange then
+    classicHotkeys.finishProfileChange()
+  end
+end
+
+function changeActiveHotkeyProfile(profileName, syncCombos)
+  local changed, classicHotkeys = selectActiveHotkeyProfile(profileName, syncCombos)
+  if not changed then
+    return false
+  end
+
   modules.game_actionbar.resetActionBar()
   KeyBinds:setupAndReset(Options.currentHotkeySetName, getSelectedHotkeyChatType())
   configureGeneralHotkeys("")
   ActionHotkey.configureActionBarHotkeys()
+  finishClassicHotkeyProfile(classicHotkeys)
   CustomHotkeys.createList(true)
   return true
 end
 
+local function scheduleHotkeyProfileChange(profileName, syncCombos, onComplete)
+  cancelHotkeyProfileChangeEvent()
+  hotkeyProfileChangeEvent = scheduleEvent(function()
+    hotkeyProfileChangeEvent = nil
+    local changed, classicHotkeys = selectActiveHotkeyProfile(profileName, syncCombos)
+    if not changed then
+      return
+    end
+
+    local phases = {
+      function() modules.game_actionbar.resetActionBar() end,
+      function() KeyBinds:setupAndReset(Options.currentHotkeySetName, getSelectedHotkeyChatType()) end,
+      function() configureGeneralHotkeys("") end,
+      function() ActionHotkey.configureActionBarHotkeys() end,
+      function() finishClassicHotkeyProfile(classicHotkeys) end,
+      function() CustomHotkeys.createList(true) end
+    }
+    local phase = 0
+    local function runNextPhase()
+      hotkeyProfileChangeEvent = nil
+      phase = phase + 1
+      phases[phase]()
+      if phase < #phases then
+        hotkeyProfileChangeEvent = scheduleEvent(runNextPhase, 1)
+      elseif onComplete then
+        onComplete()
+      end
+    end
+    hotkeyProfileChangeEvent = scheduleEvent(runNextPhase, 1)
+  end, 1)
+end
+
 function onChangeProfile(selected)
-  changeActiveHotkeyProfile(selected, false)
+  scheduleHotkeyProfileChange(selected, false)
 end
 
 function onChatOnCheck(action)
@@ -1593,10 +1659,9 @@ function toggleNextPreset()
   end
 
   local newProfile = Options.profiles[currentIndex + 1]
-  if not changeActiveHotkeyProfile(newProfile) then
-    return
-  end
-  modules.game_textmessage.displayFailureMessage(tr("Switched to hotkey preset '%s'", newProfile))
+  scheduleHotkeyProfileChange(newProfile, nil, function()
+    modules.game_textmessage.displayFailureMessage(tr("Switched to hotkey preset '%s'", newProfile))
+  end)
 end
 
 function togglePreviousPreset()
@@ -1609,14 +1674,13 @@ function togglePreviousPreset()
   end
 
   if currentIndex == 1 then
-    currentIndex = #Options.profiles
+    currentIndex = #Options.profiles + 1
   end
 
   local newProfile = Options.profiles[currentIndex - 1]
-  if not changeActiveHotkeyProfile(newProfile) then
-    return
-  end
-  modules.game_textmessage.displayFailureMessage(tr("Switched to hotkey preset '%s'", newProfile))
+  scheduleHotkeyProfileChange(newProfile, nil, function()
+    modules.game_textmessage.displayFailureMessage(tr("Switched to hotkey preset '%s'", newProfile))
+  end)
 end
 
 function onCreateProfile(windowType)
@@ -1693,7 +1757,11 @@ function onCopyProfile(windowType)
       return
     end
 
-    Options.copyProfile(text, profileBar:getCurrentOption().text)
+    local sourceProfile = profileBar:getCurrentOption().text
+    if modules.game_hotkeys and modules.game_hotkeys.copyProfile then
+      modules.game_hotkeys.copyProfile(sourceProfile, text)
+    end
+    Options.copyProfile(text, sourceProfile)
     refreshHotkeyProfileCombos(text)
     changeActiveHotkeyProfile(text, false)
 
@@ -1755,7 +1823,11 @@ function onRenameProfile(windowType)
       return
     end
 
-    Options.renamePreset(text, profileBar:getCurrentOption().text)
+    local sourceProfile = profileBar:getCurrentOption().text
+    if modules.game_hotkeys and modules.game_hotkeys.renameProfile then
+      modules.game_hotkeys.renameProfile(sourceProfile, text)
+    end
+    Options.renamePreset(text, sourceProfile)
     refreshHotkeyProfileCombos(text)
     changeActiveHotkeyProfile(text, false)
 
@@ -1812,6 +1884,9 @@ function onRemoveProfile(windowType)
   local currentProfile = profileBar:getCurrentOption().text
 
   local yesFunction = function()
+    if modules.game_hotkeys and modules.game_hotkeys.removeProfile then
+      modules.game_hotkeys.removeProfile(currentProfile)
+    end
     Options.removeProfile(currentProfile)
     local nextProfile = Options.profiles[1]
     refreshHotkeyProfileCombos(nextProfile)

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -1533,6 +1533,7 @@ local function finishClassicHotkeyProfile(classicHotkeys)
 end
 
 function changeActiveHotkeyProfile(profileName, syncCombos)
+  cancelHotkeyProfileChangeEvent()
   local changed, classicHotkeys = selectActiveHotkeyProfile(profileName, syncCombos)
   if not changed then
     return false

--- a/modules/corelib/globals.lua
+++ b/modules/corelib/globals.lua
@@ -201,6 +201,12 @@ consoleln = consoleln or function(...)
   print(table.concat(values, ' '))
 end
 
+function isKeyClaimedByHotkeyManager(keyCombo)
+  local hotkeysManager = modules and modules.game_hotkeys
+  return hotkeysManager and hotkeysManager.isHotkeyUsedByManager and
+    hotkeysManager.isHotkeyUsedByManager(keyCombo) or false
+end
+
 AttachedEffect = AttachedEffect or {}
 AttachedEffect.create = AttachedEffect.create or function(id, thingId, thingCategory)
   local effect = {

--- a/modules/corelib/keybinds.lua
+++ b/modules/corelib/keybinds.lua
@@ -920,8 +920,7 @@ function KeyBinds:setupAndReset(profile, chatType)
       if bindData.dontBindChatoff and chatType == 'chatOff' then
         canBind = false
       end
-      if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
-          modules.game_hotkeys.isHotkeyUsedByManager(hotkey) then
+      if isKeyClaimedByHotkeyManager(hotkey) then
         canBind = false
       end
 
@@ -965,8 +964,7 @@ function KeyBinds:setup()
       if bindData.dontBindChatoff and chatType == 'chatOff' then
         canBind = false
       end
-      if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
-          modules.game_hotkeys.isHotkeyUsedByManager(hotkey) then
+      if isKeyClaimedByHotkeyManager(hotkey) then
         canBind = false
       end
 
@@ -1293,8 +1291,7 @@ function KeyBinds:hotkeyIsUsed(key)
   if hotkeys[key] ~= nil then
     return true
   end
-  return modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
-    modules.game_hotkeys.isHotkeyUsedByManager(key) or false
+  return isKeyClaimedByHotkeyManager(key)
 end
 
 function KeyBinds:isUsedHotkey(key)

--- a/modules/corelib/keybinds.lua
+++ b/modules/corelib/keybinds.lua
@@ -263,7 +263,13 @@ KeyBinds.Hotkeys = {
         jsonName = "ShowOptionsHotkeys",
         bindKeyDown = function()
           if not canPerformAction() then return end
-          addEvent(function() m_settings.toggleHotkeys() end)
+          addEvent(function()
+            if modules.game_hotkeys and modules.game_hotkeys.toggle then
+              modules.game_hotkeys.toggle()
+            else
+              m_settings.toggleHotkeys()
+            end
+          end)
         end,
       },
       ["Open Prey Dialog"] = {
@@ -914,6 +920,10 @@ function KeyBinds:setupAndReset(profile, chatType)
       if bindData.dontBindChatoff and chatType == 'chatOff' then
         canBind = false
       end
+      if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
+          modules.game_hotkeys.isHotkeyUsedByManager(hotkey) then
+        canBind = false
+      end
 
       if bindData.bindKeyDown and canBind then
         g_keyboard.bindKeyDown(hotkey, bindData.bindKeyDown)
@@ -953,6 +963,10 @@ function KeyBinds:setup()
 			local bindData = KeyBinds:getBindFunction(setting)
       local canBind = true
       if bindData.dontBindChatoff and chatType == 'chatOff' then
+        canBind = false
+      end
+      if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
+          modules.game_hotkeys.isHotkeyUsedByManager(hotkey) then
         canBind = false
       end
 
@@ -1012,6 +1026,9 @@ function KeyBind:getFirstKey() return self.firstKey end
 function KeyBind:getSecondKey() return self.secondKey end
 
 function KeyBind:setFirstKey(key)
+  if key and key ~= '' and modules.game_hotkeys and modules.game_hotkeys.removeHotkeyByCombo then
+    modules.game_hotkeys.removeHotkeyByCombo(key)
+  end
   if self.action == "Go North-East" or self.action == "Go North-West" or self.action == "Go South-East" or self.action == "Go South-West" then
     if self.firstKey then
       g_ui.removeDiagonalKey(getKeyCode(self.firstKey))
@@ -1090,6 +1107,9 @@ function KeyBind:setFirstKey(key)
 end
 
 function KeyBind:setSecondKey(key)
+  if key and key ~= '' and modules.game_hotkeys and modules.game_hotkeys.removeHotkeyByCombo then
+    modules.game_hotkeys.removeHotkeyByCombo(key)
+  end
   if self.action == "Go North-East" or self.action == "Go North-West" or self.action == "Go South-East" or self.action == "Go South-West" then
     if self.secondKey then
       g_ui.removeDiagonalKey(getKeyCode(self.secondKey))
@@ -1270,7 +1290,11 @@ function KeyBind:deactive()
 end
 
 function KeyBinds:hotkeyIsUsed(key)
-  return hotkeys[key] ~= nil
+  if hotkeys[key] ~= nil then
+    return true
+  end
+  return modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
+    modules.game_hotkeys.isHotkeyUsedByManager(key) or false
 end
 
 function KeyBinds:isUsedHotkey(key)

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -21,6 +21,7 @@ local spellGroupCooldownCache = {}
 local spellGroupPressed = {}
 
 local MULTI_ACTION_DELAY_MS = 500
+local CLASSIC_HOTKEY_WARNING_COLOR = "#ff9854"
 
 local cachedItemWidget = {}
 local dragButton = nil
@@ -2562,6 +2563,8 @@ function setupHotkeyButton(button)
 	if not Options.currentHotkeySet then
 		return
 	end
+	button.hotkeyLabel:setColor("#dfdfdf")
+	button.hotkeyLabel:setTooltip("")
 
 	local currentSet = Options.isChatOnEnabled and Options.currentHotkeySet["chatOn"] or Options.currentHotkeySet["chatOff"]
 	for _, data in pairs(currentSet) do
@@ -2569,8 +2572,10 @@ function setupHotkeyButton(button)
 			if data["actionsetting"]["action"] == "TriggerActionButton_" .. button:getId() then
 				local keySequence = data["keysequence"]
 				if keySequence and not string.empty(keySequence) then
-					if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
-						modules.game_hotkeys.isHotkeyUsedByManager(keySequence) then
+					if isKeyClaimedByHotkeyManager(keySequence) then
+						button.hotkeyLabel:setText(translateDisplayHotkey(keySequence))
+						button.hotkeyLabel:setColor(CLASSIC_HOTKEY_WARNING_COLOR)
+						button.hotkeyLabel:setTooltip(tr("Blocked by classic Hotkeys Manager"))
 						goto continue
 					end
 					if not data["secondary"] then
@@ -2599,8 +2604,7 @@ function isHotkeyUsed(key, secondary)
 	if not key or not Options.currentHotkeySet then
 		return false
 	end
-	if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
-		modules.game_hotkeys.isHotkeyUsedByManager(key) then
+	if isKeyClaimedByHotkeyManager(key) then
 		return true
 	end
 

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -2322,6 +2322,9 @@ function assignHotkey(button)
 			return true
 		end
 
+    if modules.game_hotkeys and modules.game_hotkeys.removeHotkeyByCombo then
+      modules.game_hotkeys.removeHotkeyByCombo(hotkey)
+    end
     Options.clearHotkey(hotkey)
 
 		local usedButton = getUsedHotkeyButton(hotkey)
@@ -2566,6 +2569,10 @@ function setupHotkeyButton(button)
 			if data["actionsetting"]["action"] == "TriggerActionButton_" .. button:getId() then
 				local keySequence = data["keysequence"]
 				if keySequence and not string.empty(keySequence) then
+					if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
+						modules.game_hotkeys.isHotkeyUsedByManager(keySequence) then
+						goto continue
+					end
 					if not data["secondary"] then
 						button.cache.hotkey = keySequence
 					end
@@ -2580,6 +2587,7 @@ function setupHotkeyButton(button)
 				end
 			end
 		end
+		::continue::
 	end
 end
 
@@ -2590,6 +2598,10 @@ function isHotkeyUsed(key, secondary)
 
 	if not key or not Options.currentHotkeySet then
 		return false
+	end
+	if modules.game_hotkeys and modules.game_hotkeys.isHotkeyUsedByManager and
+		modules.game_hotkeys.isHotkeyUsedByManager(key) then
+		return true
 	end
 
 	local currentSet = Options.isChatOnEnabled and Options.currentHotkeySet["chatOn"] or Options.currentHotkeySet["chatOff"]

--- a/modules/game_hotkeys/LICENSE
+++ b/modules/game_hotkeys/LICENSE
@@ -1,0 +1,21 @@
+OTClient is made available under the MIT License
+
+Copyright (c) 2010-2020 OTClient <https://github.com/edubart/otclient>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -54,6 +54,18 @@ local hotkeyList = {}
 local hotkeyBlockingSources = {}
 local nextSourceId = 1
 local lastHotkeyTime = g_clock.millis()
+local saveEvent
+local refreshModernHotkeysEvent
+local chatTextEvent
+local hotkeyAssignWindow
+local choosingItem = false
+local loadedServerKey
+local loadedCharacterKey
+local loadedProfileKey
+local loadedPerServer
+local loadedPerCharacter
+
+local SETTINGS_SAVE_DELAY = 250
 
 local function getGameRootPanel()
   if m_interface and m_interface.getRootPanel then
@@ -65,15 +77,105 @@ local function getGameRootPanel()
   return rootWidget
 end
 
+local function encodeSettingsKey(value)
+  return tostring(value):gsub('[^%w%.%- ]', function(character)
+    return string.format('_%02X', string.byte(character))
+  end)
+end
+
 local function getServerKey()
   local host = G and G.host or g_settings.getString('host') or 'default'
   host = tostring(host):gsub('^https?://', '')
-  return host ~= '' and host or 'default'
+  return encodeSettingsKey(host ~= '' and host or 'default')
 end
 
 local function getCharacterKey()
   local name = g_game.getCharacterName()
-  return name and name ~= '' and name or 'default'
+  return encodeSettingsKey(name and name ~= '' and name or 'default')
+end
+
+local function getProfileKey()
+  local profile = Options and Options.currentHotkeySetName
+  return encodeSettingsKey(profile and profile ~= '' and profile or 'default')
+end
+
+local function cancelSaveEvent()
+  if saveEvent then
+    removeEvent(saveEvent)
+    saveEvent = nil
+  end
+end
+
+local function cancelRefreshModernHotkeysEvent()
+  if refreshModernHotkeysEvent then
+    removeEvent(refreshModernHotkeysEvent)
+    refreshModernHotkeysEvent = nil
+  end
+end
+
+local function cancelChatTextEvent()
+  if chatTextEvent then
+    removeEvent(chatTextEvent)
+    chatTextEvent = nil
+  end
+end
+
+local function scheduleSettingsSave()
+  cancelSaveEvent()
+  saveEvent = scheduleEvent(function()
+    saveEvent = nil
+    g_settings.save()
+  end, SETTINGS_SAVE_DELAY)
+end
+
+local function flushSettingsSave()
+  if not saveEvent then
+    return
+  end
+  cancelSaveEvent()
+  g_settings.save()
+end
+
+local function getSettingsScope(settings, create, serverKey, characterKey, savePerServer, savePerCharacter)
+  local scope = settings
+  if savePerServer then
+    if create then
+      scope[serverKey] = type(scope[serverKey]) == 'table' and scope[serverKey] or {}
+    end
+    scope = type(scope) == 'table' and scope[serverKey] or nil
+  end
+  if savePerCharacter then
+    if create and type(scope) == 'table' then
+      scope[characterKey] = type(scope[characterKey]) == 'table' and scope[characterKey] or {}
+    end
+    scope = type(scope) == 'table' and scope[characterKey] or nil
+  end
+  return scope
+end
+
+local function isLegacyHotkeyTable(scope)
+  if type(scope) ~= 'table' then
+    return false
+  end
+  for key, value in pairs(scope) do
+    if key ~= 'profiles' and type(value) == 'table' and
+        (value.autoSend ~= nil or value.itemId ~= nil or value.useType ~= nil or
+          value.value ~= nil or value.action ~= nil) then
+      return true
+    end
+  end
+  return false
+end
+
+local function cloneTable(value)
+  if type(value) ~= 'table' then
+    return value
+  end
+  local copy = {}
+  for key, child in pairs(value) do
+    copy[key] = cloneTable(child)
+  end
+  return copy
 end
 
 local function getHotkeyDelay()
@@ -106,23 +208,29 @@ local function refreshModernHotkeys()
     return
   end
 
-  addEvent(function()
+  cancelRefreshModernHotkeysEvent()
+  refreshModernHotkeysEvent = scheduleEvent(function()
+    refreshModernHotkeysEvent = nil
     if not g_game.isOnline() then
       return
     end
+    local refreshedCustomHotkeys = false
     if modules.game_actionbar and modules.game_actionbar.switchChatMode and Options then
       modules.game_actionbar.switchChatMode(Options.isChatOnEnabled == true)
+      refreshedCustomHotkeys = true
     elseif KeyBinds and KeyBinds.setupAndReset and Options then
       KeyBinds:setupAndReset(Options.currentHotkeySetName,
         Options.isChatOnEnabled and 'chatOn' or 'chatOff')
     end
 
-    local customHotkeys = m_settings and m_settings.CustomHotkeys or
-      (modules.client_settings and modules.client_settings.CustomHotkeys)
-    if customHotkeys and customHotkeys.createList then
-      customHotkeys.createList(true)
+    if not refreshedCustomHotkeys then
+      local customHotkeys = m_settings and m_settings.CustomHotkeys or
+        (modules.client_settings and modules.client_settings.CustomHotkeys)
+      if customHotkeys and customHotkeys.createList then
+        customHotkeys.createList(true)
+      end
     end
-  end)
+  end, 1)
 end
 
 local function bindCombo(keyCombo)
@@ -202,6 +310,28 @@ function terminate()
     onGameEnd = offline
   })
 
+  if hotkeysManagerLoaded then
+    save()
+  else
+    flushSettingsSave()
+  end
+  cancelRefreshModernHotkeysEvent()
+  cancelChatTextEvent()
+
+  if hotkeyAssignWindow then
+    hotkeyAssignWindow:destroy()
+    hotkeyAssignWindow = nil
+  end
+  if choosingItem and mouseGrabberWidget then
+    mouseGrabberWidget:ungrabMouse()
+    if usesNativeCursor() then
+      g_window.restoreMouseCursor()
+    else
+      g_mouse.popCursor('target')
+    end
+    choosingItem = false
+  end
+
   unload()
 
   if hotkeysWindowButton then
@@ -239,6 +369,9 @@ function terminate()
 end
 
 function configure(savePerServer, savePerCharacter)
+  if hotkeysManagerLoaded then
+    save()
+  end
   perServer = savePerServer
   perCharacter = savePerCharacter
   reload()
@@ -251,6 +384,13 @@ function online()
 end
 
 function offline()
+  if hotkeysManagerLoaded then
+    save()
+  else
+    flushSettingsSave()
+  end
+  cancelRefreshModernHotkeysEvent()
+  cancelChatTextEvent()
   unload()
   hide()
 end
@@ -285,27 +425,31 @@ function toggle()
 end
 
 function ok()
-  save()
+  queueSave()
   hide()
-  refreshModernHotkeys()
 end
 
 function cancel()
-  reload()
+  queueSave()
   hide()
-  refreshModernHotkeys()
 end
 
 function load(forceDefaults)
   hotkeysManagerLoaded = false
   local settings = g_settings.getNode('game_hotkeys') or {}
-  local stored = settings
+  loadedServerKey = getServerKey()
+  loadedCharacterKey = getCharacterKey()
+  loadedProfileKey = getProfileKey()
+  loadedPerServer = perServer
+  loadedPerCharacter = perCharacter
 
-  if perServer then
-    stored = type(stored) == 'table' and stored[getServerKey()] or nil
-  end
-  if perCharacter then
-    stored = type(stored) == 'table' and stored[getCharacterKey()] or nil
+  local scope = getSettingsScope(settings, false, loadedServerKey, loadedCharacterKey,
+    loadedPerServer, loadedPerCharacter)
+  local stored
+  if type(scope) == 'table' and type(scope.profiles) == 'table' then
+    stored = scope.profiles[loadedProfileKey]
+  elseif isLegacyHotkeyTable(scope) then
+    stored = scope
   end
 
   hotkeyList = {}
@@ -324,6 +468,7 @@ function load(forceDefaults)
 end
 
 function unload()
+  hotkeysManagerLoaded = false
   for keyCombo, callback in pairs(boundCombosCallback) do
     g_keyboard.unbindKeyPress(keyCombo, callback, getGameRootPanel())
   end
@@ -342,6 +487,8 @@ end
 function reset()
   unload()
   load(true)
+  queueSave()
+  refreshModernHotkeys()
 end
 
 function reload()
@@ -349,24 +496,18 @@ function reload()
   load()
 end
 
-function save()
-  if not currentHotkeys then
+function save(flushToDisk)
+  if not currentHotkeys or not hotkeysManagerLoaded then
     return
   end
 
   local settings = g_settings.getNode('game_hotkeys') or {}
-  local stored = settings
-
-  if perServer then
-    local serverKey = getServerKey()
-    stored[serverKey] = stored[serverKey] or {}
-    stored = stored[serverKey]
-  end
-  if perCharacter then
-    local characterKey = getCharacterKey()
-    stored[characterKey] = stored[characterKey] or {}
-    stored = stored[characterKey]
-  end
+  local scope = getSettingsScope(settings, true, loadedServerKey, loadedCharacterKey,
+    loadedPerServer, loadedPerCharacter)
+  scope.profiles = type(scope.profiles) == 'table' and scope.profiles or {}
+  scope.profiles[loadedProfileKey] = type(scope.profiles[loadedProfileKey]) == 'table' and
+    scope.profiles[loadedProfileKey] or {}
+  local stored = scope.profiles[loadedProfileKey]
 
   table.clear(stored)
   for _, child in ipairs(currentHotkeys:getChildren()) do
@@ -382,7 +523,95 @@ function save()
 
   hotkeyList = stored
   g_settings.setNode('game_hotkeys', settings)
-  g_settings.save()
+  if flushToDisk ~= false then
+    cancelSaveEvent()
+    g_settings.save()
+  end
+end
+
+function queueSave()
+  if not currentHotkeys or not hotkeysManagerLoaded then
+    return
+  end
+  save(false)
+  scheduleSettingsSave()
+end
+
+function prepareProfileChange()
+  if not hotkeysManagerLoaded then
+    return
+  end
+  queueSave()
+  unload()
+end
+
+function finishProfileChange()
+  if not currentHotkeys or hotkeysManagerLoaded then
+    return
+  end
+  load()
+end
+
+function copyProfile(sourceProfile, targetProfile)
+  if not sourceProfile or sourceProfile == '' or not targetProfile or targetProfile == '' then
+    return
+  end
+  if hotkeysManagerLoaded then
+    save(false)
+  end
+  local sourceKey = encodeSettingsKey(sourceProfile)
+  local targetKey = encodeSettingsKey(targetProfile)
+  local settings = g_settings.getNode('game_hotkeys') or {}
+  local scope = getSettingsScope(settings, true, loadedServerKey or getServerKey(),
+    loadedCharacterKey or getCharacterKey(), loadedPerServer ~= false, loadedPerCharacter ~= false)
+  scope.profiles = type(scope.profiles) == 'table' and scope.profiles or {}
+  if type(scope.profiles[sourceKey]) == 'table' then
+    scope.profiles[targetKey] = cloneTable(scope.profiles[sourceKey])
+    g_settings.setNode('game_hotkeys', settings)
+    scheduleSettingsSave()
+  end
+end
+
+function renameProfile(sourceProfile, targetProfile)
+  if not sourceProfile or sourceProfile == '' or not targetProfile or targetProfile == '' then
+    return
+  end
+  if hotkeysManagerLoaded then
+    save(false)
+  end
+  local sourceKey = encodeSettingsKey(sourceProfile)
+  local targetKey = encodeSettingsKey(targetProfile)
+  local settings = g_settings.getNode('game_hotkeys') or {}
+  local scope = getSettingsScope(settings, true, loadedServerKey or getServerKey(),
+    loadedCharacterKey or getCharacterKey(), loadedPerServer ~= false, loadedPerCharacter ~= false)
+  scope.profiles = type(scope.profiles) == 'table' and scope.profiles or {}
+  if type(scope.profiles[sourceKey]) == 'table' then
+    scope.profiles[targetKey] = scope.profiles[sourceKey]
+    scope.profiles[sourceKey] = nil
+    if loadedProfileKey == sourceKey then
+      loadedProfileKey = targetKey
+    end
+    g_settings.setNode('game_hotkeys', settings)
+    scheduleSettingsSave()
+  end
+end
+
+function removeProfile(profileName)
+  if not profileName or profileName == '' then
+    return
+  end
+  local profileKey = encodeSettingsKey(profileName)
+  if hotkeysManagerLoaded and loadedProfileKey == profileKey then
+    unload()
+  end
+  local settings = g_settings.getNode('game_hotkeys') or {}
+  local scope = getSettingsScope(settings, false, loadedServerKey or getServerKey(),
+    loadedCharacterKey or getCharacterKey(), loadedPerServer ~= false, loadedPerCharacter ~= false)
+  if type(scope) == 'table' and type(scope.profiles) == 'table' then
+    scope.profiles[profileKey] = nil
+    g_settings.setNode('game_hotkeys', settings)
+    scheduleSettingsSave()
+  end
 end
 
 function loadDefautComboKeys()
@@ -408,7 +637,10 @@ end
 function onActionChange(comboBox)
   local option = comboBox:getCurrentOption()
   local action = option and option.data or 0
-  if not currentHotkeyLabel then
+  if not hotkeysManagerLoaded or not currentHotkeyLabel then
+    return
+  end
+  if (currentHotkeyLabel.action or 0) == action then
     return
   end
 
@@ -424,6 +656,7 @@ function onActionChange(comboBox)
   end
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(true, true)
+  queueSave()
 end
 
 function onChooseItemMouseRelease(self, mousePosition, mouseButton)
@@ -452,6 +685,7 @@ function onChooseItemMouseRelease(self, mousePosition, mouseButton)
     currentHotkeyLabel.autoSend = false
     updateHotkeyLabel(currentHotkeyLabel)
     updateHotkeyForm(true)
+    queueSave()
   end
 
   show()
@@ -461,6 +695,7 @@ function onChooseItemMouseRelease(self, mousePosition, mouseButton)
     g_mouse.popCursor('target')
   end
   self:ungrabMouse()
+  choosingItem = false
   return true
 end
 
@@ -474,6 +709,7 @@ function startChooseItem()
   else
     g_mouse.pushCursor('target')
   end
+  choosingItem = true
   hide()
 end
 
@@ -489,15 +725,23 @@ function clearObject()
   currentHotkeyLabel.action = nil
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(true)
+  queueSave()
 end
 
 function addHotkey()
+  if hotkeyAssignWindow then
+    hotkeyAssignWindow:destroy()
+  end
   local assignWindow = g_ui.createWidget('HotkeyAssignWindow', rootWidget)
+  hotkeyAssignWindow = assignWindow
   assignWindow:grabKeyboard()
   g_client.setInputLockWidget(assignWindow)
 
   assignWindow.onDestroy = function()
     g_client.setInputLockWidget(nil)
+    if hotkeyAssignWindow == assignWindow then
+      hotkeyAssignWindow = nil
+    end
   end
   local comboLabel = assignWindow:getChildById('comboPreview')
   comboLabel.keyCombo = ''
@@ -599,11 +843,14 @@ function doKeyCombo(keyCombo)
     if not modules.game_console.isChatEnabled() then
       modules.game_console.toggleChat()
     end
-    addEvent(function()
+    local text = hotkey.value
+    cancelChatTextEvent()
+    chatTextEvent = scheduleEvent(function()
+      chatTextEvent = nil
       if g_chat then
-        g_chat:setTextEditText(hotkey.value)
+        g_chat:setTextEditText(text)
       end
-    end)
+    end, 1)
   end
 end
 
@@ -890,11 +1137,17 @@ local function removeHotkeyLabel(hotkeyLabel)
 end
 
 function removeHotkey()
-  removeHotkeyLabel(currentHotkeyLabel)
+  if removeHotkeyLabel(currentHotkeyLabel) then
+    queueSave()
+    refreshModernHotkeys()
+  end
 end
 
 function onHotkeyTextChange(value)
   if not hotkeysManagerLoaded or not currentHotkeyLabel then
+    return
+  end
+  if currentHotkeyLabel.value == value then
     return
   end
   currentHotkeyLabel.value = value
@@ -903,6 +1156,7 @@ function onHotkeyTextChange(value)
   end
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(false, true)
+  queueSave()
 end
 
 function onSendAutomaticallyChange(autoSend)
@@ -910,28 +1164,36 @@ function onSendAutomaticallyChange(autoSend)
       not currentHotkeyLabel.value or currentHotkeyLabel.value == '' then
     return
   end
+  if currentHotkeyLabel.autoSend == autoSend then
+    return
+  end
   currentHotkeyLabel.autoSend = autoSend
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(false, true)
+  queueSave()
 end
 
 function onChangeUseType(useTypeWidget)
   if not hotkeysManagerLoaded or not currentHotkeyLabel then
     return
   end
+  local useType = HOTKEY_MANAGER_USE
   if useTypeWidget == useOnSelf then
-    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEONSELF
+    useType = HOTKEY_MANAGER_USEONSELF
   elseif useTypeWidget == useOnTarget then
-    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEONTARGET
+    useType = HOTKEY_MANAGER_USEONTARGET
   elseif useTypeWidget == useWith then
-    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEWITH
+    useType = HOTKEY_MANAGER_USEWITH
   elseif useTypeWidget == useAtCursor then
-    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEATCURSOR
-  else
-    currentHotkeyLabel.useType = HOTKEY_MANAGER_USE
+    useType = HOTKEY_MANAGER_USEATCURSOR
   end
+  if currentHotkeyLabel.useType == useType then
+    return
+  end
+  currentHotkeyLabel.useType = useType
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm()
+  queueSave()
 end
 
 function onSelectHotkeyLabel(hotkeyLabel)
@@ -954,6 +1216,8 @@ function hotkeyCaptureOk(assignWindow, keyCombo)
     return
   end
   addKeyCombo(keyCombo, nil, true)
+  queueSave()
+  refreshModernHotkeys()
   g_client.setInputLockWidget(nil)
   assignWindow:destroy()
 end
@@ -1049,7 +1313,7 @@ function removeHotkeyByCombo(keyCombo, persist)
     return false
   end
   if persist ~= false then
-    save()
+    queueSave()
   end
   return true
 end

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -1,0 +1,1063 @@
+HOTKEY_MANAGER_USE = nil
+HOTKEY_MANAGER_USEONSELF = 1
+HOTKEY_MANAGER_USEONTARGET = 2
+HOTKEY_MANAGER_USEWITH = 3
+HOTKEY_MANAGER_USEATCURSOR = 4
+
+HOTKEY_ACTION_TOGGLE_WASD = 1
+HOTKEY_ACTION_ATTACK_NEXT = 2
+HOTKEY_ACTION_ATTACK_PREV = 3
+HOTKEY_ACTION_TOGGLE_CHASE = 4
+
+HotkeyActions = {
+  { id = HOTKEY_ACTION_TOGGLE_WASD, text = tr('Toggle WASD chat mode') },
+  { id = HOTKEY_ACTION_ATTACK_NEXT, text = tr('Attack next creature in battle list') },
+  { id = HOTKEY_ACTION_ATTACK_PREV, text = tr('Attack previous creature in battle list') },
+  { id = HOTKEY_ACTION_TOGGLE_CHASE, text = tr('Toggle chase mode') }
+}
+
+HotkeyColors = {
+  text = '#888888',
+  textAutoSend = '#FFFFFF',
+  itemUse = '#8888FF',
+  itemUseSelf = '#00FF00',
+  itemUseTarget = '#FF0000',
+  itemUseWith = '#F5B325',
+  action = '#F97ACD'
+}
+
+local hotkeysManagerLoaded = false
+local hotkeysWindow
+local hotkeysWindowButton
+local currentHotkeyLabel
+local currentItemPreview
+local addHotkeyButton
+local removeHotkeyButton
+local hotkeyActionCombo
+local hotkeyText
+local hotKeyTextLabel
+local sendAutomatically
+local selectObjectButton
+local clearObjectButton
+local useOnSelf
+local useOnTarget
+local useWith
+local useAtCursor
+local defaultComboKeys
+local perServer = true
+local perCharacter = true
+local mouseGrabberWidget
+local useRadioGroup
+local currentHotkeys
+local boundCombosCallback = {}
+local hotkeyList = {}
+local hotkeyBlockingSources = {}
+local nextSourceId = 1
+local lastHotkeyTime = g_clock.millis()
+
+local function getGameRootPanel()
+  if m_interface and m_interface.getRootPanel then
+    return m_interface.getRootPanel()
+  end
+  if modules.game_interface and modules.game_interface.getRootPanel then
+    return modules.game_interface.getRootPanel()
+  end
+  return rootWidget
+end
+
+local function getServerKey()
+  local host = G and G.host or g_settings.getString('host') or 'default'
+  host = tostring(host):gsub('^https?://', '')
+  return host ~= '' and host or 'default'
+end
+
+local function getCharacterKey()
+  local name = g_game.getCharacterName()
+  return name and name ~= '' and name or 'default'
+end
+
+local function getHotkeyDelay()
+  if m_settings and m_settings.getOption then
+    return math.max(0, tonumber(m_settings.getOption('hotkeyDelay')) or 50)
+  end
+  return math.max(0, g_settings.getNumber('hotkeyDelay') or 50)
+end
+
+local function usesNativeCursor()
+  return m_settings and m_settings.getOption and m_settings.getOption('nativeMouseCursor') == true
+end
+
+local function unbindComboEverywhere(keyCombo)
+  local gameRootPanel = getGameRootPanel()
+  local targets = { rootWidget }
+  if gameRootPanel and gameRootPanel ~= rootWidget then
+    targets[#targets + 1] = gameRootPanel
+  end
+
+  for _, target in ipairs(targets) do
+    g_keyboard.unbindKeyPress(keyCombo, nil, target)
+    g_keyboard.unbindKeyDown(keyCombo, nil, target)
+    g_keyboard.unbindKeyUp(keyCombo, nil, target)
+  end
+end
+
+local function refreshModernHotkeys()
+  if not g_game.isOnline() then
+    return
+  end
+
+  addEvent(function()
+    if not g_game.isOnline() then
+      return
+    end
+    if modules.game_actionbar and modules.game_actionbar.switchChatMode and Options then
+      modules.game_actionbar.switchChatMode(Options.isChatOnEnabled == true)
+    elseif KeyBinds and KeyBinds.setupAndReset and Options then
+      KeyBinds:setupAndReset(Options.currentHotkeySetName,
+        Options.isChatOnEnabled and 'chatOn' or 'chatOff')
+    end
+
+    local customHotkeys = m_settings and m_settings.CustomHotkeys or
+      (modules.client_settings and modules.client_settings.CustomHotkeys)
+    if customHotkeys and customHotkeys.createList then
+      customHotkeys.createList(true)
+    end
+  end)
+end
+
+local function bindCombo(keyCombo)
+  unbindComboEverywhere(keyCombo)
+  boundCombosCallback[keyCombo] = function()
+    doKeyCombo(keyCombo)
+  end
+  g_keyboard.bindKeyPress(keyCombo, boundCombosCallback[keyCombo], getGameRootPanel())
+end
+
+function init()
+  hotkeysWindow = g_ui.displayUI('hotkeys_manager')
+  hotkeysWindow:hide()
+
+  hotkeysWindowButton = modules.client_topmenu.addRightGameToggleButton(
+    'hotkeysWindowButton', tr('Hotkeys') .. ' (Ctrl+K)', '/images/options/hotkeys', toggle)
+
+  currentHotkeys = hotkeysWindow:getChildById('currentHotkeys')
+  currentItemPreview = hotkeysWindow:getChildById('itemPreview')
+  addHotkeyButton = hotkeysWindow:getChildById('addHotkeyButton')
+  removeHotkeyButton = hotkeysWindow:getChildById('removeHotkeyButton')
+  hotkeyText = hotkeysWindow:getChildById('hotkeyText')
+  hotKeyTextLabel = hotkeysWindow:getChildById('hotKeyTextLabel')
+  sendAutomatically = hotkeysWindow:getChildById('sendAutomatically')
+  selectObjectButton = hotkeysWindow:getChildById('selectObjectButton')
+  clearObjectButton = hotkeysWindow:getChildById('clearObjectButton')
+  useOnSelf = hotkeysWindow:getChildById('useOnSelf')
+  useOnTarget = hotkeysWindow:getChildById('useOnTarget')
+  useWith = hotkeysWindow:getChildById('useWith')
+  useAtCursor = hotkeysWindow:getChildById('useAtCursor')
+
+  useRadioGroup = UIRadioGroup.create()
+  useRadioGroup:addWidget(useOnSelf)
+  useRadioGroup:addWidget(useOnTarget)
+  useRadioGroup:addWidget(useWith)
+  useRadioGroup:addWidget(useAtCursor)
+  useRadioGroup.onSelectionChange = function(_, selected)
+    onChangeUseType(selected)
+  end
+
+  hotkeyActionCombo = hotkeysWindow:getChildById('hotkeyActionCombo')
+  hotkeyActionCombo:addOption(tr('None'), 0)
+  for _, action in ipairs(HotkeyActions) do
+    hotkeyActionCombo:addOption(action.text, action.id)
+  end
+  hotkeyActionCombo.onOptionChange = onActionChange
+
+  mouseGrabberWidget = g_ui.createWidget('UIWidget')
+  mouseGrabberWidget:setVisible(false)
+  mouseGrabberWidget:setFocusable(false)
+  mouseGrabberWidget.onMouseRelease = onChooseItemMouseRelease
+
+  currentHotkeys.onChildFocusChange = function(_, hotkeyLabel)
+    onSelectHotkeyLabel(hotkeyLabel)
+  end
+  g_keyboard.bindKeyPress('Down', function()
+    currentHotkeys:focusNextChild(KeyboardFocusReason)
+  end, hotkeysWindow)
+  g_keyboard.bindKeyPress('Up', function()
+    currentHotkeys:focusPreviousChild(KeyboardFocusReason)
+  end, hotkeysWindow)
+
+  connect(g_game, {
+    onGameStart = online,
+    onGameEnd = offline
+  })
+
+  load()
+  if g_game.isOnline() then
+    online()
+  end
+end
+
+function terminate()
+  disconnect(g_game, {
+    onGameStart = online,
+    onGameEnd = offline
+  })
+
+  unload()
+
+  if hotkeysWindowButton then
+    hotkeysWindowButton:destroy()
+    hotkeysWindowButton = nil
+  end
+  if hotkeysWindow then
+    hotkeysWindow:destroy()
+    hotkeysWindow = nil
+  end
+  if mouseGrabberWidget then
+    mouseGrabberWidget:destroy()
+    mouseGrabberWidget = nil
+  end
+  if useRadioGroup then
+    useRadioGroup:destroy()
+    useRadioGroup = nil
+  end
+
+  hotkeyActionCombo = nil
+  hotKeyTextLabel = nil
+  hotkeyText = nil
+  sendAutomatically = nil
+  selectObjectButton = nil
+  clearObjectButton = nil
+  addHotkeyButton = nil
+  removeHotkeyButton = nil
+  currentItemPreview = nil
+  useOnSelf = nil
+  useOnTarget = nil
+  useWith = nil
+  useAtCursor = nil
+  currentHotkeys = nil
+  clearAllHotkeyBlocks()
+end
+
+function configure(savePerServer, savePerCharacter)
+  perServer = savePerServer
+  perCharacter = savePerCharacter
+  reload()
+end
+
+function online()
+  reload()
+  hide()
+  refreshModernHotkeys()
+end
+
+function offline()
+  unload()
+  hide()
+end
+
+function show()
+  if not g_game.isOnline() or not hotkeysWindow then
+    return
+  end
+  hotkeysWindow:show()
+  hotkeysWindow:raise()
+  hotkeysWindow:focus()
+  if hotkeysWindowButton then
+    hotkeysWindowButton:setOn(true)
+  end
+end
+
+function hide()
+  if hotkeysWindow then
+    hotkeysWindow:hide()
+  end
+  if hotkeysWindowButton then
+    hotkeysWindowButton:setOn(false)
+  end
+end
+
+function toggle()
+  if not hotkeysWindow or hotkeysWindow:isVisible() then
+    hide()
+  else
+    show()
+  end
+end
+
+function ok()
+  save()
+  hide()
+  refreshModernHotkeys()
+end
+
+function cancel()
+  reload()
+  hide()
+  refreshModernHotkeys()
+end
+
+function load(forceDefaults)
+  hotkeysManagerLoaded = false
+  local settings = g_settings.getNode('game_hotkeys') or {}
+  local stored = settings
+
+  if perServer then
+    stored = type(stored) == 'table' and stored[getServerKey()] or nil
+  end
+  if perCharacter then
+    stored = type(stored) == 'table' and stored[getCharacterKey()] or nil
+  end
+
+  hotkeyList = {}
+  if not forceDefaults and type(stored) == 'table' then
+    for keyCombo, keySettings in pairs(stored) do
+      local combo = tostring(keyCombo)
+      addKeyCombo(combo, keySettings)
+      hotkeyList[combo] = keySettings
+    end
+  end
+
+  if currentHotkeys:getChildCount() == 0 then
+    loadDefautComboKeys()
+  end
+  hotkeysManagerLoaded = true
+end
+
+function unload()
+  for keyCombo, callback in pairs(boundCombosCallback) do
+    g_keyboard.unbindKeyPress(keyCombo, callback, getGameRootPanel())
+  end
+  boundCombosCallback = {}
+  hotkeyList = {}
+  currentHotkeyLabel = nil
+
+  if currentHotkeys then
+    currentHotkeys:destroyChildren()
+  end
+  if hotkeysWindow then
+    updateHotkeyForm(true)
+  end
+end
+
+function reset()
+  unload()
+  load(true)
+end
+
+function reload()
+  unload()
+  load()
+end
+
+function save()
+  if not currentHotkeys then
+    return
+  end
+
+  local settings = g_settings.getNode('game_hotkeys') or {}
+  local stored = settings
+
+  if perServer then
+    local serverKey = getServerKey()
+    stored[serverKey] = stored[serverKey] or {}
+    stored = stored[serverKey]
+  end
+  if perCharacter then
+    local characterKey = getCharacterKey()
+    stored[characterKey] = stored[characterKey] or {}
+    stored = stored[characterKey]
+  end
+
+  table.clear(stored)
+  for _, child in ipairs(currentHotkeys:getChildren()) do
+    stored[child.keyCombo] = {
+      autoSend = child.autoSend,
+      itemId = child.itemId,
+      subType = child.subType,
+      useType = child.useType,
+      value = child.value,
+      action = child.action
+    }
+  end
+
+  hotkeyList = stored
+  g_settings.setNode('game_hotkeys', settings)
+  g_settings.save()
+end
+
+function loadDefautComboKeys()
+  if defaultComboKeys then
+    for keyCombo, keySettings in pairs(defaultComboKeys) do
+      addKeyCombo(keyCombo, keySettings)
+    end
+    return
+  end
+
+  for index = 1, 12 do
+    addKeyCombo('F' .. index)
+  end
+  for index = 1, 4 do
+    addKeyCombo('Shift+F' .. index)
+  end
+end
+
+function setDefaultComboKeys(combos)
+  defaultComboKeys = combos
+end
+
+function onActionChange(comboBox)
+  local option = comboBox:getCurrentOption()
+  local action = option and option.data or 0
+  if not currentHotkeyLabel then
+    return
+  end
+
+  if action > 0 then
+    currentHotkeyLabel.action = action
+    currentHotkeyLabel.itemId = nil
+    currentHotkeyLabel.subType = nil
+    currentHotkeyLabel.useType = nil
+    currentHotkeyLabel.value = nil
+    currentHotkeyLabel.autoSend = false
+  else
+    currentHotkeyLabel.action = nil
+  end
+  updateHotkeyLabel(currentHotkeyLabel)
+  updateHotkeyForm(true, true)
+end
+
+function onChooseItemMouseRelease(self, mousePosition, mouseButton)
+  local item
+  if mouseButton == MouseLeftButton then
+    local clickedWidget = getGameRootPanel():recursiveGetChildByPos(mousePosition, false)
+    if clickedWidget then
+      if clickedWidget:getClassName() == 'UIGameMap' then
+        local tile = clickedWidget:getTile(mousePosition)
+        local thing = tile and tile:getTopMoveThing()
+        if thing and thing:isItem() then
+          item = thing
+        end
+      elseif clickedWidget:getClassName() == 'UIItem' and not clickedWidget:isVirtual() then
+        item = clickedWidget:getItem()
+      end
+    end
+  end
+
+  if item and currentHotkeyLabel then
+    currentHotkeyLabel.itemId = item:getId()
+    currentHotkeyLabel.subType = item:isFluidContainer() and item:getSubType() or nil
+    currentHotkeyLabel.useType = item:isMultiUse() and HOTKEY_MANAGER_USEWITH or HOTKEY_MANAGER_USE
+    currentHotkeyLabel.value = nil
+    currentHotkeyLabel.action = nil
+    currentHotkeyLabel.autoSend = false
+    updateHotkeyLabel(currentHotkeyLabel)
+    updateHotkeyForm(true)
+  end
+
+  show()
+  if usesNativeCursor() then
+    g_window.restoreMouseCursor()
+  else
+    g_mouse.popCursor('target')
+  end
+  self:ungrabMouse()
+  return true
+end
+
+function startChooseItem()
+  if g_ui.isMouseGrabbed() then
+    return
+  end
+  mouseGrabberWidget:grabMouse()
+  if usesNativeCursor() then
+    g_window.setSystemCursor('cross')
+  else
+    g_mouse.pushCursor('target')
+  end
+  hide()
+end
+
+function clearObject()
+  if not currentHotkeyLabel then
+    return
+  end
+  currentHotkeyLabel.itemId = nil
+  currentHotkeyLabel.subType = nil
+  currentHotkeyLabel.useType = nil
+  currentHotkeyLabel.autoSend = false
+  currentHotkeyLabel.value = ''
+  currentHotkeyLabel.action = nil
+  updateHotkeyLabel(currentHotkeyLabel)
+  updateHotkeyForm(true)
+end
+
+function addHotkey()
+  local assignWindow = g_ui.createWidget('HotkeyAssignWindow', rootWidget)
+  assignWindow:grabKeyboard()
+  g_client.setInputLockWidget(assignWindow)
+
+  assignWindow.onDestroy = function()
+    g_client.setInputLockWidget(nil)
+  end
+  local comboLabel = assignWindow:getChildById('comboPreview')
+  comboLabel.keyCombo = ''
+  assignWindow.onKeyDown = hotkeyCapture
+end
+
+function addKeyCombo(keyCombo, keySettings, focus)
+  if not keyCombo or keyCombo == '' then
+    return
+  end
+
+  local existing = currentHotkeys:getChildById(keyCombo)
+  if existing then
+    if focus then
+      currentHotkeys:focusChild(existing)
+      currentHotkeys:ensureChildVisible(existing)
+      updateHotkeyForm(true)
+    end
+    return existing
+  end
+
+  local hotkeyLabel = g_ui.createWidget('HotkeyListLabel')
+  hotkeyLabel:setId(keyCombo)
+  local children = currentHotkeys:getChildren()
+  children[#children + 1] = hotkeyLabel
+  table.sort(children, function(a, b)
+    if a:getId():len() == b:getId():len() then
+      return a:getId() < b:getId()
+    end
+    return a:getId():len() < b:getId():len()
+  end)
+  for index, child in ipairs(children) do
+    if child == hotkeyLabel then
+      currentHotkeys:insertChild(index, hotkeyLabel)
+      break
+    end
+  end
+
+  hotkeyLabel.keyCombo = keyCombo
+  hotkeyLabel.autoSend = keySettings and toboolean(keySettings.autoSend) or false
+  hotkeyLabel.itemId = keySettings and tonumber(keySettings.itemId) or nil
+  hotkeyLabel.subType = keySettings and tonumber(keySettings.subType) or nil
+  hotkeyLabel.useType = keySettings and tonumber(keySettings.useType) or nil
+  hotkeyLabel.action = keySettings and tonumber(keySettings.action) or nil
+  hotkeyLabel.value = keySettings and tostring(keySettings.value or '') or ''
+
+  updateHotkeyLabel(hotkeyLabel)
+  bindCombo(keyCombo)
+
+  if focus then
+    currentHotkeyLabel = hotkeyLabel
+    currentHotkeys:focusChild(hotkeyLabel)
+    currentHotkeys:ensureChildVisible(hotkeyLabel)
+    updateHotkeyForm(true)
+  end
+  return hotkeyLabel
+end
+
+function doKeyCombo(keyCombo)
+  if not g_game.isOnline() or not canPerformKeyCombo(keyCombo) then
+    return
+  end
+
+  local hotkey = hotkeyList[keyCombo]
+  if not hotkey then
+    return
+  end
+
+  local now = g_clock.millis()
+  if now - lastHotkeyTime < getHotkeyDelay() then
+    return
+  end
+  lastHotkeyTime = now
+
+  if hotkey.action then
+    if hotkey.action == HOTKEY_ACTION_TOGGLE_WASD then
+      modules.game_console.toggleChat()
+    elseif hotkey.action == HOTKEY_ACTION_ATTACK_NEXT and modules.game_battle then
+      modules.game_battle.chooseNextCreature()
+    elseif hotkey.action == HOTKEY_ACTION_ATTACK_PREV and modules.game_battle then
+      modules.game_battle.choosePrevCreature()
+    elseif hotkey.action == HOTKEY_ACTION_TOGGLE_CHASE then
+      toggleChaseMode()
+    end
+    return
+  end
+
+  if hotkey.itemId then
+    executeHotkeyItem(hotkey.useType, hotkey.itemId, hotkey.subType)
+    return
+  end
+
+  if not hotkey.value or hotkey.value == '' then
+    return
+  end
+  if hotkey.autoSend then
+    modules.game_console.sendMessage(hotkey.value)
+  else
+    if not modules.game_console.isChatEnabled() then
+      modules.game_console.toggleChat()
+    end
+    addEvent(function()
+      if g_chat then
+        g_chat:setTextEditText(hotkey.value)
+      end
+    end)
+  end
+end
+
+function toggleChaseMode()
+  local nextMode = g_game.getChaseMode() == ChaseOpponent and DontChase or ChaseOpponent
+  g_game.setChaseMode(nextMode)
+end
+
+function executeHotkeyItem(action, itemId, subType)
+  local function getUseThingUnderCursor()
+    local mapPanel = m_interface and m_interface.getMapPanel and m_interface.getMapPanel()
+    if not mapPanel then
+      return nil
+    end
+
+    local mousePosition = g_window.getMousePosition()
+    if not mapPanel:containsPoint(mousePosition) then
+      return nil
+    end
+
+    local mapPosition = mapPanel:getPosition(mousePosition)
+    if not mapPosition then
+      return nil
+    end
+
+    local player = g_game.getLocalPlayer()
+    if player and mapPosition.z ~= player:getPosition().z then
+      local dz = mapPosition.z - player:getPosition().z
+      mapPosition.x = mapPosition.x + dz
+      mapPosition.y = mapPosition.y + dz
+      mapPosition.z = player:getPosition().z
+    end
+
+    local tile = g_map.getTile(mapPosition)
+    if not tile then
+      return nil
+    end
+
+    local virtualItem = Item.create(itemId)
+    if virtualItem:isFluidContainer() or virtualItem:isMultiUse() then
+      return tile:getTopMultiUseThing()
+    end
+    return tile:getTopUseThing()
+  end
+
+  local function getInventoryItem()
+    return g_game.findPlayerItem(itemId, subType or -1)
+  end
+
+  local function getUseItem()
+    if g_game.getClientVersion() < 780 or subType then
+      return getInventoryItem()
+    end
+    return Item.create(itemId)
+  end
+
+  if action == HOTKEY_MANAGER_USE then
+    if g_game.getClientVersion() < 780 or subType then
+      local item = getInventoryItem()
+      if item then
+        g_game.use(item)
+      end
+    else
+      g_game.useInventoryItem(itemId)
+    end
+  elseif action == HOTKEY_MANAGER_USEONSELF then
+    local player = g_game.getLocalPlayer()
+    if g_game.getClientVersion() < 780 or subType then
+      local item = getInventoryItem()
+      if item and player then
+        g_game.useWith(item, player)
+      end
+    elseif player then
+      g_game.useInventoryItemWith(itemId, player)
+    end
+  elseif action == HOTKEY_MANAGER_USEONTARGET then
+    local target = g_game.getAttackingCreature()
+    if not target then
+      local item = getUseItem()
+      if item then
+        modules.game_interface.startUseWith(item, subType)
+      end
+      return
+    end
+    if not target:getTile() then
+      return
+    end
+    if g_game.getClientVersion() < 780 or subType then
+      local item = getInventoryItem()
+      if item then
+        g_game.useWith(item, target)
+      end
+    else
+      g_game.useInventoryItemWith(itemId, target)
+    end
+  elseif action == HOTKEY_MANAGER_USEWITH then
+    local item = getUseItem()
+    if item then
+      modules.game_interface.startUseWith(item, subType)
+    end
+  elseif action == HOTKEY_MANAGER_USEATCURSOR then
+    local useThing = getUseThingUnderCursor()
+    if not useThing then
+      local item = getUseItem()
+      if item then
+        modules.game_interface.startUseWith(item, subType)
+      end
+      return
+    end
+    if g_game.getClientVersion() < 780 or subType then
+      local item = getInventoryItem()
+      if item then
+        g_game.useWith(item, useThing)
+      end
+    else
+      g_game.useInventoryItemWith(itemId, useThing)
+    end
+  end
+end
+
+function updateHotkeyLabel(hotkeyLabel)
+  if not hotkeyLabel then
+    return
+  end
+
+  if hotkeyLabel.useType == HOTKEY_MANAGER_USEONSELF then
+    hotkeyLabel:setText(tr('%s: (use object on yourself)', hotkeyLabel.keyCombo))
+    hotkeyLabel:setColor(HotkeyColors.itemUseSelf)
+  elseif hotkeyLabel.useType == HOTKEY_MANAGER_USEONTARGET then
+    hotkeyLabel:setText(tr('%s: (use object on target)', hotkeyLabel.keyCombo))
+    hotkeyLabel:setColor(HotkeyColors.itemUseTarget)
+  elseif hotkeyLabel.useType == HOTKEY_MANAGER_USEWITH then
+    hotkeyLabel:setText(tr('%s: (use object with crosshair)', hotkeyLabel.keyCombo))
+    hotkeyLabel:setColor(HotkeyColors.itemUseWith)
+  elseif hotkeyLabel.useType == HOTKEY_MANAGER_USEATCURSOR then
+    hotkeyLabel:setText(tr('%s: (use object at cursor position)', hotkeyLabel.keyCombo))
+    hotkeyLabel:setColor(HotkeyColors.itemUseWith)
+  elseif hotkeyLabel.itemId then
+    hotkeyLabel:setText(tr('%s: (use object)', hotkeyLabel.keyCombo))
+    hotkeyLabel:setColor(HotkeyColors.itemUse)
+  elseif hotkeyLabel.action then
+    local description = ''
+    for _, action in ipairs(HotkeyActions) do
+      if action.id == hotkeyLabel.action then
+        description = action.text
+        break
+      end
+    end
+    hotkeyLabel:setText(string.format('%s: %s', hotkeyLabel.keyCombo, description))
+    hotkeyLabel:setColor(HotkeyColors.action)
+  else
+    hotkeyLabel:setText(hotkeyLabel.keyCombo .. ': ' .. (hotkeyLabel.value or ''))
+    hotkeyLabel:setColor(hotkeyLabel.autoSend and HotkeyColors.textAutoSend or HotkeyColors.text)
+  end
+end
+
+function updateHotkeyForm(reset, dontUpdateCombo)
+  if not hotkeysWindow then
+    return
+  end
+
+  if not currentHotkeyLabel then
+    if not dontUpdateCombo then
+      hotkeyActionCombo:setCurrentIndex(1)
+    end
+    hotkeyActionCombo:disable()
+    removeHotkeyButton:disable()
+    hotkeyText:disable()
+    hotKeyTextLabel:disable()
+    sendAutomatically:disable()
+    selectObjectButton:disable()
+    clearObjectButton:disable()
+    useOnSelf:disable()
+    useOnTarget:disable()
+    useWith:disable()
+    useAtCursor:disable()
+    hotkeyText:clearText()
+    useRadioGroup:clearSelected()
+    sendAutomatically:setChecked(false)
+    currentItemPreview:clearItem()
+    return
+  end
+
+  removeHotkeyButton:enable()
+  if currentHotkeyLabel.itemId then
+    if not dontUpdateCombo then
+      hotkeyActionCombo:setCurrentIndex(1)
+    end
+    hotkeyActionCombo:disable()
+    hotkeyText:clearText()
+    hotkeyText:disable()
+    hotKeyTextLabel:disable()
+    sendAutomatically:setChecked(false)
+    sendAutomatically:disable()
+    selectObjectButton:disable()
+    clearObjectButton:enable()
+    currentItemPreview:setItemId(currentHotkeyLabel.itemId)
+    if currentHotkeyLabel.subType then
+      currentItemPreview:setItemSubType(currentHotkeyLabel.subType)
+    end
+
+    local item = currentItemPreview:getItem()
+    if item and item:isMultiUse() then
+      useOnSelf:enable()
+      useOnTarget:enable()
+      useWith:enable()
+      useAtCursor:enable()
+      if currentHotkeyLabel.useType == HOTKEY_MANAGER_USEONSELF then
+        useRadioGroup:selectWidget(useOnSelf)
+      elseif currentHotkeyLabel.useType == HOTKEY_MANAGER_USEONTARGET then
+        useRadioGroup:selectWidget(useOnTarget)
+      elseif currentHotkeyLabel.useType == HOTKEY_MANAGER_USEWITH then
+        useRadioGroup:selectWidget(useWith)
+      elseif currentHotkeyLabel.useType == HOTKEY_MANAGER_USEATCURSOR then
+        useRadioGroup:selectWidget(useAtCursor)
+      end
+    else
+      useOnSelf:disable()
+      useOnTarget:disable()
+      useWith:disable()
+      useAtCursor:disable()
+      useRadioGroup:clearSelected()
+    end
+  elseif currentHotkeyLabel.action then
+    if not dontUpdateCombo then
+      hotkeyActionCombo:setCurrentOptionByData(currentHotkeyLabel.action)
+    end
+    hotkeyActionCombo:enable()
+    hotkeyText:clearText()
+    hotkeyText:disable()
+    hotKeyTextLabel:disable()
+    sendAutomatically:setChecked(false)
+    sendAutomatically:disable()
+    selectObjectButton:disable()
+    clearObjectButton:disable()
+    useOnSelf:disable()
+    useOnTarget:disable()
+    useWith:disable()
+    useAtCursor:disable()
+    useRadioGroup:clearSelected()
+    currentItemPreview:clearItem()
+  else
+    if not dontUpdateCombo then
+      hotkeyActionCombo:setCurrentIndex(1)
+    end
+    hotkeyActionCombo:enable()
+    useOnSelf:disable()
+    useOnTarget:disable()
+    useWith:disable()
+    useAtCursor:disable()
+    useRadioGroup:clearSelected()
+    hotkeyText:enable()
+    hotKeyTextLabel:enable()
+    hotkeyText:setText(currentHotkeyLabel.value or '')
+    if reset then
+      hotkeyText:setCursorPos(-1)
+    end
+    sendAutomatically:setChecked(currentHotkeyLabel.autoSend == true)
+    sendAutomatically:setEnabled(currentHotkeyLabel.value and currentHotkeyLabel.value ~= '')
+    selectObjectButton:enable()
+    clearObjectButton:disable()
+    currentItemPreview:clearItem()
+  end
+end
+
+local function removeHotkeyLabel(hotkeyLabel)
+  if not hotkeyLabel then
+    return false
+  end
+
+  local keyCombo = hotkeyLabel.keyCombo
+  local callback = boundCombosCallback[keyCombo]
+  if callback then
+    g_keyboard.unbindKeyPress(keyCombo, callback, getGameRootPanel())
+  end
+  boundCombosCallback[keyCombo] = nil
+  hotkeyList[keyCombo] = nil
+  if currentHotkeyLabel == hotkeyLabel then
+    currentHotkeyLabel = nil
+  end
+  hotkeyLabel:destroy()
+  updateHotkeyForm(true)
+  return true
+end
+
+function removeHotkey()
+  removeHotkeyLabel(currentHotkeyLabel)
+end
+
+function onHotkeyTextChange(value)
+  if not hotkeysManagerLoaded or not currentHotkeyLabel then
+    return
+  end
+  currentHotkeyLabel.value = value
+  if value == '' then
+    currentHotkeyLabel.autoSend = false
+  end
+  updateHotkeyLabel(currentHotkeyLabel)
+  updateHotkeyForm(false, true)
+end
+
+function onSendAutomaticallyChange(autoSend)
+  if not hotkeysManagerLoaded or not currentHotkeyLabel or
+      not currentHotkeyLabel.value or currentHotkeyLabel.value == '' then
+    return
+  end
+  currentHotkeyLabel.autoSend = autoSend
+  updateHotkeyLabel(currentHotkeyLabel)
+  updateHotkeyForm(false, true)
+end
+
+function onChangeUseType(useTypeWidget)
+  if not hotkeysManagerLoaded or not currentHotkeyLabel then
+    return
+  end
+  if useTypeWidget == useOnSelf then
+    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEONSELF
+  elseif useTypeWidget == useOnTarget then
+    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEONTARGET
+  elseif useTypeWidget == useWith then
+    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEWITH
+  elseif useTypeWidget == useAtCursor then
+    currentHotkeyLabel.useType = HOTKEY_MANAGER_USEATCURSOR
+  else
+    currentHotkeyLabel.useType = HOTKEY_MANAGER_USE
+  end
+  updateHotkeyLabel(currentHotkeyLabel)
+  updateHotkeyForm()
+end
+
+function onSelectHotkeyLabel(hotkeyLabel)
+  currentHotkeyLabel = hotkeyLabel
+  updateHotkeyForm(true)
+end
+
+function hotkeyCapture(assignWindow, keyCode, keyboardModifiers)
+  local keyCombo = determineKeyComboDesc(keyCode, keyboardModifiers)
+  local comboPreview = assignWindow:getChildById('comboPreview')
+  comboPreview:setText(tr('Current hotkey to add: %s', keyCombo))
+  comboPreview.keyCombo = keyCombo
+  comboPreview:resizeToText()
+  assignWindow:getChildById('addButton'):setEnabled(keyCombo ~= '')
+  return true
+end
+
+function hotkeyCaptureOk(assignWindow, keyCombo)
+  if not keyCombo or keyCombo == '' then
+    return
+  end
+  addKeyCombo(keyCombo, nil, true)
+  g_client.setInputLockWidget(nil)
+  assignWindow:destroy()
+end
+
+function enableHotkeys(sourceId)
+  if sourceId then
+    hotkeyBlockingSources[sourceId] = nil
+  end
+end
+
+function disableHotkeys(sourceIdentifier)
+  local sourceId = sourceIdentifier or ('auto_' .. nextSourceId)
+  nextSourceId = nextSourceId + 1
+  hotkeyBlockingSources[sourceId] = true
+  return sourceId
+end
+
+local function getCallerModule()
+  local info = debug.getinfo(3, 'S')
+  if not info or not info.source then
+    return 'unknown'
+  end
+  local source = info.source:gsub('@', '')
+  local moduleName = source:match('/modules/([^/]+)/') or
+    source:match('\\modules\\([^\\]+)\\') or source:match('([^/\\]+)%.lua$') or 'unknown'
+  return moduleName:gsub('_', '')
+end
+
+function createHotkeyBlock(sourceIdentifier)
+  local callerModule = getCallerModule()
+  local fullId = sourceIdentifier and (sourceIdentifier .. '_' .. callerModule) or
+    ('auto_' .. callerModule .. '_' .. nextSourceId)
+  local blockId = disableHotkeys(fullId)
+  return {
+    release = function()
+      enableHotkeys(blockId)
+    end,
+    getId = function()
+      return fullId
+    end
+  }
+end
+
+function areHotkeysDisabled()
+  return next(hotkeyBlockingSources) ~= nil
+end
+
+function clearAllHotkeyBlocks()
+  hotkeyBlockingSources = {}
+end
+
+function getHotkeyBlockingInfo()
+  local sources = {}
+  for sourceId in pairs(hotkeyBlockingSources) do
+    sources[#sources + 1] = sourceId
+  end
+  table.sort(sources)
+  return #sources, sources
+end
+
+function printHotkeyBlockingInfo()
+  local count, sources = getHotkeyBlockingInfo()
+  print('=== Hotkey Blocking Info ===')
+  print('Total blocks: ' .. count)
+  for index, source in ipairs(sources) do
+    print('  ' .. index .. '. ' .. source)
+  end
+  print('============================')
+end
+
+function canPerformKeyCombo(keyCombo)
+  if areHotkeysDisabled() then
+    return false
+  end
+  if not modules.game_console.isChatEnabled() then
+    return true
+  end
+
+  local platformType = g_window.getPlatformType() or ''
+  if platformType:find('MACOS') then
+    return keyCombo:match('Cmd%+') or keyCombo:match('Ctrl%+') or
+      keyCombo:match('Alt%+') or keyCombo:match('Option%+') or keyCombo:match('F%d+')
+  end
+  return keyCombo:match('Ctrl%+') or keyCombo:match('Alt%+') or keyCombo:match('F%d+')
+end
+
+function removeHotkeyByCombo(keyCombo, persist)
+  if not keyCombo or keyCombo == '' or not currentHotkeys then
+    return false
+  end
+  local hotkeyLabel = currentHotkeys:getChildById(keyCombo)
+  if not removeHotkeyLabel(hotkeyLabel) then
+    return false
+  end
+  if persist ~= false then
+    save()
+  end
+  return true
+end
+
+function isHotkeyUsedByManager(keyCombo)
+  if not keyCombo or keyCombo == '' then
+    return false
+  end
+  return boundCombosCallback[keyCombo] ~= nil or
+    (currentHotkeys and currentHotkeys:getChildById(keyCombo) ~= nil)
+end

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -446,10 +446,13 @@ function load(forceDefaults)
   local scope = getSettingsScope(settings, false, loadedServerKey, loadedCharacterKey,
     loadedPerServer, loadedPerCharacter)
   local stored
+  local hasStoredProfile = false
   if type(scope) == 'table' and type(scope.profiles) == 'table' then
     stored = scope.profiles[loadedProfileKey]
+    hasStoredProfile = stored ~= nil
   elseif isLegacyHotkeyTable(scope) then
     stored = scope
+    hasStoredProfile = true
   end
 
   hotkeyList = {}
@@ -461,7 +464,7 @@ function load(forceDefaults)
     end
   end
 
-  if currentHotkeys:getChildCount() == 0 then
+  if forceDefaults or not hasStoredProfile then
     loadDefautComboKeys()
   end
   hotkeysManagerLoaded = true

--- a/modules/game_hotkeys/hotkeys_manager.otmod
+++ b/modules/game_hotkeys/hotkeys_manager.otmod
@@ -1,0 +1,9 @@
+Module
+  name: game_hotkeys
+  description: Manage classic client hotkeys
+  author: andrefaramir, BeniS, AstraClient
+  website: https://github.com/opentibiabr/otclient
+  sandboxed: true
+  scripts: [ hotkeys_manager ]
+  @onLoad: init()
+  @onUnload: terminate()

--- a/modules/game_hotkeys/hotkeys_manager.otui
+++ b/modules/game_hotkeys/hotkeys_manager.otui
@@ -11,7 +11,7 @@ HotkeyListLabel < UILabel
 MainWindow
   id: hotkeysWindow
   !text: tr('Hotkeys')
-  size: 340 470
+  size: 380 470
 
   @onEnter: modules.game_hotkeys.ok()
   @onEscape: modules.game_hotkeys.cancel()
@@ -204,7 +204,7 @@ MainWindow
 
   Button
     id: cancelButton
-    !text: tr('Cancel')
+    !text: tr('Close')
     width: 64
     anchors.right: parent.right
     anchors.bottom: parent.bottom

--- a/modules/game_hotkeys/hotkeys_manager.otui
+++ b/modules/game_hotkeys/hotkeys_manager.otui
@@ -1,0 +1,258 @@
+HotkeyListLabel < UILabel
+  font: verdana-11px-monochrome
+  background-color: alpha
+  text-offset: 2 0
+  focusable: true
+  phantom: false
+
+  $focus:
+    background-color: #ffffff22
+
+MainWindow
+  id: hotkeysWindow
+  !text: tr('Hotkeys')
+  size: 340 470
+
+  @onEnter: modules.game_hotkeys.ok()
+  @onEscape: modules.game_hotkeys.cancel()
+
+  Label
+    id: currentHotkeysLabel
+    !text: tr('Current hotkeys') .. ':'
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
+
+  VerticalScrollBar
+    id: currentHotkeysScrollBar
+    height: 150
+    anchors.top: parent.top
+    anchors.right: parent.right
+    step: 14
+    pixels-scroll: true
+
+  TextList
+    id: currentHotkeys
+    vertical-scrollbar: currentHotkeysScrollBar
+    anchors.left: parent.left
+    anchors.right: prev.left
+    anchors.top: prev.top
+    anchors.bottom: prev.bottom
+    focusable: false
+
+  Button
+    id: resetButton
+    width: 96
+    !text: tr('Reset All')
+    anchors.left: parent.left
+    anchors.top: next.top
+    @onClick: modules.game_hotkeys.reset()
+    margin-right: 10
+
+  Button
+    id: addHotkeyButton
+    !text: tr('Add')
+    width: 64
+    anchors.right: next.left
+    anchors.top: next.top
+    margin-right: 5
+    @onClick: modules.game_hotkeys.addHotkey()
+
+  Button
+    id: removeHotkeyButton
+    !text: tr('Remove')
+    width: 64
+    enabled: false
+    anchors.right: parent.right
+    anchors.top: currentHotkeys.bottom
+    margin-top: 8
+    @onClick: modules.game_hotkeys.removeHotkey()
+
+  Label
+    id: hotKeyActionLabel
+    !text: tr('Hotkey Action') .. ':'
+    enabled: false
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 10
+
+  ComboBox
+    id: hotkeyActionCombo
+    enabled: false
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 2
+    mouse-scroll: false
+
+  Label
+    id: hotKeyTextLabel
+    !text: tr('Edit hotkey text') .. ':'
+    enabled: false
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 10
+
+  TextEdit
+    id: hotkeyText
+    enabled: false
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    margin-top: 2
+    @onTextChange: modules.game_hotkeys.onHotkeyTextChange(self:getText())
+
+  CheckBox
+    id: sendAutomatically
+    !text: tr('Send automatically')
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    enabled: false
+    margin-top: 5
+    @onCheckChange: modules.game_hotkeys.onSendAutomaticallyChange(self:isChecked())
+
+  Item
+    id: itemPreview
+    anchors.left: parent.left
+    anchors.top: prev.bottom
+    margin-top: 10
+    virtual: true
+
+  Button
+    id: selectObjectButton
+    !text: tr('Select object')
+    width: 128
+    enabled: false
+    anchors.left: prev.right
+    anchors.top: prev.top
+    margin-left: 10
+    @onClick: modules.game_hotkeys.startChooseItem()
+
+  Button
+    id: clearObjectButton
+    !text: tr('Clear object')
+    width: 128
+    enabled: false
+    anchors.left: prev.left
+    anchors.right: prev.right
+    anchors.top: prev.bottom
+    margin-top: 2
+    @onClick: modules.game_hotkeys.clearObject()
+
+  ButtonBox
+    id: useOnSelf
+    !text: tr('Use on yourself')
+    width: 128
+    enabled: false
+    anchors.left: selectObjectButton.right
+    anchors.right: parent.right
+    anchors.top: selectObjectButton.top
+    checked: false
+    margin-left: 10
+
+  ButtonBox
+    id: useOnTarget
+    !text: tr('Use on target')
+    width: 128
+    enabled: false
+    anchors.left: prev.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    checked: false
+    margin-top: 2
+
+  ButtonBox
+    id: useWith
+    !text: tr('With crosshair')
+    width: 128
+    enabled: false
+    anchors.left: prev.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    checked: false
+    margin-top: 2
+
+  ButtonBox
+    id: useAtCursor
+    !text: tr('Use at cursor position')
+    width: 128
+    enabled: false
+    anchors.left: prev.left
+    anchors.right: parent.right
+    anchors.top: prev.bottom
+    checked: false
+    margin-top: 2
+
+  HorizontalSeparator
+    id: separator
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: next.top
+    margin-bottom: 10
+
+  Button
+    id: okButton
+    !text: tr('Ok')
+    width: 64
+    anchors.right: next.left
+    anchors.bottom: parent.bottom
+    @onClick: modules.game_hotkeys.ok()
+    margin-right: 10
+
+  Button
+    id: cancelButton
+    !text: tr('Cancel')
+    width: 64
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    @onClick: modules.game_hotkeys.cancel()
+
+HotkeyAssignWindow < MainWindow
+  id: assignWindow
+  !text: tr('Button Assign')
+  size: 360 150
+  @onEscape: self:destroy()
+
+  Label
+    !text: tr('Please, press the key you wish to add onto your hotkeys manager')
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
+    text-auto-resize: true
+    text-align: left
+
+  Label
+    id: comboPreview
+    !text: tr('Current hotkey to add: %s', 'none')
+    anchors.horizontalCenter: parent.horizontalCenter
+    anchors.top: prev.bottom
+    margin-top: 10
+    text-auto-resize: true
+
+  HorizontalSeparator
+    id: separator
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.bottom: next.top
+    margin-bottom: 10
+
+  Button
+    id: addButton
+    !text: tr('Add')
+    width: 64
+    enabled: false
+    anchors.right: next.left
+    anchors.bottom: parent.bottom
+    margin-right: 10
+    @onClick: modules.game_hotkeys.hotkeyCaptureOk(self:getParent(), self:getParent():getChildById('comboPreview').keyCombo)
+
+  Button
+    id: cancelButton
+    !text: tr('Cancel')
+    width: 64
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    @onClick: self:getParent():destroy()

--- a/modules/game_interface/interface.otmod
+++ b/modules/game_interface/interface.otmod
@@ -30,6 +30,7 @@ Module
     - game_walking
     - game_itemselector
     - game_actionbar
+    - game_hotkeys
     - game_prey
     - game_imbuing
     - game_stats


### PR DESCRIPTION
## What changed

- ports the complete `game_hotkeys` manager from opentibiabr/otclient (mehah)
- adds the classic F1-F12 and Shift+F1-F4 workflow with text, auto-send, item selection, and self/target/crosshair/cursor use modes
- saves every edit by server, character, and active hotkey preset, including copy, rename, and removal of presets
- flushes pending changes on logout and client shutdown, while debouncing disk writes during typing
- encodes OTML scope keys so hosts such as `127.0.0.1:7171:860` remain valid after a full client restart
- routes Ctrl+K and a top-menu button to the classic manager
- coordinates classic hotkeys with general keybinds, custom hotkeys, and action bars so one key does not execute twice
- splits preset rebuild work across frames and cancels scheduled callbacks during logout/termination
- widens the classic window so `Use at cursor position` is not clipped
- preserves the upstream MIT license and attribution

## Why

Players using the 8.6 classic setup prefer the compact classic hotkey manager. Astra previously exposed only the modern preset-oriented editor, and copying the module without persistence and integration allowed settings to disappear after restart or duplicate callbacks for the same key.

## Validation

- parsed every changed Lua file with `luac -p`
- ran `git diff --check`
- launched `otclient_dx_x64.exe` against the working tree with no module/UI `ERROR` or `FATAL`
- wrote classic hotkeys in one client process and loaded them in a second fresh process
- verified active presets remain isolated across the process restart
- restored the local `config.otml` after the persistence test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado um gerenciador completo de teclas de atalho.
  * Permite configurar ações, uso de itens, mensagens automáticas e atalhos especiais.
  * Inclui criação, edição, remoção, redefinição e captura de combinações de teclas.
  * Perfis de atalhos podem ser salvos por servidor e personagem.

* **Correções**
  * Impedidos conflitos entre atalhos personalizados, da barra de ações e do sistema global.
  * Atalhos são bloqueados temporariamente durante estados do jogo que impedem sua execução.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->