### PR TITLE
fix(ui): restore focus after window close

### DIFF
--- a/modules/corelib/globals.lua
+++ b/modules/corelib/globals.lua
@@ -477,6 +477,16 @@ if g_ui then
   g_ui.isUsedCallEscapeKey = g_ui.isUsedCallEscapeKey or function()
     return callEscapeKey
   end
+  g_ui.isUsedCallEnterKey = g_ui.isUsedCallEnterKey or function()
+    return callEnterKey
+  end
+  -- Reset per-key guards before the focused widget chain handles the press.
+  -- UIWindow raises these flags when it consumes Escape or Enter; without a
+  -- reset, one consumed press would suppress all later global hotkeys.
+  g_ui.onKeyDown = g_ui.onKeyDown or function()
+    callEscapeKey = false
+    callEnterKey = false
+  end
   g_ui.getActionTimer = g_ui.getActionTimer or function()
     return 0
   end

--- a/modules/corelib/ui/uiwindow.lua
+++ b/modules/corelib/ui/uiwindow.lua
@@ -23,7 +23,27 @@ function UIWindow:onKeyDown(keyCode, keyboardModifiers)
 end
 
 function UIWindow:onFocusChange(focused)
-  if focused then self:raise() end
+  if focused then
+    self:raise()
+    return
+  end
+
+  -- Hiding a focused window makes the framework choose a previous sibling.
+  -- Restore the in-game focus chain so global movement and action hotkeys keep
+  -- reaching gameRootPanel after any feature window closes.
+  if not self:isDestroyed() and self:isExplicitlyVisible() then
+    return
+  end
+
+  if not g_game.isOnline() then
+    return
+  end
+
+  local root = rootWidget or g_ui.getRootWidget()
+  local gameWindow = root and root:getChildById('gameRootPanel')
+  if gameWindow and gameWindow:isVisible() then
+    gameWindow:focus()
+  end
 end
 
 function UIWindow:onDragEnter(mousePos)

--- a/modules/corelib/ui/uiwindow.lua
+++ b/modules/corelib/ui/uiwindow.lua
@@ -41,6 +41,12 @@ function UIWindow:onFocusChange(focused)
 
   local root = rootWidget or g_ui.getRootWidget()
   local gameWindow = root and root:getChildById('gameRootPanel')
+  local focusedWidget = root and root:getFocusedChild()
+  if focusedWidget and focusedWidget ~= self and focusedWidget ~= gameWindow
+      and focusedWidget:isFocusable() and focusedWidget:isVisible() then
+    return
+  end
+
   if gameWindow and gameWindow:isVisible() then
     gameWindow:focus()
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Melhorias**
  * Aprimorado o gerenciamento das teclas Enter e Escape durante a interação com elementos da interface.
  * Janelas agora são trazidas para frente imediatamente ao receber foco.
  * Ao perder o foco, as janelas respeitam melhor sua visibilidade e podem restaurar o foco da interface principal quando apropriado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->