### PR TITLE
perf: remove per-kill work from the creature death frame

### DIFF
--- a/mods/game_analyser/analyser.lua
+++ b/mods/game_analyser/analyser.lua
@@ -354,6 +354,16 @@ function onImpactTracker(analyzerType, amount, effect, target)
 end
 
 function onKillTracker(monsterName, monsterOutfit, dropItems, lootItems, lootNames)
+  -- 0xD1 is the first thing the client sees for a death, so it opens the KillPerf scope.
+  if KillPerf then
+    KillPerf.newKill(monsterName)
+    return KillPerf.measure("onKillTracker", onKillTrackerImpl,
+      monsterName, monsterOutfit, dropItems, lootItems, lootNames)
+  end
+  return onKillTrackerImpl(monsterName, monsterOutfit, dropItems, lootItems, lootNames)
+end
+
+function onKillTrackerImpl(monsterName, monsterOutfit, dropItems, lootItems, lootNames)
   HuntingAnalyser:addMonsterKilled(monsterName)
 
   for index, item in ipairs(lootItems or {}) do

--- a/mods/game_analyser/classes/LootAnalyser.lua
+++ b/mods/game_analyser/classes/LootAnalyser.lua
@@ -51,7 +51,10 @@ function LootAnalyser:queueWindowUpdate()
 		end
 
 		LootAnalyser:checkBalance(true)
-		LootAnalyser:updateGraphics()
+		-- Keep the gold/h figure current for the labels, but leave the graph sample to the
+		-- Controller's 60s cycle: the graph is a time series, so appending a point per kill
+		-- would both distort it and touch a widget on every kill.
+		LootAnalyser:refreshGoldHour()
 		if LootAnalyser.window:isVisible() then
 			LootAnalyser:updateWindow(true, true)
 		end
@@ -194,14 +197,18 @@ function LootAnalyser:updateWindow(updateScroll, ignoreVisible)
 	contentsPanel.lootedItems:setHeight(35 * (numOfLines + ((numOfLines > 0 and numOfItems == 0) and -1 or 0)))
 end
 
-function LootAnalyser:updateGraphics()
+-- Pure arithmetic, no widget access: safe to call while the window is hidden.
+function LootAnalyser:refreshGoldHour()
 	local uptime = math.floor((g_clock.millis() - LootAnalyser.launchTime)/1000)
 	if uptime < 5*60 then
 		LootAnalyser.goldHour = LootAnalyser.goldValue
 	else
 		LootAnalyser.goldHour = math.floor((LootAnalyser.goldValue/uptime)*3600)
 	end
+end
 
+function LootAnalyser:updateGraphics()
+	LootAnalyser:refreshGoldHour()
 	LootAnalyser.window.contentsPanel.graphPanel:addValue(LootAnalyser.goldHour)
 end
 

--- a/mods/game_cyclopedia/cyclopediaprotocol.lua
+++ b/mods/game_cyclopedia/cyclopediaprotocol.lua
@@ -40,9 +40,27 @@ local RESP_BESTIARY_PROGRESS = 6
 local registered = false
 local monsterCache = {}
 
+-- g_things.getMonsterList() walks every known creature type and rebuilds a fresh table on each
+-- call, so it must not be called from anything that runs per kill. Both lists are memoized:
+-- the static one never changes during a session, and the merged one is invalidated whenever
+-- monsterCache is written.
+local staticMonsterList = nil
+local mergedMonsterList = nil
+
+local function invalidateMonsterLists()
+  staticMonsterList = nil
+  mergedMonsterList = nil
+end
+
+local function getStaticMonsterList()
+  if not staticMonsterList then
+    staticMonsterList = g_things.getMonsterList() or {}
+  end
+  return staticMonsterList
+end
+
 local function getStaticCreatureName(raceId)
-  local monsters = g_things.getMonsterList()
-  local creature = monsters and monsters[tonumber(raceId) or 0]
+  local creature = getStaticMonsterList()[tonumber(raceId) or 0]
   return creature and creature[1]
 end
 
@@ -71,6 +89,7 @@ local function cacheCreatureInfo(raceId, creature)
     creature.feet,
     creature.addons
   }
+  mergedMonsterList = nil
 end
 
 function cacheCyclopediaMonster(raceId, creature)
@@ -94,12 +113,22 @@ function cacheCyclopediaMonster(raceId, creature)
   })
 end
 
+-- The returned table is shared and must be treated as read-only by callers.
 function getCyclopediaMonsterList()
-  local monsters = g_things.getMonsterList() or {}
+  if mergedMonsterList then
+    return mergedMonsterList
+  end
+
+  local monsters = {}
+  for raceId, creature in pairs(getStaticMonsterList()) do
+    monsters[raceId] = creature
+  end
   for raceId, creature in pairs(monsterCache) do
     monsters[raceId] = creature
   end
-  return monsters
+
+  mergedMonsterList = monsters
+  return mergedMonsterList
 end
 
 function getCyclopediaMonster(raceId)
@@ -369,9 +398,17 @@ local function onCyclopediaMessage(protocolGame, msg)
   elseif response == RESP_BESTIARY_MONSTER then
     parseBestiaryMonster(msg)
   elseif response == RESP_TRACKER then
-    parseTracker(msg)
+    if KillPerf then
+      KillPerf.measure("cyclopedia.parseTracker", parseTracker, msg)
+    else
+      parseTracker(msg)
+    end
   elseif response == RESP_BESTIARY_PROGRESS then
-    parseBestiaryProgress(msg)
+    if KillPerf then
+      KillPerf.measure("cyclopedia.bestiaryProgress", parseBestiaryProgress, msg)
+    else
+      parseBestiaryProgress(msg)
+    end
   end
   return true
 end
@@ -380,6 +417,8 @@ function CyclopediaProtocol.register()
   if registered then
     return
   end
+  -- Drop the memoized lists so a creature reload between sessions cannot leave them stale.
+  invalidateMonsterLists()
   ProtocolGame.unregisterOpcode(OPCODE_SEND)
   ProtocolGame.registerOpcode(OPCODE_SEND, onCyclopediaMessage)
   registered = true

--- a/mods/game_killperf/killperf.lua
+++ b/mods/game_killperf/killperf.lua
@@ -1,0 +1,130 @@
+--[[
+  KillPerf -- temporary profiler for the frame in which a creature dies.
+
+  Disabled by default: with KillPerf.enabled == false every helper is a direct passthrough
+  with no clock read, so leaving this mod installed costs nothing.
+
+  Turn it on from the console:
+
+      KillPerf.start()            -- log anything >= 0.5 ms
+      KillPerf.start(1000)        -- log anything >= 1.0 ms
+      KillPerf.stop()
+      KillPerf.report()           -- totals per system since start()
+
+  Output looks like:
+
+      [KillPerf] kill #1258 Demon
+      [KillPerf]   onKillTracker            2.140 ms
+      [KillPerf]   BestiaryTracker.render   3.870 ms
+
+  A system appearing twice under the same kill id means it is registered twice.
+]]
+
+KillPerf = KillPerf or {}
+
+KillPerf.enabled = false
+KillPerf.thresholdUs = 500
+KillPerf.killSeq = 0
+
+local stats = {}
+local currentKill = nil
+
+local function record(label, elapsedUs)
+  local entry = stats[label]
+  if not entry then
+    entry = { count = 0, totalUs = 0, maxUs = 0, perKill = 0 }
+    stats[label] = entry
+  end
+  entry.count = entry.count + 1
+  entry.totalUs = entry.totalUs + elapsedUs
+  if elapsedUs > entry.maxUs then
+    entry.maxUs = elapsedUs
+  end
+end
+
+-- Opens a new kill scope. Call this where the death first becomes visible to the client.
+function KillPerf.newKill(name)
+  if not KillPerf.enabled then
+    return
+  end
+  KillPerf.killSeq = KillPerf.killSeq + 1
+  currentKill = KillPerf.killSeq
+  for _, entry in pairs(stats) do
+    entry.perKill = 0
+  end
+  g_logger.info(string.format("[KillPerf] kill #%d %s", currentKill, tostring(name or "?")))
+end
+
+-- Times fn(...) under `label` and returns its results untouched.
+function KillPerf.measure(label, fn, ...)
+  if not KillPerf.enabled then
+    return fn(...)
+  end
+
+  local startedAt = g_clock.realMicros()
+  local a, b, c, d = fn(...)
+  local elapsedUs = g_clock.realMicros() - startedAt
+
+  record(label, elapsedUs)
+  local entry = stats[label]
+  entry.perKill = entry.perKill + 1
+
+  if elapsedUs >= KillPerf.thresholdUs then
+    local duplicate = entry.perKill > 1 and "  <-- SECOND CALL IN THE SAME KILL" or ""
+    g_logger.info(string.format("[KillPerf]   %-28s %7.3f ms%s",
+      label, elapsedUs / 1000, duplicate))
+  elseif entry.perKill > 1 then
+    g_logger.info(string.format("[KillPerf]   %-28s duplicate call in kill #%s",
+      label, tostring(currentKill)))
+  end
+
+  return a, b, c, d
+end
+
+-- Wraps a function once, so it reports under `label` every time it is called.
+function KillPerf.wrap(label, fn)
+  if type(fn) ~= "function" then
+    return fn
+  end
+  return function(...)
+    return KillPerf.measure(label, fn, ...)
+  end
+end
+
+function KillPerf.start(thresholdUs)
+  KillPerf.thresholdUs = tonumber(thresholdUs) or 500
+  KillPerf.enabled = true
+  stats = {}
+  KillPerf.killSeq = 0
+  g_logger.info(string.format("[KillPerf] enabled, threshold %.3f ms", KillPerf.thresholdUs / 1000))
+end
+
+function KillPerf.stop()
+  KillPerf.enabled = false
+  g_logger.info("[KillPerf] disabled")
+end
+
+function KillPerf.report()
+  local rows = {}
+  for label, entry in pairs(stats) do
+    rows[#rows + 1] = { label = label, entry = entry }
+  end
+  table.sort(rows, function(a, b) return a.entry.totalUs > b.entry.totalUs end)
+
+  g_logger.info(string.format("[KillPerf] report over %d kill(s)", KillPerf.killSeq))
+  g_logger.info(string.format("[KillPerf] %-28s %8s %10s %10s %10s",
+    "system", "calls", "total ms", "avg ms", "max ms"))
+  for _, row in ipairs(rows) do
+    local e = row.entry
+    g_logger.info(string.format("[KillPerf] %-28s %8d %10.3f %10.3f %10.3f",
+      row.label, e.count, e.totalUs / 1000, (e.totalUs / e.count) / 1000, e.maxUs / 1000))
+  end
+end
+
+function init()
+end
+
+function terminate()
+  KillPerf.enabled = false
+  stats = {}
+end

--- a/mods/game_killperf/killperf.otmod
+++ b/mods/game_killperf/killperf.otmod
@@ -1,0 +1,11 @@
+Module
+  name: game_killperf
+  description: Temporary profiler for the creature-death frame. Disabled by default.
+  author: audit
+  reloadable: true
+  sandboxed: false
+  autoload: true
+  autoload-priority: 1100
+  scripts: [ killperf ]
+  @onLoad: init()
+  @onUnload: terminate()

--- a/mods/game_proficiency/proficiency.lua
+++ b/mods/game_proficiency/proficiency.lua
@@ -716,7 +716,11 @@ function onWeaponProficiencyExperience(itemId, experience, hasUnusedPerk)
 
     WeaponProficiency.dirtyItemIds = WeaponProficiency.dirtyItemIds or {}
     WeaponProficiency.dirtyItemIds[itemId] = true
-    scheduleDataRefresh()
+    if KillPerf then
+        KillPerf.measure("proficiency.xpPacket", scheduleDataRefresh)
+    else
+        scheduleDataRefresh()
+    end
 end
 
 -- Update the proficiency button highlight based on unused perk state

--- a/mods/game_proficiency/proficiency.lua
+++ b/mods/game_proficiency/proficiency.lua
@@ -432,6 +432,40 @@ function cancelDataRefresh()
     WeaponProficiency.dataRefreshEvent = nil
 end
 
+-- Runs the catalog sort that was deferred while the window was closed.
+function flushPendingProficiencySort()
+    if not WeaponProficiency.catalogNeedsSort then
+        return
+    end
+    WeaponProficiency.catalogNeedsSort = false
+    sortWeaponProficiency(MarketCategory.WeaponsAll)
+    for _, categoryId in pairs(WeaponProficiency.ItemCategory) do
+        sortWeaponProficiency(categoryId)
+    end
+end
+
+local function sortDirtyCategories(dirtyItems)
+    if WeaponProficiency.catalogNeedsSort then
+        flushPendingProficiencySort()
+        return
+    end
+
+    -- Determine which categories need re-sorting from the dirty items.
+    local dirtyCategories = {}
+    for itemId in pairs(dirtyItems) do
+        local marketItem = WeaponProficiency:findMarketItem(itemId)
+        local cat = marketItem and marketItem.marketData and marketItem.marketData.category
+        if cat and cat ~= MarketCategory.WeaponsAll then
+            dirtyCategories[cat] = true
+        end
+        -- WeaponsAll always needs sorting when any item is dirty.
+        dirtyCategories[MarketCategory.WeaponsAll] = true
+    end
+    for categoryId in pairs(dirtyCategories) do
+        sortWeaponProficiency(categoryId)
+    end
+end
+
 function scheduleDataRefresh()
     if WeaponProficiency.dataRefreshEvent then
         return
@@ -441,37 +475,26 @@ function scheduleDataRefresh()
         local dirtyItems = WeaponProficiency.dirtyItemIds or {}
         WeaponProficiency.dirtyItemIds = {}
 
-        if WeaponProficiency.catalogNeedsSort then
-            WeaponProficiency.catalogNeedsSort = false
-            sortWeaponProficiency(MarketCategory.WeaponsAll)
-            for _, categoryId in pairs(WeaponProficiency.ItemCategory) do
-                sortWeaponProficiency(categoryId)
+        -- Sorting only decides the order of the item list widget, and findMarketItem is a
+        -- linear scan of the whole catalog feeding it. Nothing reads either while the window
+        -- is closed, and an experience packet arrives on every kill, so defer the work to
+        -- whenever the window is actually shown.
+        if not (WeaponProficiency.window and WeaponProficiency.window:isVisible()) then
+            if next(dirtyItems) ~= nil then
+                WeaponProficiency.catalogNeedsSort = true
             end
-        else
-            -- Determine which categories need re-sorting from the dirty items.
-            local dirtyCategories = {}
-            for itemId in pairs(dirtyItems) do
-                local marketItem = WeaponProficiency:findMarketItem(itemId)
-                local cat = marketItem and marketItem.marketData and marketItem.marketData.category
-                if cat and cat ~= MarketCategory.WeaponsAll then
-                    dirtyCategories[cat] = true
-                end
-                -- WeaponsAll always needs sorting when any item is dirty.
-                dirtyCategories[MarketCategory.WeaponsAll] = true
-            end
-            for categoryId in pairs(dirtyCategories) do
-                sortWeaponProficiency(categoryId)
-            end
+            updateTopBarProficiency()
+            return
         end
 
-        if WeaponProficiency.window and WeaponProficiency.window:isVisible() then
-            WeaponProficiency:refreshItemList(false)
-            local selectedId = WeaponProficiency.selectedItemId
-            local selected = selectedId and WeaponProficiency.cacheList[selectedId] or nil
-            local isDirty = selected and dirtyItems[selectedId]
-            if isDirty then
-                WeaponProficiency:displayProficiencyData(selectedId, selected.exp, selected.perks)
-            end
+        sortDirtyCategories(dirtyItems)
+
+        WeaponProficiency:refreshItemList(false)
+        local selectedId = WeaponProficiency.selectedItemId
+        local selected = selectedId and WeaponProficiency.cacheList[selectedId] or nil
+        local isDirty = selected and dirtyItems[selectedId]
+        if isDirty then
+            WeaponProficiency:displayProficiencyData(selectedId, selected.exp, selected.perks)
         end
         updateTopBarProficiency()
     end)
@@ -750,6 +773,9 @@ function show()
             bright:setVisible(false)
         end
     end
+
+    -- Apply the sort skipped while the window was closed, before the list is built.
+    flushPendingProficiencySort()
 
     -- Refresh item list to show all items
     WeaponProficiency:refreshItemList()
@@ -1272,8 +1298,19 @@ function sortWeaponProficiency(marketCategory)
         local expB = WeaponProficiency.cacheList[idB] and WeaponProficiency.cacheList[idB].exp or 0
 
         if expA == expB then
-            local nameA = (a.marketData.name or ""):lower()
-            local nameB = (b.marketData.name or ""):lower()
+            -- Equal experience is the common case (most weapons sit at 0), so this branch runs
+            -- for most comparisons. Memoize the lowercased name instead of allocating a new
+            -- string on every comparison; marketData.name never changes after the catalog load.
+            local nameA = a.sortName
+            if not nameA then
+                nameA = (a.marketData.name or ""):lower()
+                a.sortName = nameA
+            end
+            local nameB = b.sortName
+            if not nameB then
+                nameB = (b.marketData.name or ""):lower()
+                b.sortName = nameB
+            end
             return nameA < nameB
         end
         return expA > expB

--- a/mods/game_trackers/classes/bestiary_tracker.lua
+++ b/mods/game_trackers/classes/bestiary_tracker.lua
@@ -216,6 +216,14 @@ end
 
 function BestiaryTracker.showTrackerData(update)
 	BestiaryTracker.cancelRender()
+
+	-- The server resends the whole tracker list every time a tracked creature is killed, so
+	-- this runs per kill. Everything below only produces widgets, so with the window closed it
+	-- is pure waste; toggleBestiaryTracker() re-renders from BestiaryTrackerList on open.
+	if not bestiaryTrackerWindow or not bestiaryTrackerWindow:isVisible() then
+		return
+	end
+
 	if not BestiaryTrackerList or #BestiaryTrackerList == 0 then
 		bestiaryTrackerWindow.contentsPanel:destroyChildren()
 		return

--- a/mods/game_trackers/classes/boss_tracker.lua
+++ b/mods/game_trackers/classes/boss_tracker.lua
@@ -50,6 +50,12 @@ function BossTracker.resetWindow()
 end
 
 function BossTracker.showTrackerData()
+	-- Same as the bestiary tracker: this is driven by a server push and only builds widgets,
+	-- so skip it entirely while the window is closed. toggleBossTracker() re-renders on open.
+	if not bossTrackerWindow or not bossTrackerWindow:isVisible() then
+		return
+	end
+
 	bossTrackerWindow.contentsPanel:destroyChildren()
 
 	if not BossTrackerList or #BossTrackerList == 0 then

--- a/mods/game_trackers/game_trackers.lua
+++ b/mods/game_trackers/game_trackers.lua
@@ -94,10 +94,18 @@ end
 function Trackers.onMonsterTrackerData(trackerType, monsterData)
 	if trackerType == 0 then
 		BestiaryTrackerList = monsterData
-		BestiaryTracker.showTrackerData()
+		if KillPerf then
+			KillPerf.measure("BestiaryTracker.render", BestiaryTracker.showTrackerData)
+		else
+			BestiaryTracker.showTrackerData()
+		end
 	else
 		BossTrackerList = monsterData
-		BossTracker.showTrackerData()
+		if KillPerf then
+			KillPerf.measure("BossTracker.render", BossTracker.showTrackerData)
+		else
+			BossTracker.showTrackerData()
+		end
 	end
 end
 
@@ -109,8 +117,10 @@ function toggleBossTracker()
 		if m_interface.addToPanels(bossTrackerWindow) then
 			bossTrackerWindow:getParent():moveChildToIndex(bossTrackerWindow, #bossTrackerWindow:getParent():getChildren())
 			BossTracker.initSortFields()
-			BossTracker.showTrackerData()
 		end
+		-- Rendering is skipped while the window is closed, so it has to happen on every open,
+		-- not only the first one that adds the window to a panel.
+		BossTracker.showTrackerData()
 	end
 end
 
@@ -123,9 +133,11 @@ function toggleBestiaryTracker()
 		if m_interface.addToPanels(bestiaryTrackerWindow) then
 			bestiaryTrackerWindow:getParent():moveChildToIndex(bestiaryTrackerWindow, #bestiaryTrackerWindow:getParent():getChildren())
 			BestiaryTracker.initSortFields()
-			BestiaryTracker.showTrackerData()
     		modules.game_sidebuttons.setButtonVisible("bestiaryTrackerWidget", true)
 		end
+		-- Rendering is skipped while the window is closed, so it has to happen on every open,
+		-- not only the first one that adds the window to a panel.
+		BestiaryTracker.showTrackerData()
 	end
 end
 


### PR DESCRIPTION
## Problem

There is a micro-stutter exactly on the frame where a creature dies. `Otcv8--Classic-8.6` connected to the same server does not stutter.

Two per-kill costs were found and removed. The second one is the largest.

---

## Root cause #2 — full monster list rebuilt on every kill (largest)

The server resends **the entire bestiary tracker list** every time a tracked creature dies (`sendTrackerIfTracked` → `sendTracker`, `data/scripts/network/cyclopedia/ciclopedia.lua`). Astra handles that with `BestiaryTracker.showTrackerData()`, which calls `getCyclopediaMonsterList()` → `g_things.getMonsterList()`.

That C++ binding (`src/client/creatures.cpp:170`) iterates over **all** known creature types, builds a `std::map` with a copied string for every creature, and the Lua binding then materializes **one table per monster**. There was no cache at all. So this entire path ran on every tracked-creature death — which, when farming the same monster, means **every single kill**.

Worse, `cacheCreatureInfo()` could call `getMonsterList()` again for each tracked entry when the name was missing, so one tracker packet could rebuild the monster list multiple times.

Neither tracker checked whether its window was open. Everything below the entry point only produces widgets, so doing it with the window closed was entirely wasted work.

**This explains the A/B test:** Classic does not have the bestiary tracker.

### Fix

- Both monster lists are now memoized. The static list does not change during the session; the merged list is invalidated whenever `monsterCache` is written. The returned table is now shared and must be treated as read-only — all current callers only index it.
- Added visibility guards to `BestiaryTracker.showTrackerData()` and `BossTracker.showTrackerData()`.
- Tracker toggles now render on **every** open, not only the first time the window is added to the panel. This is required because rendering is now skipped while the window is closed.

---

## Root cause #1 — weapon catalog sort on every kill

The server sends `0x5C` (proficiency XP) on every kill that grants weapon XP. `onWeaponProficiencyExperience` reacted by re-sorting the catalog: `table.sort` over **670 entries** (~6,300 comparisons) plus a linear `findMarketItem` scan, while the visibility guard protected only `refreshItemList`.

The comparator also called `:lower()` on both names for every comparison. Equal experience is the common case because most weapons stay at 0 XP, so that branch ran for most comparisons → roughly 12,000 temporary strings per kill.

### Fix

- Deferred sorting: a kill now only marks the catalog as dirty, and `show()` performs one sort before building the list. Behavior remains identical while the window is open.
- Lowercase name is memoized in the market item.
- `LootAnalyser:queueWindowUpdate` used to call `updateGraphics()` before `window:isVisible()`. Gold/gold-per-hour arithmetic still runs every time; only the widget update was removed from the kill path and left to the Controller's 60-second cycle.

---

## Instrumentation: `mods/game_killperf`

Disabled by default — when `KillPerf.enabled == false`, the helpers become direct passthroughs with no clock reads.

```
KillPerf.start()       -- logs >= 0.5 ms
KillPerf.start(1000)   -- logs >= 1.0 ms
KillPerf.report()
KillPerf.stop()
```

Output:

```
[KillPerf] kill #1258 Demon
[KillPerf]   onKillTracker              2.140 ms
[KillPerf]   BestiaryTracker.render     3.870 ms
```

Each kill gets a sequence id. **If one system appears twice under the same id, that indicates duplicate registration** — exactly the duplication test requested.

Instrumented points: `onKillTracker`, `cyclopedia.parseTracker`, `cyclopedia.bestiaryProgress`, `BestiaryTracker.render`, `BossTracker.render`, `proficiency.xpPacket`.

---

## Duplications checked and **not found**

- **Bestiary C++ + Lua:** not duplicated. `creature.cpp:689` increments once and queues via `setPendingBestiaryKill`; Lua consumes it exactly once with `takePendingBestiaryKill`. This is a handoff, not a double-count.
- **Loot 0xD1 + 0xCF:** already guarded — `sendHuntAnalyzerKill` skips the legacy `0xCF` stream for Astra.
- **Prey:** has no kill hook. Zero per-kill cost.

## Server-side findings (not fixed here — they belong to the other repository)

- `sendTracker` sends the full tracker state when only one counter changes.
- `BattlePassSystem.onKill` runs `loadState` (3 `scoped()` calls + KV deserialization) and scans all general missions before knowing whether any mission cares about that monster; there is no early return for the feature-disabled case; `sendMissionState` resends the full state.

## Test plan

- [ ] `KillPerf.start()`, 30 kills, `KillPerf.report()` — no system should appear 2× under the same kill id
- [ ] Kill a **tracked** bestiary creature with the tracker **closed** — main reproduction case
- [ ] Open the bestiary tracker afterward: the list should appear complete and sorted
- [ ] Close and reopen the tracker multiple times — content must return every time because rendering now happens on every open
- [ ] Boss tracker: same open/close cycle
- [ ] 100 kills with the proficiency window closed, then open it: list should be sorted by experience
- [ ] Loot Analyzer: gold and gold/hour remain correct; graph continues receiving points every 60 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
