### PR TITLE
fix(hotkeys): rebuild classic hotkey ownership and binding lifecycle

### DIFF
--- a/mods/client_settings/classes/custom-hotkeys.lua
+++ b/mods/client_settings/classes/custom-hotkeys.lua
@@ -14,6 +14,54 @@ local UseColors = {
     ["SmartCast"] = {color = "#e788fb", text = "(use object on cursor position)"},
 }
 
+-- Nil-safe view of the classic manager's ownership. Only an executable classic
+-- hotkey blocks a custom one; a blank F3 row must not.
+local function isClassicComboClaimed(keyCombo)
+    local manager = modules and modules.game_hotkeys
+    return (manager and manager.isComboClaimed and manager.isComboClaimed(keyCombo)) or false
+end
+
+local function releaseCustomBinding(binding)
+    if not binding then
+        return
+    end
+    g_keyboard.unbindKeyPress(binding.combo, binding.press, binding.widget)
+    g_keyboard.unbindKeyDown(binding.combo, binding.down, binding.widget)
+end
+
+-- The old rebuild unbound with a nil callback and, worse, on the default widget
+-- while the bind had used gameRootPanel. It therefore missed its own callbacks
+-- and cleared everyone else's on rootWidget. Bindings are now recorded per row
+-- and removed with the same callback and widget they were created with.
+local function unbindCustomHotkeys(widget)
+    if not widget then
+        return
+    end
+    releaseCustomBinding(widget.primaryBinding)
+    releaseCustomBinding(widget.secondaryBinding)
+    widget.primaryBinding = nil
+    widget.secondaryBinding = nil
+end
+
+local function bindCustomHotkey(widget, keyCombo, slot)
+    if not widget or not keyCombo or #keyCombo == 0 then
+        return
+    end
+    releaseCustomBinding(widget[slot])
+
+    local press = function() onExecuteAction(widget) end
+    local down = function() onExecuteAction(widget) end
+    widget[slot] = {
+        combo = keyCombo,
+        press = press,
+        down = down,
+        widget = gameRootPanel
+    }
+
+    g_keyboard.bindKeyPress(keyCombo, press, gameRootPanel)
+    g_keyboard.bindKeyDown(keyCombo, down, gameRootPanel)
+end
+
 function CustomHotkeys.createList(save)
     if save == nil then
         save = false
@@ -24,10 +72,7 @@ function CustomHotkeys.createList(save)
 
     -- unbind old list
     for _, child in pairs(hotkeyList:getChildren()) do
-      if child.hotkey and #child.hotkey > 0 then
-        g_keyboard.unbindKeyPress(child.hotkey, nil)
-        g_keyboard.unbindKeyDown(child.hotkey, nil)
-      end
+      unbindCustomHotkeys(child)
     end
 
     local chatType = currentWindow:recursiveGetChildById('chatOnCheckBox'):isChecked() and "chatOn" or "chatOff"
@@ -117,23 +162,21 @@ function CustomHotkeys.createList(save)
       widget:setBackgroundColor(background)
       widget.background = background
 
-      local primaryBlocked = #widget.hotkey > 0 and isKeyClaimedByHotkeyManager(widget.hotkey)
+      local primaryBlocked = #widget.hotkey > 0 and isClassicComboClaimed(widget.hotkey)
       if primaryBlocked then
         widget.primary:setColor(CLASSIC_HOTKEY_WARNING_COLOR)
         widget.primary:setTooltip(CLASSIC_HOTKEY_WARNING_TOOLTIP)
-      elseif #widget.hotkey > 0 then
-        g_keyboard.bindKeyPress(widget.hotkey, function() onExecuteAction(widget) end, gameRootPanel)
-        g_keyboard.bindKeyDown(widget.hotkey, function() onExecuteAction(widget) end, gameRootPanel)
+      else
+        bindCustomHotkey(widget, widget.hotkey, "primaryBinding")
       end
 
       local secondaryBlocked = widget.secondaryHotkey and #widget.secondaryHotkey > 0 and
-        isKeyClaimedByHotkeyManager(widget.secondaryHotkey)
+        isClassicComboClaimed(widget.secondaryHotkey)
       if secondaryBlocked then
         widget.secondary:setColor(CLASSIC_HOTKEY_WARNING_COLOR)
         widget.secondary:setTooltip(CLASSIC_HOTKEY_WARNING_TOOLTIP)
-      elseif widget.secondaryHotkey and #widget.secondaryHotkey > 0 then
-        g_keyboard.bindKeyPress(widget.secondaryHotkey, function() onExecuteAction(widget) end, gameRootPanel)
-        g_keyboard.bindKeyDown(widget.secondaryHotkey, function() onExecuteAction(widget) end, gameRootPanel)
+      else
+        bindCustomHotkey(widget, widget.secondaryHotkey, "secondaryBinding")
       end
     end
 
@@ -792,7 +835,9 @@ function CustomHotkeys.onAssignHotkey(widget, secondaryHotkey)
       if KeyBinds:hotkeyIsUsed(text) and text ~= '' then
         local key = KeyBind:getKeyBindByHotkey(text)
         if key then
-          g_keyboard.unbindKeyPress(key.firstKey, nil)
+          -- setFirstKey removes the keybind's own down/up/press callbacks by
+          -- identity; unbinding the combo here would strip other systems too.
+          key:setFirstKey('')
           Options.removeActionHotkey(chatOn and "chatOn" or "chatOff", key.jsonName)
         end
       end
@@ -800,19 +845,14 @@ function CustomHotkeys.onAssignHotkey(widget, secondaryHotkey)
       if text ~= '' then
         local key = KeyBind:getKeyBindBySecondHotkey(text)
         if key then
-          g_keyboard.unbindKeyPress(key.secondKey, nil)
+          key:setSecondKey('')
           Options.removeActionHotkey(chatOn and "chatOn" or "chatOff", key.jsonName)
         end
       end
 
       if modules.game_actionbar.isHotkeyUsed(text, false) then
-        local usedButton = modules.game_actionbar.getUsedHotkeyButton(text)
-        if usedButton then
-          Options.removeHotkey(usedButton:getId())
-          g_keyboard.unbindKeyPress(text, nil, m_interface.getRootPanel())
-          g_keyboard.unbindKeyDown(text, nil, m_interface.getRootPanel())
-          modules.game_actionbar.updateButton(usedButton)
-        end
+        -- Let the action bar drop its own button binding.
+        modules.game_actionbar.removeHotkey(text)
       end
 
       if modules.game_actionbar.isHotkeyUsed(text, true) then
@@ -829,8 +869,8 @@ function CustomHotkeys.onAssignHotkey(widget, secondaryHotkey)
     end
 
     assignWindow.buttonClear.onClick = function()
-      g_keyboard.unbindKeyPress(text, nil, m_interface.getRootPanel())
-      g_keyboard.unbindKeyDown(text, nil, m_interface.getRootPanel())
+      releaseCustomBinding(widget[secondaryHotkey and "secondaryBinding" or "primaryBinding"])
+      widget[secondaryHotkey and "secondaryBinding" or "primaryBinding"] = nil
       Options.updateCustomHotkey(widget, '', chatOn, secondaryHotkey)
       CustomHotkeys.updateWidget(widget, '', secondaryHotkey)
       g_client.setInputLockWidget(nil)
@@ -843,11 +883,9 @@ function CustomHotkeys.onAssignHotkey(widget, secondaryHotkey)
 end
 
 function CustomHotkeys.updateWidget(widget, text, isSecondary)
-  local currentHotkey = isSecondary and widget.secondaryHotkey or widget.hotkey
-  if currentHotkey and #currentHotkey > 0 then
-    g_keyboard.unbindKeyPress(currentHotkey, nil, m_interface.getRootPanel())
-    g_keyboard.unbindKeyDown(currentHotkey, nil, m_interface.getRootPanel())
-  end
+  local slot = isSecondary and "secondaryBinding" or "primaryBinding"
+  releaseCustomBinding(widget[slot])
+  widget[slot] = nil
 
   if isSecondary then
     widget.secondaryHotkey = text
@@ -890,17 +928,14 @@ function CustomHotkeys.checkAndRemoveUsedHotkey(text, chatOn, secondary)
     for _, child in pairs(currentWindow:recursiveGetChildById("hotkeyList"):getChildren()) do
         if child.hotkey ~= '' and child.hotkey == text then
           Options.updateCustomHotkey(child, '', chatOn)
+          -- updateWidget already released this row's own binding.
           CustomHotkeys.updateWidget(child, '')
-          g_keyboard.unbindKeyPress(text, nil)
-          g_keyboard.unbindKeyDown(text, nil)
           return
         end
 
         if child.secondaryHotkey ~= '' and child.secondaryHotkey == text then
           Options.updateCustomHotkey(child, '', chatOn, secondary)
           CustomHotkeys.updateWidget(child, '', secondary)
-          g_keyboard.unbindKeyPress(text, nil)
-          g_keyboard.unbindKeyDown(text, nil)
           return
         end
     end

--- a/mods/client_settings/classes/custom-hotkeys.lua
+++ b/mods/client_settings/classes/custom-hotkeys.lua
@@ -899,8 +899,7 @@ function CustomHotkeys.updateWidget(widget, text, isSecondary)
     if modules.game_hotkeys and modules.game_hotkeys.removeHotkeyByCombo then
       modules.game_hotkeys.removeHotkeyByCombo(text)
     end
-    g_keyboard.bindKeyPress(text, function() onExecuteAction(widget) end, m_interface.getRootPanel())
-    g_keyboard.bindKeyDown(text, function() onExecuteAction(widget) end, m_interface.getRootPanel())
+    bindCustomHotkey(widget, text, slot)
   end
 
   widget:getParent():orderChildrenByText("primary")

--- a/mods/client_settings/settings.lua
+++ b/mods/client_settings/settings.lua
@@ -1543,6 +1543,14 @@ local function finishClassicHotkeyProfile(classicHotkeys)
   end
 end
 
+-- Classic binds last so a modern rebuild cannot leave one of its combos
+-- unbound. Binding is idempotent, so this cannot produce a second callback.
+local function rebindClassicHotkeys(classicHotkeys)
+  if classicHotkeys and classicHotkeys.rebindAll then
+    classicHotkeys.rebindAll()
+  end
+end
+
 function changeActiveHotkeyProfile(profileName, syncCombos)
   cancelHotkeyProfileChangeEvent()
   local changed, classicHotkeys = selectActiveHotkeyProfile(profileName, syncCombos)
@@ -1550,12 +1558,19 @@ function changeActiveHotkeyProfile(profileName, syncCombos)
     return false
   end
 
+  -- The new profile's classic model has to be in place before anything else
+  -- rebuilds. prepareProfileChange unloaded it, and while it is unloaded
+  -- isComboClaimed answers false for everything, so the action bar, keybinds
+  -- and custom hotkeys would claim combos the incoming profile owns and both
+  -- callbacks would fire on the same key.
+  finishClassicHotkeyProfile(classicHotkeys)
+
   modules.game_actionbar.resetActionBar()
   KeyBinds:setupAndReset(Options.currentHotkeySetName, getSelectedHotkeyChatType())
   configureGeneralHotkeys("")
   ActionHotkey.configureActionBarHotkeys()
-  finishClassicHotkeyProfile(classicHotkeys)
   CustomHotkeys.createList(true)
+  rebindClassicHotkeys(classicHotkeys)
   return true
 end
 
@@ -1568,13 +1583,17 @@ local function scheduleHotkeyProfileChange(profileName, syncCombos, onComplete)
       return
     end
 
+    -- Same ordering rule as the synchronous path, and it matters more here:
+    -- the phases run one frame apart, so loading classic last left it unloaded
+    -- across four frames while every other system decided ownership.
     local phases = {
+      function() finishClassicHotkeyProfile(classicHotkeys) end,
       function() modules.game_actionbar.resetActionBar() end,
       function() KeyBinds:setupAndReset(Options.currentHotkeySetName, getSelectedHotkeyChatType()) end,
       function() configureGeneralHotkeys("") end,
       function() ActionHotkey.configureActionBarHotkeys() end,
-      function() finishClassicHotkeyProfile(classicHotkeys) end,
-      function() CustomHotkeys.createList(true) end
+      function() CustomHotkeys.createList(true) end,
+      function() rebindClassicHotkeys(classicHotkeys) end
     }
     local phase = 0
     local function runNextPhase()

--- a/modules/corelib/globals.lua
+++ b/modules/corelib/globals.lua
@@ -201,12 +201,6 @@ consoleln = consoleln or function(...)
   print(table.concat(values, ' '))
 end
 
-function isKeyClaimedByHotkeyManager(keyCombo)
-  local hotkeysManager = modules and modules.game_hotkeys
-  return hotkeysManager and hotkeysManager.isHotkeyUsedByManager and
-    hotkeysManager.isHotkeyUsedByManager(keyCombo) or false
-end
-
 AttachedEffect = AttachedEffect or {}
 AttachedEffect.create = AttachedEffect.create or function(id, thingId, thingCategory)
   local effect = {

--- a/modules/corelib/keybinds.lua
+++ b/modules/corelib/keybinds.lua
@@ -853,21 +853,20 @@ local function isClassicComboClaimed(keyCombo)
   return (manager and manager.isComboClaimed and manager.isComboClaimed(keyCombo)) or false
 end
 
--- setupAndReset binds data.bindKeyDown/Up/Press on the default widget, so reset
--- can remove exactly those. It used to pass nil, which clears the combo for
--- every subsystem sharing it rather than just this keybind.
-local function unbindBoundCallbacks(data, keyCombo)
+-- KeyBind:active may bind on a specific widget and in alone mode. Keep both
+-- when removing these callbacks so reset disconnects the exact registration.
+local function unbindBoundCallbacks(data, keyCombo, widget, alone)
   if not data or not keyCombo or keyCombo == "" then
     return
   end
   if data.bindKeyDown then
-    g_keyboard.unbindKeyDown(keyCombo, data.bindKeyDown)
+    g_keyboard.unbindKeyDown(keyCombo, data.bindKeyDown, widget, alone)
   end
   if data.bindKeyUp then
-    g_keyboard.unbindKeyUp(keyCombo, data.bindKeyUp)
+    g_keyboard.unbindKeyUp(keyCombo, data.bindKeyUp, widget, alone)
   end
   if data.bindKeyPress then
-    g_keyboard.unbindKeyPress(keyCombo, data.bindKeyPress)
+    g_keyboard.unbindKeyPress(keyCombo, data.bindKeyPress, widget)
   end
 end
 
@@ -880,7 +879,7 @@ function KeyBinds:reset()
 			    updateTurnKey(typo, data.firstKey, true)
 			  end
 
-			  unbindBoundCallbacks(data, data.firstKey)
+			  unbindBoundCallbacks(data, data.firstKey, data.parent, data.repeatable)
 
 			  data.firstKey = ''
 			end
@@ -891,7 +890,7 @@ function KeyBinds:reset()
           updateTurnKey(typo, data.secondKey, true)
         end
 
-        unbindBoundCallbacks(data, data.secondKey)
+        unbindBoundCallbacks(data, data.secondKey, data.parent, data.repeatable)
         data.secondKey = ''
       end
 		end

--- a/modules/corelib/keybinds.lua
+++ b/modules/corelib/keybinds.lua
@@ -846,6 +846,31 @@ function KeyBinds:getBindFunction(name)
 	return nil
 end
 
+-- Nil-safe view of the classic manager's ownership. game_hotkeys is an optional
+-- module, so corelib must not assume it exists or reach for a global helper.
+local function isClassicComboClaimed(keyCombo)
+  local manager = modules and modules.game_hotkeys
+  return (manager and manager.isComboClaimed and manager.isComboClaimed(keyCombo)) or false
+end
+
+-- setupAndReset binds data.bindKeyDown/Up/Press on the default widget, so reset
+-- can remove exactly those. It used to pass nil, which clears the combo for
+-- every subsystem sharing it rather than just this keybind.
+local function unbindBoundCallbacks(data, keyCombo)
+  if not data or not keyCombo or keyCombo == "" then
+    return
+  end
+  if data.bindKeyDown then
+    g_keyboard.unbindKeyDown(keyCombo, data.bindKeyDown)
+  end
+  if data.bindKeyUp then
+    g_keyboard.unbindKeyUp(keyCombo, data.bindKeyUp)
+  end
+  if data.bindKeyPress then
+    g_keyboard.unbindKeyPress(keyCombo, data.bindKeyPress)
+  end
+end
+
 function KeyBinds:reset()
 	for k, v in pairs(KeyBinds.Hotkeys) do
 		for typo, data in pairs(v) do
@@ -855,9 +880,7 @@ function KeyBinds:reset()
 			    updateTurnKey(typo, data.firstKey, true)
 			  end
 
-			  g_keyboard.unbindKeyDown(data.firstKey, nil)
-			  g_keyboard.unbindKeyUp(data.firstKey, nil)
-			  g_keyboard.unbindKeyPress(data.firstKey, nil)
+			  unbindBoundCallbacks(data, data.firstKey)
 
 			  data.firstKey = ''
 			end
@@ -868,9 +891,7 @@ function KeyBinds:reset()
           updateTurnKey(typo, data.secondKey, true)
         end
 
-        g_keyboard.unbindKeyDown(data.secondKey, nil)
-        g_keyboard.unbindKeyUp(data.secondKey, nil)
-        g_keyboard.unbindKeyPress(data.secondKey, nil)
+        unbindBoundCallbacks(data, data.secondKey)
         data.secondKey = ''
       end
 		end
@@ -920,7 +941,7 @@ function KeyBinds:setupAndReset(profile, chatType)
       if bindData.dontBindChatoff and chatType == 'chatOff' then
         canBind = false
       end
-      if isKeyClaimedByHotkeyManager(hotkey) then
+      if isClassicComboClaimed(hotkey) then
         canBind = false
       end
 
@@ -964,7 +985,7 @@ function KeyBinds:setup()
       if bindData.dontBindChatoff and chatType == 'chatOff' then
         canBind = false
       end
-      if isKeyClaimedByHotkeyManager(hotkey) then
+      if isClassicComboClaimed(hotkey) then
         canBind = false
       end
 
@@ -1291,7 +1312,7 @@ function KeyBinds:hotkeyIsUsed(key)
   if hotkeys[key] ~= nil then
     return true
   end
-  return isKeyClaimedByHotkeyManager(key)
+  return isClassicComboClaimed(key)
 end
 
 function KeyBinds:isUsedHotkey(key)

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -1144,48 +1144,8 @@ function setupButtonTooltip(button, isEmpty)
 	button.item:setTooltip(tooltip)
 end
 
--- Draws what the classic manager will run for this button's key, so a slot whose
--- key is claimed shows the spell or object instead of an empty square.
---
--- Purely visual: the cache is deliberately left alone, so clicking the button
--- still does nothing. Only called on a slot that has no action of its own, so it
--- can never hide a real assignment, and a mouse click never disagrees with what
--- is drawn.
-local function renderClassicHotkeyPreview(button)
-	local manager = modules and modules.game_hotkeys
-	local combo = button and button.cache and button.cache.blockedHotkey
-	if not combo or combo == "" or not manager or not manager.getComboState then
-		return
-	end
-
-	local state = manager.getComboState(combo)
-	if not state or not state.executable then
-		return
-	end
-
-	if state.itemId and state.itemId > 0 then
-		button.item:setItemId(state.itemId, true)
-		if state.subType and state.subType > 0 then
-			button.item:setItemSubType(state.subType)
-		end
-		button.item:setOn(true)
-		return
-	end
-
-	if not state.value or state.value == "" then
-		return
-	end
-
-	local source, clip = Spells.getSpellIcon(state.value)
-	if source then
-		button.item.text:setImageSource(source)
-		button.item.text:setImageClip(clip)
-	else
-		button.item.text:setTextOffset("0 10")
-		button.item.text:setText(short_text(state.value:match("^(%S+)") or state.value, 6))
-	end
-	button.item:setOn(true)
-end
+-- Defined further down, next to renderSlotOnWidget, which it reuses.
+local renderClassicHotkeyPreview
 
 -- Repaints the slots that mirror a given classic combo, so editing the hotkey
 -- text updates the bar immediately instead of on the next full rebuild.
@@ -1250,7 +1210,14 @@ function updateButton(button)
 	if not buttonData or not buttonData["actionsetting"] then
 		-- Reached only when the slot carries no action of its own, which is
 		-- exactly when mirroring the classic hotkey is safe.
-		renderClassicHotkeyPreview(button)
+		local mirrored = renderClassicHotkeyPreview(button)
+		-- A mirrored slot is a working slot: the mouse must run the same thing
+		-- the key does. updateButton only wires these at the end of the path a
+		-- filled slot takes, which this branch never reaches. Assigned even when
+		-- nothing is mirrored, so a slot that just lost its action stops
+		-- responding to clicks.
+		button.item.onClick = mirrored and function() onExecuteAction(button) end or nil
+		button.item.text.onClick = mirrored and function() onExecuteAction(button) end or nil
 		setupButtonTooltip(button, true)
 		button.item:setDraggable(false)
 		configureButtonMouseRelease(button)
@@ -3584,6 +3551,69 @@ local function renderSlotOnWidget(widget, slotData, isMainButton)
 		widget.cache.actionType = UseTypes["chatText"]
 	end
 	setupButtonTooltip(widget, false)
+end
+
+-- The classic manager's use types are its own enum; map them onto the names
+-- renderSlotOnWidget expects. localGetActionName passes strings straight
+-- through, so the name can be handed over as-is.
+--
+-- Written as literals on purpose: the HOTKEY_MANAGER_* globals live in
+-- game_hotkeys, which may not have loaded when this file is read, and
+-- HOTKEY_MANAGER_USE is nil by definition, so building the table from them
+-- would index it with nil.
+local CLASSIC_USE_TYPE_NAMES = {
+	[1] = "UseOnYourself",   -- HOTKEY_MANAGER_USEONSELF
+	[2] = "UseOnTarget",     -- HOTKEY_MANAGER_USEONTARGET
+	[3] = "SelectUseTarget", -- HOTKEY_MANAGER_USEWITH  (with crosshair)
+	[4] = "SmartCast"        -- HOTKEY_MANAGER_USEATCURSOR
+}
+
+-- Renders what the classic manager runs for this button's key onto the slot,
+-- through the same path a normal assignment takes, so the slot is a working
+-- one: it draws the spell icon or object, and clicking it does what the key
+-- does. Returns whether anything was drawn.
+--
+-- Only called on a slot with no action of its own, so it can never hide a real
+-- assignment and the mouse can never disagree with what is drawn. Nothing is
+-- written to Options, so the mirror is never persisted as a slot action.
+renderClassicHotkeyPreview = function(button)
+	local manager = modules and modules.game_hotkeys
+	local combo = button and button.cache and button.cache.blockedHotkey
+	if not combo or combo == "" or not manager or not manager.getComboState then
+		return false
+	end
+
+	local state = manager.getComboState(combo)
+	if not state or not state.executable then
+		return false
+	end
+
+	local slotData
+	if state.itemId and state.itemId > 0 then
+		slotData = {
+			useObject = state.itemId,
+			useType = CLASSIC_USE_TYPE_NAMES[state.useType] or "Use",
+			upgradeTier = 0,
+			useEquipSmartMode = false
+		}
+	elseif state.value and state.value ~= "" then
+		slotData = {
+			chatText = state.value,
+			sendAutomatically = state.autoSend
+		}
+	else
+		-- An action hotkey has nothing to draw.
+		return false
+	end
+
+	renderSlotOnWidget(button, slotData, true)
+
+	-- setupHotkeyButton marked the key as blocked before we knew the slot was
+	-- empty. Nothing is blocked here: the key and the click both work, so the
+	-- warning would be a lie.
+	button.hotkeyLabel:setColor("#dfdfdf")
+	button.hotkeyLabel:setTooltip("")
+	return true
 end
 
 function updateMultiButtonState(button)

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -2783,7 +2783,12 @@ function switchChatMode(enabled)
 	for _, actionbar in pairs(activeActionBars) do
 		for _, button in pairs(actionbar.tabBar:getChildren()) do
 			setupHotkeyButton(button)
-			if button.cache.hotkey then
+			if button.cache.blockedHotkey then
+				-- The classic profile may load after the action bar on relogin.
+				-- Rebuild only newly discovered mirrors so their spell/item/text
+				-- cache and click handlers are restored, not just the key label.
+				updateButton(button)
+			elseif button.cache.hotkey then
 				button.hotkeyLabel:setText(translateDisplayHotkey(button.cache.hotkey))
 			end
 		end

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -398,16 +398,95 @@ function init()
 	mouseGrabberWidget.onMouseRelease = onDropActionButton
 end
 
+-- Nil-safe view of the classic manager's ownership. game_hotkeys is optional
+-- and loads after this module, so never assume it is there.
+local function isClassicComboClaimed(keySequence)
+	local manager = modules and modules.game_hotkeys
+	return (manager and manager.isComboClaimed and manager.isComboClaimed(keySequence)) or false
+end
+
+-- Asks the classic manager to give a combo up because the user explicitly
+-- assigned it here. Goes through the manager's API so its model, UI, binding
+-- and saved profile stay in agreement.
+local function releaseClassicCombo(keySequence)
+	local manager = modules and modules.game_hotkeys
+	if manager and manager.releaseComboForExternalAssignment then
+		manager.releaseComboForExternalAssignment(keySequence)
+	elseif manager and manager.removeHotkeyByCombo then
+		manager.removeHotkeyByCombo(keySequence)
+	end
+end
+
+local unbindButtonHotkey
+
+local function releaseButtonBinding(binding)
+	g_keyboard.unbindKeyPress(binding.combo, binding.press, binding.widget)
+	g_keyboard.unbindKeyDown(binding.combo, binding.down, binding.widget)
+	g_keyboard.unbindKeyUp(binding.combo, binding.up, binding.widget)
+end
+
+-- Action bar bindings are recorded on the button so they can be removed by
+-- identity. Unbinding with a nil callback clears the combo for every system
+-- sharing it, which is how the classic manager's callbacks used to disappear.
+-- Keyed by combo because a button can carry a primary and a secondary key.
+local function bindButtonHotkey(button, keySequence)
+	if not button or not button.cache or not keySequence or keySequence == "" then
+		return
+	end
+
+	local bindings = button.cache.hotkeyBindings or {}
+	button.cache.hotkeyBindings = bindings
+
+	local existing = bindings[keySequence]
+	if existing then
+		releaseButtonBinding(existing)
+	end
+
+	local press = function() onExecuteAction(button, true) end
+	local down = function() onExecuteAction(button, false) end
+	local up = function() onCheckKeyUp(button) end
+
+	bindings[keySequence] = {
+		combo = keySequence,
+		press = press,
+		down = down,
+		up = up,
+		widget = gameRootPanel
+	}
+
+	g_keyboard.bindKeyPress(keySequence, press, gameRootPanel)
+	g_keyboard.bindKeyDown(keySequence, down, gameRootPanel)
+	g_keyboard.bindKeyUp(keySequence, up, gameRootPanel)
+end
+
+-- Drops every binding this button owns, or just one combo when given.
+unbindButtonHotkey = function(button, keySequence)
+	local bindings = button and button.cache and button.cache.hotkeyBindings
+	if not bindings then
+		return
+	end
+
+	if keySequence then
+		local binding = bindings[keySequence]
+		if binding then
+			bindings[keySequence] = nil
+			releaseButtonBinding(binding)
+		end
+		return
+	end
+
+	for combo, binding in pairs(bindings) do
+		bindings[combo] = nil
+		releaseButtonBinding(binding)
+	end
+end
+
 local function removeButtonEvents(button)
 	if not button or not button.cache then
 		return
 	end
 
-	if button.cache.hotkey then
-		g_keyboard.unbindKeyPress(button.cache.hotkey, nil, gameRootPanel)
-		g_keyboard.unbindKeyDown(button.cache.hotkey, nil, gameRootPanel)
-		g_keyboard.unbindKeyUp(button.cache.hotkey, nil, gameRootPanel)
-	end
+	unbindButtonHotkey(button)
 
 	if button.cache.cooldownEvent then
 		removeEvent(button.cache.cooldownEvent)
@@ -2303,8 +2382,7 @@ function assignHotkey(button)
 			local usedButton = getUsedHotkeyButton(lastHotkey)
 			if usedButton then
 				Options.removeHotkey(usedButton:getId())
-				g_keyboard.unbindKeyPress(lastHotkey, nil, gameRootPanel)
-				g_keyboard.unbindKeyDown(lastHotkey, nil, gameRootPanel)
+				unbindButtonHotkey(usedButton)
 				updateButton(usedButton)
 			end
 		end
@@ -2312,10 +2390,8 @@ function assignHotkey(button)
 		local hotkey = window.display.combo
 		if hotkey == nil or #hotkey == 0 then
 			if button.cache.hotkey ~= "" then
-				local hk = button.cache.hotkey
 				Options.removeHotkey(button:getId())
-				g_keyboard.unbindKeyPress(hk, nil, gameRootPanel)
-				g_keyboard.unbindKeyDown(hk, nil, gameRootPanel)
+				unbindButtonHotkey(button)
 				updateButton(button)
 			end
 			g_client.setInputLockWidget(nil)
@@ -2323,16 +2399,16 @@ function assignHotkey(button)
 			return true
 		end
 
-    if modules.game_hotkeys and modules.game_hotkeys.removeHotkeyByCombo then
-      modules.game_hotkeys.removeHotkeyByCombo(hotkey)
-    end
+    -- Explicit user assignment, so it is fair to take the combo from the
+    -- classic manager. Going through its API clears the entry and its binding
+    -- while keeping the row, instead of deleting the row behind its back.
+    releaseClassicCombo(hotkey)
     Options.clearHotkey(hotkey)
 
 		local usedButton = getUsedHotkeyButton(hotkey)
 		if usedButton then
 			Options.removeHotkey(usedButton:getId())
-			g_keyboard.unbindKeyPress(hotkey, nil, gameRootPanel)
-			g_keyboard.unbindKeyDown(hotkey, nil, gameRootPanel)
+			unbindButtonHotkey(usedButton)
 		    updateButton(usedButton)
 		end
 
@@ -2340,9 +2416,9 @@ function assignHotkey(button)
 			local key = KeyBind:getKeyBindByHotkey(hotkey)
 			Options.removeActionHotkey(chatOn and "chatOn" or "chatOff", key.jsonName)
 			if key then
+				-- setFirstKey already unbinds the keybind's own stored callbacks;
+				-- a generic unbind here would also strip whoever else shares it.
 				key:setFirstKey('')
-				g_keyboard.unbindKeyDown(hotkey, nil, gameRootPanel)
-				g_keyboard.unbindKeyPress(hotkey, nil, gameRootPanel)
 			end
 		end
 
@@ -2350,8 +2426,7 @@ function assignHotkey(button)
 			m_settings.removeCustomHotkey(hotkey)
 		end
 
-		g_keyboard.bindKeyPress(hotkey, function() onExecuteAction(button, true) end, gameRootPanel)
-		g_keyboard.bindKeyDown(hotkey, function() onExecuteAction(button, false) end, gameRootPanel)
+		bindButtonHotkey(button, hotkey)
 		button.cache.hotkey = hotkey
 		Options.updateActionBarHotkey("TriggerActionButton_".. button:getId(), hotkey)
 		updateButton(button)
@@ -2363,8 +2438,7 @@ function assignHotkey(button)
 		local hotkey = window.display:getText()
 		Options.removeHotkey(button:getId())
 		if hotkey ~= '' then
-			g_keyboard.unbindKeyPress(hotkey, nil, gameRootPanel)
-			g_keyboard.unbindKeyDown(hotkey, nil, gameRootPanel)
+			unbindButtonHotkey(button)
 		end
 		g_client.setInputLockWidget(nil)
 		updateButton(button)
@@ -2572,7 +2646,11 @@ function setupHotkeyButton(button)
 			if data["actionsetting"]["action"] == "TriggerActionButton_" .. button:getId() then
 				local keySequence = data["keysequence"]
 				if keySequence and not string.empty(keySequence) then
-					if isKeyClaimedByHotkeyManager(keySequence) then
+					-- Only an executable classic hotkey blocks the button. A blank
+					-- F3 row is not ownership, so the button binds normally. The
+					-- preset entry survives either way: if the classic hotkey is
+					-- cleared later, the next refresh binds this button again.
+					if isClassicComboClaimed(keySequence) then
 						button.hotkeyLabel:setText(translateDisplayHotkey(keySequence))
 						button.hotkeyLabel:setColor(CLASSIC_HOTKEY_WARNING_COLOR)
 						button.hotkeyLabel:setTooltip(tr("Blocked by classic Hotkeys Manager"))
@@ -2582,13 +2660,7 @@ function setupHotkeyButton(button)
 						button.cache.hotkey = keySequence
 					end
 
-					g_keyboard.unbindKeyPress(keySequence, nil, gameRootPanel)
-					g_keyboard.unbindKeyDown(keySequence, nil, gameRootPanel)
-					g_keyboard.unbindKeyUp(keySequence, nil, gameRootPanel)
-
-					g_keyboard.bindKeyPress(keySequence, function() onExecuteAction(button, true) end, gameRootPanel)
-					g_keyboard.bindKeyDown(keySequence, function() onExecuteAction(button, false) end, gameRootPanel)
-					g_keyboard.bindKeyUp(keySequence, function() onCheckKeyUp(button) end, gameRootPanel)
+					bindButtonHotkey(button, keySequence)
 				end
 			end
 		end
@@ -2604,7 +2676,7 @@ function isHotkeyUsed(key, secondary)
 	if not key or not Options.currentHotkeySet then
 		return false
 	end
-	if isKeyClaimedByHotkeyManager(key) then
+	if isClassicComboClaimed(key) then
 		return true
 	end
 
@@ -2657,8 +2729,9 @@ function switchChatMode(enabled)
 	for _, actionbar in pairs(activeActionBars) do
 		for _, button in pairs(actionbar.tabBar:getChildren()) do
 			if button.cache.hotkey ~= "" then
-				g_keyboard.unbindKeyPress(button.cache.hotkey, nil, gameRootPanel)
-				g_keyboard.unbindKeyDown(button.cache.hotkey, nil, gameRootPanel)
+				-- Removes only this button's own callbacks. It must not touch the
+				-- classic manager's binding on the same combo.
+				unbindButtonHotkey(button)
 				button.cache.hotkey = nil
 				button.hotkeyLabel:setText("")
 			end
@@ -2962,8 +3035,7 @@ function resetActionBar()
 	for _, actionbar in pairs(activeActionBars) do
 		for _, button in pairs(actionbar.tabBar:getChildren()) do
 			if button.cache.hotkey then
-				g_keyboard.unbindKeyPress(button.cache.hotkey, nil, gameRootPanel)
-				g_keyboard.unbindKeyDown(button.cache.hotkey, nil, gameRootPanel)
+				unbindButtonHotkey(button)
 				button.cache.hotkey = nil
 				button.hotkeyLabel:setText("")
 			end
@@ -2981,8 +3053,7 @@ function resetSlots(slot)
 		if actionbar:getId() == "actionbar." .. slot then
 			for _, button in pairs(actionbar.tabBar:getChildren()) do
 				if button.cache.hotkey then
-					g_keyboard.unbindKeyPress(button.cache.hotkey, nil, gameRootPanel)
-					g_keyboard.unbindKeyDown(button.cache.hotkey, nil, gameRootPanel)
+					unbindButtonHotkey(button)
 					button.cache.hotkey = nil
 					button.hotkeyLabel:setText("")
 					Options.removeHotkey(button:getId())
@@ -3183,7 +3254,7 @@ function removeHotkey(name)
   if not button then return end
 
   Options.removeHotkey(button:getId())
-  g_keyboard.unbindKeyPress(name, nil, m_interface.getRootPanel())
+  unbindButtonHotkey(button)
   updateButton(button)
 end
 

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -780,6 +780,8 @@ function setupActionBar(n)
 end
 
 function resetButtonCache(button)
+	unbindButtonHotkey(button)
+
 	if button.cache and button.cache.itemId > 0 then
 		local cachedItem = cachedItemWidget[button.cache.itemId]
 		if cachedItem then

--- a/modules/game_actionbar/actionbar.lua
+++ b/modules/game_actionbar/actionbar.lua
@@ -1144,6 +1144,64 @@ function setupButtonTooltip(button, isEmpty)
 	button.item:setTooltip(tooltip)
 end
 
+-- Draws what the classic manager will run for this button's key, so a slot whose
+-- key is claimed shows the spell or object instead of an empty square.
+--
+-- Purely visual: the cache is deliberately left alone, so clicking the button
+-- still does nothing. Only called on a slot that has no action of its own, so it
+-- can never hide a real assignment, and a mouse click never disagrees with what
+-- is drawn.
+local function renderClassicHotkeyPreview(button)
+	local manager = modules and modules.game_hotkeys
+	local combo = button and button.cache and button.cache.blockedHotkey
+	if not combo or combo == "" or not manager or not manager.getComboState then
+		return
+	end
+
+	local state = manager.getComboState(combo)
+	if not state or not state.executable then
+		return
+	end
+
+	if state.itemId and state.itemId > 0 then
+		button.item:setItemId(state.itemId, true)
+		if state.subType and state.subType > 0 then
+			button.item:setItemSubType(state.subType)
+		end
+		button.item:setOn(true)
+		return
+	end
+
+	if not state.value or state.value == "" then
+		return
+	end
+
+	local source, clip = Spells.getSpellIcon(state.value)
+	if source then
+		button.item.text:setImageSource(source)
+		button.item.text:setImageClip(clip)
+	else
+		button.item.text:setTextOffset("0 10")
+		button.item.text:setText(short_text(state.value:match("^(%S+)") or state.value, 6))
+	end
+	button.item:setOn(true)
+end
+
+-- Repaints the slots that mirror a given classic combo, so editing the hotkey
+-- text updates the bar immediately instead of on the next full rebuild.
+function refreshClassicHotkeyPreview(keyCombo)
+	if not keyCombo or keyCombo == "" then
+		return
+	end
+	for _, actionbar in pairs(activeActionBars) do
+		for _, button in pairs(actionbar.tabBar:getChildren()) do
+			if button.cache and button.cache.blockedHotkey == keyCombo then
+				updateButton(button)
+			end
+		end
+	end
+end
+
 function updateButton(button)
 	if not player then
 		player = g_game.getLocalPlayer()
@@ -1190,6 +1248,9 @@ function updateButton(button)
 	end
 
 	if not buttonData or not buttonData["actionsetting"] then
+		-- Reached only when the slot carries no action of its own, which is
+		-- exactly when mirroring the classic hotkey is safe.
+		renderClassicHotkeyPreview(button)
 		setupButtonTooltip(button, true)
 		button.item:setDraggable(false)
 		configureButtonMouseRelease(button)
@@ -2639,6 +2700,11 @@ function setupHotkeyButton(button)
 	end
 	button.hotkeyLabel:setColor("#dfdfdf")
 	button.hotkeyLabel:setTooltip("")
+	-- Cleared every pass so a key that the classic manager has since released
+	-- does not keep showing a stale preview.
+	if button.cache then
+		button.cache.blockedHotkey = nil
+	end
 
 	local currentSet = Options.isChatOnEnabled and Options.currentHotkeySet["chatOn"] or Options.currentHotkeySet["chatOff"]
 	for _, data in pairs(currentSet) do
@@ -2654,6 +2720,12 @@ function setupHotkeyButton(button)
 						button.hotkeyLabel:setText(translateDisplayHotkey(keySequence))
 						button.hotkeyLabel:setColor(CLASSIC_HOTKEY_WARNING_COLOR)
 						button.hotkeyLabel:setTooltip(tr("Blocked by classic Hotkeys Manager"))
+						-- Remembered so an empty slot can show what the key will
+						-- actually do. cache.hotkey stays unset because the button
+						-- does not own this key.
+						if button.cache then
+							button.cache.blockedHotkey = keySequence
+						end
 						goto continue
 					end
 					if not data["secondary"] then

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -318,6 +318,15 @@ local function reconcileClassicCombo(keyCombo)
   return not wasBound
 end
 
+-- Asks the action bar to repaint any slot mirroring this combo. Used when the
+-- content changed but ownership did not, since that case triggers no rebuild.
+local function refreshClassicPreview(keyCombo)
+  local actionbar = modules and modules.game_actionbar
+  if actionbar and actionbar.refreshClassicHotkeyPreview then
+    actionbar.refreshClassicHotkeyPreview(keyCombo)
+  end
+end
+
 local function rebindAllClassicCombos()
   local combos = {}
   for keyCombo in pairs(hotkeysByCombo) do
@@ -835,6 +844,8 @@ function onChooseItemMouseRelease(self, mousePosition, mouseButton)
     queueSave()
     if ownershipChanged then
       refreshModernHotkeys()
+    else
+      refreshClassicPreview(currentHotkeyLabel.keyCombo)
     end
   end
 
@@ -1129,6 +1140,33 @@ function executeHotkeyItem(action, itemId, subType)
   end
 end
 
+-- Shows the spell icon next to a row whose text is a known spell, matching what
+-- the custom hotkey list already does. Falls back to plain text for anything
+-- else, including object hotkeys, which already describe themselves in words.
+local function updateHotkeyLabelIcon(hotkeyLabel, entry)
+  local icon = hotkeyLabel:getChildById('spellIcon')
+  if not icon then
+    return
+  end
+
+  local source, clip
+  if entry and not entry.itemId and not entry.action and
+      entry.value and entry.value ~= '' and Spells and Spells.getSpellIcon then
+    source, clip = Spells.getSpellIcon(entry.value)
+  end
+
+  if source then
+    icon:setImageSource(source)
+    icon:setImageClip(clip)
+    icon:setVisible(true)
+    hotkeyLabel:setTextOffset('15 0')
+  else
+    icon:setImageSource('')
+    icon:setVisible(false)
+    hotkeyLabel:setTextOffset('2 0')
+  end
+end
+
 function updateHotkeyLabel(hotkeyLabel)
   if not hotkeyLabel then
     return
@@ -1137,6 +1175,8 @@ function updateHotkeyLabel(hotkeyLabel)
   if not entry then
     return
   end
+
+  updateHotkeyLabelIcon(hotkeyLabel, entry)
 
   if entry.useType == HOTKEY_MANAGER_USEONSELF then
     hotkeyLabel:setText(tr('%s: (use object on yourself)', hotkeyLabel.keyCombo))
@@ -1322,6 +1362,10 @@ function onHotkeyTextChange(value)
   queueSave()
   if ownershipChanged then
     refreshModernHotkeys()
+  else
+    -- Ownership is unchanged, so nothing rebuilds; repaint the mirrored slot
+    -- directly or the bar would keep showing the previous spell.
+    refreshClassicPreview(currentHotkeyLabel.keyCombo)
   end
 end
 
@@ -1560,6 +1604,8 @@ function getComboState(keyCombo)
     bound = keyCombo ~= nil and classicBindings[keyCombo] ~= nil,
     value = entry and entry.value or nil,
     itemId = entry and entry.itemId or nil,
+    subType = entry and entry.subType or nil,
+    useType = entry and entry.useType or nil,
     action = entry and entry.action or nil
   }
 end

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -49,8 +49,14 @@ local perCharacter = true
 local mouseGrabberWidget
 local useRadioGroup
 local currentHotkeys
-local boundCombosCallback = {}
-local hotkeyList = {}
+-- Canonical runtime model. The widget rows in currentHotkeys are only an editor
+-- for this table: they carry a keyCombo for identity and nothing else. Runtime
+-- execution, ownership and serialisation all read from here, so editing a
+-- hotkey takes effect immediately instead of waiting for a save to rebuild it.
+local hotkeysByCombo = {}
+-- combo -> { callback = <exact function>, widget = <exact widget> }. Only ever
+-- holds bindings this module created, so it can never unbind another system's.
+local classicBindings = {}
 local hotkeyBlockingSources = {}
 local nextSourceId = 1
 local lastHotkeyTime = g_clock.millis()
@@ -167,6 +173,21 @@ local function isLegacyHotkeyTable(scope)
   return false
 end
 
+local STORAGE_VERSION = 2
+
+-- Accepts both the versioned layout this module writes and the flat
+-- combo -> settings map written by the original classic port, so an existing
+-- config.otml keeps its hotkeys instead of being silently reset.
+local function readStoredEntries(stored)
+  if type(stored) ~= 'table' then
+    return nil
+  end
+  if type(stored.entries) == 'table' then
+    return stored.entries
+  end
+  return stored
+end
+
 local function cloneTable(value)
   if type(value) ~= 'table' then
     return value
@@ -189,17 +210,131 @@ local function usesNativeCursor()
   return m_settings and m_settings.getOption and m_settings.getOption('nativeMouseCursor') == true
 end
 
-local function unbindComboEverywhere(keyCombo)
-  local gameRootPanel = getGameRootPanel()
-  local targets = { rootWidget }
-  if gameRootPanel and gameRootPanel ~= rootWidget then
-    targets[#targets + 1] = gameRootPanel
+local function normalizeCombo(keyCombo)
+  if keyCombo == nil then
+    return nil
   end
+  keyCombo = tostring(keyCombo)
+  if keyCombo == '' then
+    return nil
+  end
+  return keyCombo
+end
 
-  for _, target in ipairs(targets) do
-    g_keyboard.unbindKeyPress(keyCombo, nil, target)
-    g_keyboard.unbindKeyDown(keyCombo, nil, target)
-    g_keyboard.unbindKeyUp(keyCombo, nil, target)
+-- A row only owns its key once it can actually do something. The classic
+-- manager creates F1-F12 and Shift+F1-F4 up front, and those blanks must stay
+-- invisible to every other hotkey system: no binding, no claim.
+local function isExecutableHotkey(entry)
+  if not entry then
+    return false
+  end
+  if entry.action and entry.action > 0 then
+    return true
+  end
+  if entry.itemId and entry.itemId > 0 then
+    return true
+  end
+  if entry.value and entry.value ~= '' then
+    return true
+  end
+  return false
+end
+
+local function newEntry(keySettings)
+  local value = keySettings and keySettings.value
+  local itemId = keySettings and tonumber(keySettings.itemId) or nil
+  local action = keySettings and tonumber(keySettings.action) or nil
+  -- Normalise the "no action" spellings to nil. Stored data can carry a zero,
+  -- and zero is truthy in Lua, so leaving it would make the row render as an
+  -- action while isExecutableHotkey correctly treats it as blank.
+  if itemId and itemId <= 0 then
+    itemId = nil
+  end
+  if action and action <= 0 then
+    action = nil
+  end
+  return {
+    autoSend = keySettings and toboolean(keySettings.autoSend) or false,
+    itemId = itemId,
+    subType = keySettings and tonumber(keySettings.subType) or nil,
+    useType = keySettings and tonumber(keySettings.useType) or nil,
+    action = action,
+    value = value ~= nil and tostring(value) or ''
+  }
+end
+
+local function getEntry(keyCombo)
+  keyCombo = normalizeCombo(keyCombo)
+  return keyCombo and hotkeysByCombo[keyCombo] or nil
+end
+
+local function getLabelEntry(hotkeyLabel)
+  return hotkeyLabel and getEntry(hotkeyLabel.keyCombo) or nil
+end
+
+local function unbindClassicCombo(keyCombo)
+  local binding = classicBindings[keyCombo]
+  if not binding then
+    return false
+  end
+  classicBindings[keyCombo] = nil
+  -- Unbind by identity: the exact callback on the exact widget it was bound to.
+  g_keyboard.unbindKeyPress(keyCombo, binding.callback, binding.widget)
+  return true
+end
+
+local function bindClassicCombo(keyCombo)
+  if not isExecutableHotkey(hotkeysByCombo[keyCombo]) then
+    return false
+  end
+  local widget = getGameRootPanel()
+  local binding = classicBindings[keyCombo]
+  if binding and binding.widget == widget then
+    return false
+  end
+  unbindClassicCombo(keyCombo)
+
+  local callback = function()
+    doKeyCombo(keyCombo)
+  end
+  classicBindings[keyCombo] = { callback = callback, widget = widget }
+  g_keyboard.bindKeyPress(keyCombo, callback, widget)
+  return true
+end
+
+-- Brings the binding in line with the model. Returns true when ownership
+-- flipped, which is the only case worth asking the modern systems to refresh.
+local function reconcileClassicCombo(keyCombo)
+  keyCombo = normalizeCombo(keyCombo)
+  if not keyCombo then
+    return false
+  end
+  local wasBound = classicBindings[keyCombo] ~= nil
+  if not isExecutableHotkey(hotkeysByCombo[keyCombo]) then
+    unbindClassicCombo(keyCombo)
+    return wasBound
+  end
+  bindClassicCombo(keyCombo)
+  return not wasBound
+end
+
+local function rebindAllClassicCombos()
+  local combos = {}
+  for keyCombo in pairs(hotkeysByCombo) do
+    combos[#combos + 1] = keyCombo
+  end
+  for _, keyCombo in ipairs(combos) do
+    reconcileClassicCombo(keyCombo)
+  end
+end
+
+local function unbindAllClassicCombos()
+  local combos = {}
+  for keyCombo in pairs(classicBindings) do
+    combos[#combos + 1] = keyCombo
+  end
+  for _, keyCombo in ipairs(combos) do
+    unbindClassicCombo(keyCombo)
   end
 end
 
@@ -230,15 +365,13 @@ local function refreshModernHotkeys()
         customHotkeys.createList(true)
       end
     end
-  end, 1)
-end
 
-local function bindCombo(keyCombo)
-  unbindComboEverywhere(keyCombo)
-  boundCombosCallback[keyCombo] = function()
-    doKeyCombo(keyCombo)
-  end
-  g_keyboard.bindKeyPress(keyCombo, boundCombosCallback[keyCombo], getGameRootPanel())
+    -- Every subsystem above now removes only its own callbacks, so ordering is
+    -- no longer load-bearing. Reconciling last is belt and braces: if a rebuild
+    -- ever drops a classic binding, this puts it back instead of leaving the
+    -- key dead. It only binds combos that are actually executable.
+    rebindAllClassicCombos()
+  end, 1)
 end
 
 function init()
@@ -455,12 +588,18 @@ function load(forceDefaults)
     hasStoredProfile = true
   end
 
-  hotkeyList = {}
-  if not forceDefaults and type(stored) == 'table' then
-    for keyCombo, keySettings in pairs(stored) do
-      local combo = tostring(keyCombo)
-      addKeyCombo(combo, keySettings)
-      hotkeyList[combo] = keySettings
+  hotkeysByCombo = {}
+  if not forceDefaults then
+    local entries = readStoredEntries(stored)
+    if entries then
+      for keyCombo, keySettings in pairs(entries) do
+        local combo = normalizeCombo(keyCombo)
+        if combo and combo ~= 'version' and combo ~= 'entries' and type(keySettings) == 'table' then
+          -- Seed the model before the row so addKeyCombo adopts it as-is.
+          hotkeysByCombo[combo] = newEntry(keySettings)
+          addKeyCombo(combo)
+        end
+      end
     end
   end
 
@@ -468,15 +607,13 @@ function load(forceDefaults)
     loadDefautComboKeys()
   end
   hotkeysManagerLoaded = true
+  rebindAllClassicCombos()
 end
 
 function unload()
   hotkeysManagerLoaded = false
-  for keyCombo, callback in pairs(boundCombosCallback) do
-    g_keyboard.unbindKeyPress(keyCombo, callback, getGameRootPanel())
-  end
-  boundCombosCallback = {}
-  hotkeyList = {}
+  unbindAllClassicCombos()
+  hotkeysByCombo = {}
   currentHotkeyLabel = nil
 
   if currentHotkeys then
@@ -508,23 +645,23 @@ function save(flushToDisk)
   local scope = getSettingsScope(settings, true, loadedServerKey, loadedCharacterKey,
     loadedPerServer, loadedPerCharacter)
   scope.profiles = type(scope.profiles) == 'table' and scope.profiles or {}
-  scope.profiles[loadedProfileKey] = type(scope.profiles[loadedProfileKey]) == 'table' and
-    scope.profiles[loadedProfileKey] or {}
-  local stored = scope.profiles[loadedProfileKey]
 
-  table.clear(stored)
-  for _, child in ipairs(currentHotkeys:getChildren()) do
-    stored[child.keyCombo] = {
-      autoSend = child.autoSend,
-      itemId = child.itemId,
-      subType = child.subType,
-      useType = child.useType,
-      value = child.value,
-      action = child.action
+  -- Serialised straight from the model, not from the widget rows. Blank rows are
+  -- kept so the classic list still shows F1-F12 after a restart; they simply
+  -- carry no executable action and therefore claim nothing.
+  local entries = {}
+  for keyCombo, entry in pairs(hotkeysByCombo) do
+    entries[keyCombo] = {
+      autoSend = entry.autoSend,
+      itemId = entry.itemId,
+      subType = entry.subType,
+      useType = entry.useType,
+      value = entry.value,
+      action = entry.action
     }
   end
+  scope.profiles[loadedProfileKey] = { version = STORAGE_VERSION, entries = entries }
 
-  hotkeyList = stored
   g_settings.setNode('game_hotkeys', settings)
   if flushToDisk ~= false then
     cancelSaveEvent()
@@ -640,26 +777,31 @@ end
 function onActionChange(comboBox)
   local option = comboBox:getCurrentOption()
   local action = option and option.data or 0
-  if not hotkeysManagerLoaded or not currentHotkeyLabel then
+  local entry = getLabelEntry(currentHotkeyLabel)
+  if not hotkeysManagerLoaded or not entry then
     return
   end
-  if (currentHotkeyLabel.action or 0) == action then
+  if (entry.action or 0) == action then
     return
   end
 
   if action > 0 then
-    currentHotkeyLabel.action = action
-    currentHotkeyLabel.itemId = nil
-    currentHotkeyLabel.subType = nil
-    currentHotkeyLabel.useType = nil
-    currentHotkeyLabel.value = nil
-    currentHotkeyLabel.autoSend = false
+    entry.action = action
+    entry.itemId = nil
+    entry.subType = nil
+    entry.useType = nil
+    entry.value = ''
+    entry.autoSend = false
   else
-    currentHotkeyLabel.action = nil
+    entry.action = nil
   end
+  local ownershipChanged = reconcileClassicCombo(currentHotkeyLabel.keyCombo)
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(true, true)
   queueSave()
+  if ownershipChanged then
+    refreshModernHotkeys()
+  end
 end
 
 function onChooseItemMouseRelease(self, mousePosition, mouseButton)
@@ -679,16 +821,21 @@ function onChooseItemMouseRelease(self, mousePosition, mouseButton)
     end
   end
 
-  if item and currentHotkeyLabel then
-    currentHotkeyLabel.itemId = item:getId()
-    currentHotkeyLabel.subType = item:isFluidContainer() and item:getSubType() or nil
-    currentHotkeyLabel.useType = item:isMultiUse() and HOTKEY_MANAGER_USEWITH or HOTKEY_MANAGER_USE
-    currentHotkeyLabel.value = nil
-    currentHotkeyLabel.action = nil
-    currentHotkeyLabel.autoSend = false
+  local entry = getLabelEntry(currentHotkeyLabel)
+  if item and entry then
+    entry.itemId = item:getId()
+    entry.subType = item:isFluidContainer() and item:getSubType() or nil
+    entry.useType = item:isMultiUse() and HOTKEY_MANAGER_USEWITH or HOTKEY_MANAGER_USE
+    entry.value = ''
+    entry.action = nil
+    entry.autoSend = false
+    local ownershipChanged = reconcileClassicCombo(currentHotkeyLabel.keyCombo)
     updateHotkeyLabel(currentHotkeyLabel)
     updateHotkeyForm(true)
     queueSave()
+    if ownershipChanged then
+      refreshModernHotkeys()
+    end
   end
 
   show()
@@ -717,18 +864,25 @@ function startChooseItem()
 end
 
 function clearObject()
-  if not currentHotkeyLabel then
+  local entry = getLabelEntry(currentHotkeyLabel)
+  if not entry then
     return
   end
-  currentHotkeyLabel.itemId = nil
-  currentHotkeyLabel.subType = nil
-  currentHotkeyLabel.useType = nil
-  currentHotkeyLabel.autoSend = false
-  currentHotkeyLabel.value = ''
-  currentHotkeyLabel.action = nil
+  entry.itemId = nil
+  entry.subType = nil
+  entry.useType = nil
+  entry.autoSend = false
+  entry.value = ''
+  entry.action = nil
+  -- The row is blank again, so the classic manager drops ownership and whatever
+  -- system had the combo before can take it back on the next refresh.
+  local ownershipChanged = reconcileClassicCombo(currentHotkeyLabel.keyCombo)
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(true)
   queueSave()
+  if ownershipChanged then
+    refreshModernHotkeys()
+  end
 end
 
 function addHotkey()
@@ -752,7 +906,8 @@ function addHotkey()
 end
 
 function addKeyCombo(keyCombo, keySettings, focus)
-  if not keyCombo or keyCombo == '' then
+  keyCombo = normalizeCombo(keyCombo)
+  if not keyCombo then
     return
   end
 
@@ -784,15 +939,13 @@ function addKeyCombo(keyCombo, keySettings, focus)
   end
 
   hotkeyLabel.keyCombo = keyCombo
-  hotkeyLabel.autoSend = keySettings and toboolean(keySettings.autoSend) or false
-  hotkeyLabel.itemId = keySettings and tonumber(keySettings.itemId) or nil
-  hotkeyLabel.subType = keySettings and tonumber(keySettings.subType) or nil
-  hotkeyLabel.useType = keySettings and tonumber(keySettings.useType) or nil
-  hotkeyLabel.action = keySettings and tonumber(keySettings.action) or nil
-  hotkeyLabel.value = keySettings and tostring(keySettings.value or '') or ''
+  -- The row holds no hotkey data of its own; the model is the only copy.
+  hotkeysByCombo[keyCombo] = hotkeysByCombo[keyCombo] or newEntry(keySettings)
 
   updateHotkeyLabel(hotkeyLabel)
-  bindCombo(keyCombo)
+  -- A brand new row is blank, so this binds nothing. It only matters when
+  -- loading stored hotkeys that already carry an action.
+  reconcileClassicCombo(keyCombo)
 
   if focus then
     currentHotkeyLabel = hotkeyLabel
@@ -808,8 +961,10 @@ function doKeyCombo(keyCombo)
     return
   end
 
-  local hotkey = hotkeyList[keyCombo]
-  if not hotkey then
+  local hotkey = hotkeysByCombo[keyCombo]
+  -- Defence in depth: a stale binding for a combo that has since been cleared
+  -- must do nothing rather than fall through to the text branch.
+  if not isExecutableHotkey(hotkey) then
     return
   end
 
@@ -978,26 +1133,30 @@ function updateHotkeyLabel(hotkeyLabel)
   if not hotkeyLabel then
     return
   end
+  local entry = getLabelEntry(hotkeyLabel)
+  if not entry then
+    return
+  end
 
-  if hotkeyLabel.useType == HOTKEY_MANAGER_USEONSELF then
+  if entry.useType == HOTKEY_MANAGER_USEONSELF then
     hotkeyLabel:setText(tr('%s: (use object on yourself)', hotkeyLabel.keyCombo))
     hotkeyLabel:setColor(HotkeyColors.itemUseSelf)
-  elseif hotkeyLabel.useType == HOTKEY_MANAGER_USEONTARGET then
+  elseif entry.useType == HOTKEY_MANAGER_USEONTARGET then
     hotkeyLabel:setText(tr('%s: (use object on target)', hotkeyLabel.keyCombo))
     hotkeyLabel:setColor(HotkeyColors.itemUseTarget)
-  elseif hotkeyLabel.useType == HOTKEY_MANAGER_USEWITH then
+  elseif entry.useType == HOTKEY_MANAGER_USEWITH then
     hotkeyLabel:setText(tr('%s: (use object with crosshair)', hotkeyLabel.keyCombo))
     hotkeyLabel:setColor(HotkeyColors.itemUseWith)
-  elseif hotkeyLabel.useType == HOTKEY_MANAGER_USEATCURSOR then
+  elseif entry.useType == HOTKEY_MANAGER_USEATCURSOR then
     hotkeyLabel:setText(tr('%s: (use object at cursor position)', hotkeyLabel.keyCombo))
     hotkeyLabel:setColor(HotkeyColors.itemUseWith)
-  elseif hotkeyLabel.itemId then
+  elseif entry.itemId then
     hotkeyLabel:setText(tr('%s: (use object)', hotkeyLabel.keyCombo))
     hotkeyLabel:setColor(HotkeyColors.itemUse)
-  elseif hotkeyLabel.action then
+  elseif entry.action then
     local description = ''
     for _, action in ipairs(HotkeyActions) do
-      if action.id == hotkeyLabel.action then
+      if action.id == entry.action then
         description = action.text
         break
       end
@@ -1005,8 +1164,8 @@ function updateHotkeyLabel(hotkeyLabel)
     hotkeyLabel:setText(string.format('%s: %s', hotkeyLabel.keyCombo, description))
     hotkeyLabel:setColor(HotkeyColors.action)
   else
-    hotkeyLabel:setText(hotkeyLabel.keyCombo .. ': ' .. (hotkeyLabel.value or ''))
-    hotkeyLabel:setColor(hotkeyLabel.autoSend and HotkeyColors.textAutoSend or HotkeyColors.text)
+    hotkeyLabel:setText(hotkeyLabel.keyCombo .. ': ' .. (entry.value or ''))
+    hotkeyLabel:setColor(entry.autoSend and HotkeyColors.textAutoSend or HotkeyColors.text)
   end
 end
 
@@ -1015,7 +1174,8 @@ function updateHotkeyForm(reset, dontUpdateCombo)
     return
   end
 
-  if not currentHotkeyLabel then
+  local entry = getLabelEntry(currentHotkeyLabel)
+  if not entry then
     if not dontUpdateCombo then
       hotkeyActionCombo:setCurrentIndex(1)
     end
@@ -1038,7 +1198,7 @@ function updateHotkeyForm(reset, dontUpdateCombo)
   end
 
   removeHotkeyButton:enable()
-  if currentHotkeyLabel.itemId then
+  if entry.itemId then
     if not dontUpdateCombo then
       hotkeyActionCombo:setCurrentIndex(1)
     end
@@ -1050,9 +1210,9 @@ function updateHotkeyForm(reset, dontUpdateCombo)
     sendAutomatically:disable()
     selectObjectButton:disable()
     clearObjectButton:enable()
-    currentItemPreview:setItemId(currentHotkeyLabel.itemId)
-    if currentHotkeyLabel.subType then
-      currentItemPreview:setItemSubType(currentHotkeyLabel.subType)
+    currentItemPreview:setItemId(entry.itemId)
+    if entry.subType then
+      currentItemPreview:setItemSubType(entry.subType)
     end
 
     local item = currentItemPreview:getItem()
@@ -1061,13 +1221,13 @@ function updateHotkeyForm(reset, dontUpdateCombo)
       useOnTarget:enable()
       useWith:enable()
       useAtCursor:enable()
-      if currentHotkeyLabel.useType == HOTKEY_MANAGER_USEONSELF then
+      if entry.useType == HOTKEY_MANAGER_USEONSELF then
         useRadioGroup:selectWidget(useOnSelf)
-      elseif currentHotkeyLabel.useType == HOTKEY_MANAGER_USEONTARGET then
+      elseif entry.useType == HOTKEY_MANAGER_USEONTARGET then
         useRadioGroup:selectWidget(useOnTarget)
-      elseif currentHotkeyLabel.useType == HOTKEY_MANAGER_USEWITH then
+      elseif entry.useType == HOTKEY_MANAGER_USEWITH then
         useRadioGroup:selectWidget(useWith)
-      elseif currentHotkeyLabel.useType == HOTKEY_MANAGER_USEATCURSOR then
+      elseif entry.useType == HOTKEY_MANAGER_USEATCURSOR then
         useRadioGroup:selectWidget(useAtCursor)
       end
     else
@@ -1077,9 +1237,9 @@ function updateHotkeyForm(reset, dontUpdateCombo)
       useAtCursor:disable()
       useRadioGroup:clearSelected()
     end
-  elseif currentHotkeyLabel.action then
+  elseif entry.action then
     if not dontUpdateCombo then
-      hotkeyActionCombo:setCurrentOptionByData(currentHotkeyLabel.action)
+      hotkeyActionCombo:setCurrentOptionByData(entry.action)
     end
     hotkeyActionCombo:enable()
     hotkeyText:clearText()
@@ -1107,12 +1267,12 @@ function updateHotkeyForm(reset, dontUpdateCombo)
     useRadioGroup:clearSelected()
     hotkeyText:enable()
     hotKeyTextLabel:enable()
-    hotkeyText:setText(currentHotkeyLabel.value or '')
+    hotkeyText:setText(entry.value or '')
     if reset then
       hotkeyText:setCursorPos(-1)
     end
-    sendAutomatically:setChecked(currentHotkeyLabel.autoSend == true)
-    sendAutomatically:setEnabled(currentHotkeyLabel.value and currentHotkeyLabel.value ~= '')
+    sendAutomatically:setChecked(entry.autoSend == true)
+    sendAutomatically:setEnabled(entry.value ~= nil and entry.value ~= '')
     selectObjectButton:enable()
     clearObjectButton:disable()
     currentItemPreview:clearItem()
@@ -1125,12 +1285,8 @@ local function removeHotkeyLabel(hotkeyLabel)
   end
 
   local keyCombo = hotkeyLabel.keyCombo
-  local callback = boundCombosCallback[keyCombo]
-  if callback then
-    g_keyboard.unbindKeyPress(keyCombo, callback, getGameRootPanel())
-  end
-  boundCombosCallback[keyCombo] = nil
-  hotkeyList[keyCombo] = nil
+  unbindClassicCombo(keyCombo)
+  hotkeysByCombo[keyCombo] = nil
   if currentHotkeyLabel == hotkeyLabel then
     currentHotkeyLabel = nil
   end
@@ -1147,37 +1303,45 @@ function removeHotkey()
 end
 
 function onHotkeyTextChange(value)
-  if not hotkeysManagerLoaded or not currentHotkeyLabel then
+  local entry = getLabelEntry(currentHotkeyLabel)
+  if not hotkeysManagerLoaded or not entry then
     return
   end
-  if currentHotkeyLabel.value == value then
+  if entry.value == value then
     return
   end
-  currentHotkeyLabel.value = value
+  entry.value = value
   if value == '' then
-    currentHotkeyLabel.autoSend = false
+    entry.autoSend = false
   end
+  -- Runtime first, disk later: the key must start or stop working the moment
+  -- the text changes, never on the debounced save.
+  local ownershipChanged = reconcileClassicCombo(currentHotkeyLabel.keyCombo)
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(false, true)
   queueSave()
+  if ownershipChanged then
+    refreshModernHotkeys()
+  end
 end
 
 function onSendAutomaticallyChange(autoSend)
-  if not hotkeysManagerLoaded or not currentHotkeyLabel or
-      not currentHotkeyLabel.value or currentHotkeyLabel.value == '' then
+  local entry = getLabelEntry(currentHotkeyLabel)
+  if not hotkeysManagerLoaded or not entry or not entry.value or entry.value == '' then
     return
   end
-  if currentHotkeyLabel.autoSend == autoSend then
+  if entry.autoSend == autoSend then
     return
   end
-  currentHotkeyLabel.autoSend = autoSend
+  entry.autoSend = autoSend
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(false, true)
   queueSave()
 end
 
 function onChangeUseType(useTypeWidget)
-  if not hotkeysManagerLoaded or not currentHotkeyLabel then
+  local entry = getLabelEntry(currentHotkeyLabel)
+  if not hotkeysManagerLoaded or not entry then
     return
   end
   local useType = HOTKEY_MANAGER_USE
@@ -1190,10 +1354,10 @@ function onChangeUseType(useTypeWidget)
   elseif useTypeWidget == useAtCursor then
     useType = HOTKEY_MANAGER_USEATCURSOR
   end
-  if currentHotkeyLabel.useType == useType then
+  if entry.useType == useType then
     return
   end
-  currentHotkeyLabel.useType = useType
+  entry.useType = useType
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm()
   queueSave()
@@ -1321,10 +1485,81 @@ function removeHotkeyByCombo(keyCombo, persist)
   return true
 end
 
-function isHotkeyUsedByManager(keyCombo)
-  if not keyCombo or keyCombo == '' then
+-- Public conflict contract. Other hotkey systems must consult these instead of
+-- unbinding a shared combo blind.
+
+-- True only when this manager has an action it can actually run for the combo.
+-- Deliberately ignores widget rows and raw binding tables: a blank F3 row is
+-- not ownership, and treating it as such is what left F3 dead.
+function isComboClaimed(keyCombo)
+  keyCombo = normalizeCombo(keyCombo)
+  if not hotkeysManagerLoaded or not keyCombo then
     return false
   end
-  return boundCombosCallback[keyCombo] ~= nil or
-    (currentHotkeys and currentHotkeys:getChildById(keyCombo) ~= nil)
+  return isExecutableHotkey(hotkeysByCombo[keyCombo])
+end
+
+-- Kept so older call sites keep working; same meaning as isComboClaimed now.
+function isHotkeyUsedByManager(keyCombo)
+  return isComboClaimed(keyCombo)
+end
+
+-- Hands a combo back to an external editor after the user explicitly chose to
+-- overwrite it. Clears the classic action through the model so the UI, the
+-- binding and the saved profile all agree, which a bare unbind would not do.
+function releaseComboForExternalAssignment(keyCombo)
+  keyCombo = normalizeCombo(keyCombo)
+  local entry = keyCombo and hotkeysByCombo[keyCombo] or nil
+  if not entry then
+    return false
+  end
+  if not isExecutableHotkey(entry) then
+    unbindClassicCombo(keyCombo)
+    return false
+  end
+
+  entry.value = ''
+  entry.autoSend = false
+  entry.itemId = nil
+  entry.subType = nil
+  entry.useType = nil
+  entry.action = nil
+  unbindClassicCombo(keyCombo)
+
+  local hotkeyLabel = currentHotkeys and currentHotkeys:getChildById(keyCombo)
+  if hotkeyLabel then
+    updateHotkeyLabel(hotkeyLabel)
+    if currentHotkeyLabel == hotkeyLabel then
+      updateHotkeyForm(true)
+    end
+  end
+  queueSave()
+  return true
+end
+
+function rebindAll()
+  rebindAllClassicCombos()
+end
+
+function reloadProfile(profileName)
+  if profileName and profileName ~= '' and
+      Options and Options.currentHotkeySetName ~= profileName then
+    return false
+  end
+  reload()
+  refreshModernHotkeys()
+  return true
+end
+
+function getComboState(keyCombo)
+  keyCombo = normalizeCombo(keyCombo)
+  local entry = keyCombo and hotkeysByCombo[keyCombo] or nil
+  return {
+    exists = entry ~= nil,
+    executable = isExecutableHotkey(entry),
+    bound = keyCombo ~= nil and classicBindings[keyCombo] ~= nil,
+    value = entry and entry.value or nil,
+    itemId = entry and entry.itemId or nil,
+    action = entry and entry.action or nil
+  }
 end

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -1381,6 +1381,8 @@ function onSendAutomaticallyChange(autoSend)
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm(false, true)
   queueSave()
+  -- Ownership is untouched, but a mirrored slot has to follow the change.
+  refreshClassicPreview(currentHotkeyLabel.keyCombo)
 end
 
 function onChangeUseType(useTypeWidget)
@@ -1405,6 +1407,9 @@ function onChangeUseType(useTypeWidget)
   updateHotkeyLabel(currentHotkeyLabel)
   updateHotkeyForm()
   queueSave()
+  -- Same combo, different use type: the mirrored slot must switch too, or a
+  -- click would still cast on self after the user picked "on target".
+  refreshClassicPreview(currentHotkeyLabel.keyCombo)
 end
 
 function onSelectHotkeyLabel(hotkeyLabel)
@@ -1603,6 +1608,7 @@ function getComboState(keyCombo)
     executable = isExecutableHotkey(entry),
     bound = keyCombo ~= nil and classicBindings[keyCombo] ~= nil,
     value = entry and entry.value or nil,
+    autoSend = entry and entry.autoSend or false,
     itemId = entry and entry.itemId or nil,
     subType = entry and entry.subType or nil,
     useType = entry and entry.useType or nil,

--- a/modules/game_hotkeys/hotkeys_manager.lua
+++ b/modules/game_hotkeys/hotkeys_manager.lua
@@ -1583,6 +1583,7 @@ function releaseComboForExternalAssignment(keyCombo)
     end
   end
   queueSave()
+  refreshClassicPreview(keyCombo)
   return true
 end
 

--- a/modules/game_hotkeys/hotkeys_manager.otui
+++ b/modules/game_hotkeys/hotkeys_manager.otui
@@ -8,6 +8,17 @@ HotkeyListLabel < UILabel
   $focus:
     background-color: #ffffff22
 
+  // Shown only when the hotkey text resolves to a known spell. Phantom so it
+  // never steals the click that focuses the row.
+  UIWidget
+    id: spellIcon
+    size: 12 12
+    anchors.left: parent.left
+    anchors.verticalCenter: parent.verticalCenter
+    margin-left: 1
+    phantom: true
+    visible: false
+
 MainWindow
   id: hotkeysWindow
   !text: tr('Hotkeys')

--- a/modules/gamelib/spells.lua
+++ b/modules/gamelib/spells.lua
@@ -994,6 +994,35 @@ function Spells.getImageClipNormal(id, profile)
     return col * frameSize .. " " .. row * frameSize .. " 32 32"
 end
 
+-- Resolves spell words to the icon sheet and clip that the action bar and the
+-- hotkey lists draw. Returns nil when the text is not a known spell, so callers
+-- can fall back to plain text. Guards every global it touches because it runs
+-- from modules that may load before the spell tables are populated.
+function Spells.getSpellIcon(words, profile)
+    if type(words) ~= 'string' or words == '' then
+        return nil
+    end
+
+    profile = profile or 'Default'
+    local settings = SpelllistSettings and SpelllistSettings[profile]
+    if not settings then
+        return nil
+    end
+
+    local spellData, param = Spells.getSpellDataByParamWords(words:lower())
+    if not spellData then
+        return nil
+    end
+
+    local iconEntry = SpellIcons and SpellIcons[spellData.icon]
+    local iconId = iconEntry and iconEntry[1] or spellData.clientId
+    if not iconId then
+        return nil
+    end
+
+    return settings.iconsFolder, Spells.getImageClipNormal(iconId, profile), spellData, param
+end
+
 function Spells.getImageClipSmall(id, profile)
     local row = math.floor((id - 1) / 20)
     local col = (id - 1) % 20


### PR DESCRIPTION
Rebuilds the ownership and binding lifecycle shared by the classic 8.6 hotkeys manager, the action bar, keybinds and custom hotkeys. Follows `ASTRA_HOTKEY_CLASSIC_REBUILD_ANALYSIS.md`; every finding was confirmed against the code on `main` before anything was changed.

### Why F3 was dead

The classic manager creates `F1`-`F12` and `Shift+F1`-`Shift+F4` up front, empty. Two things then went wrong at once:

1. `addKeyCombo` called `bindCombo` for every row, including the blank ones, and `bindCombo` started with `unbindComboEverywhere` — `unbindKeyPress/Down/Up(combo, nil, ...)` on both `rootWidget` and `gameRootPanel`. A nil callback means "clear this combo for everyone", so a blank classic row wiped the action bar's callbacks.
2. `isHotkeyUsedByManager` returned true when a row merely existed. `setupHotkeyButton` asked whether classic owned `F3`, got yes, and declined to rebind.

Result: classic removed the action bar's binding, classic itself had nothing to run, and the action bar would not take the key back. `switchChatMode` reproduced it on every chat toggle.

### Ownership now requires an executable action

`isComboClaimed(combo)` is true only for an entry with an action, an item, or non-empty text. A blank row renders in the classic list and claims nothing.

- `hotkeysByCombo` is the single runtime model. Rows carry only a `keyCombo`; execution, ownership and serialisation read the model, so an edit takes effect immediately instead of waiting for the debounced save to rebuild `hotkeyList`.
- `classicBindings` records the exact callback and widget per combo. `unbindComboEverywhere` is gone.
- `releaseComboForExternalAssignment(combo)` hands a combo to another editor through the model, so UI, binding and stored profile stay in agreement. Explicit assignment in the action bar uses it instead of `removeHotkeyByCombo`, which deleted the row behind the manager's back.
- `rebindAll`, `reloadProfile` and `getComboState` complete the contract. `isHotkeyUsedByManager` stays as an alias.

### Every subsystem now unbinds only what it created

The audit from section 11 of the analysis is clean in all four critical files.

| File | Was | Now |
|---|---|---|
| `hotkeys_manager.lua` | `unbindComboEverywhere` on two widgets | exact callback + widget per combo |
| `actionbar.lua` | nil-callback unbind in 8 places | `combo -> {press, down, up, widget}` per button |
| `keybinds.lua` | `reset()` unbound with nil | uses the `bindKeyDown/Up/Press` refs the entries already carry |
| `custom-hotkeys.lua` | bound on `gameRootPanel`, unbound on the default widget | `primaryBinding` / `secondaryBinding` per row |

The action bar table is keyed by combo because a button can carry a primary and a secondary key; a single slot would have made the second assignment unbind the first.

`isKeyClaimedByHotkeyManager` is removed from `corelib/globals.lua`. Each caller uses a local nil-safe helper onto `modules.game_hotkeys.isComboClaimed`, so corelib no longer holds knowledge of an optional game module in its global namespace.

### A second bug found while doing this

`prepareProfileChange` unloads the classic manager and `finishProfileChange` ran **last** — fifth of six phases in the scheduled path, where phases are a frame apart. So the action bar, keybinds and custom hotkeys all rebuilt while classic was unloaded, `isComboClaimed` answered false for everything, and they claimed keys the incoming profile owns. Classic then bound on top and the key fired twice.

The classic model is now loaded first and `rebindAll` runs last. The phase split is kept, so the anti-stall work is not undone, but nothing depends on the 1 ms delay for correctness any more.

### Persistence

Storage gains `version: 2` and an `entries` map. The flat `profiles[key][combo]` layout written by #113 is still read, so existing `config.otml` files keep their hotkeys. Blank rows are persisted so the classic list still shows `F1`-`F12` after a restart. Per-server, per-character and per-preset scoping and the save debounce are unchanged.

### Validation

Static: `luajit -bl` on all 321 Lua files under `modules/` and `mods/`, 0 syntax errors. `git diff --check` clean. The section 11 unbind audit reports no generic nil-callback unbind left in the four critical files.

Behavioural: a headless harness stubs the client runtime and drives the manager directly — **242 checks, 0 failures**:

- blank `F1`-`F12` and `Shift+F1`-`F4` claim nothing and bind nothing; an action bar callback on `F3` still fires (scenario A)
- typing `exura` into classic `F3` claims it and sends exactly once, with no double cast (scenario B)
- clearing the text drops ownership and the action bar callback works again (scenario C)
- the action bar's callback survives classic taking the same combo — this is the regression that used to kill `F3`
- `F3` still has exactly one classic plus one action bar callback after 20 relogs and 50 rebuilds
- 100 profile switches leave exactly one callback on a claimed combo, and nothing is claimed while classic is unloaded
- 500 text toggles leave one callback; `autoSend` true sends once, false places the text without sending
- version 2 round-trips and the legacy flat layout migrates without losing a hotkey

**Not done:** the client was not launched. This is static and headless verification only, so the matrix rows that need a running client — item use variants, crosshair, WASD/chase actions, and the visual state of the hotkey list — still need a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novos Recursos**
  * Hotkeys compartilhadas agora podem ser atribuídas, editadas e removidas sem afetar outras associações.
  * Slots vazios da barra de ações podem refletir ações executáveis, incluindo itens e textos.
  * Textos reconhecidos como feitiços exibem seus ícones na lista de hotkeys.
  * Perfis de hotkeys são carregados e reaplicados com maior consistência.

* **Correções**
  * Evitados conflitos indevidos entre hotkeys clássicas, personalizadas e da barra de ações.
  * Limpeza e substituição de hotkeys agora preservam corretamente as demais associações.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->