### PR TITLE
Feat/hd minimap v2

### DIFF
--- a/modules/game_minimap/minimap.lua
+++ b/modules/game_minimap/minimap.lua
@@ -17,12 +17,84 @@ oldPos = nil
 local minimapFile = '/minimap.otmm'
 local minimapBackupFile = '/minimap.otmm.bak'
 
+-- HD minimap -----------------------------------------------------------------
+-- Optional layer that composites blocks from the real item sprites. It is a pure
+-- sidecar: the base minimap.otmm above is never read or written differently
+-- because of it, and if anything HD fails the standard minimap is unaffected.
+minimapHDToggle = nil
+
+local lastHDWorld = 'unknown'
+local lastHDCharacter = 'unknown'
+
+local function sanitizeHDFilePart(value)
+  value = tostring(value or '')
+  value = value:gsub('[^%w%-_]+', '_'):gsub('^_+', ''):gsub('_+$', '')
+  if value == '' then
+    return 'unknown'
+  end
+  return value:lower()
+end
+
+-- HD tile data is keyed by client version, world and character so a cache from one
+-- world can never be loaded into another. Sanitised because these come from the
+-- server. Global so functions defined later can reach it.
+function minimapHDFile()
+  local version = sanitizeHDFilePart(g_game.getClientVersion())
+  local world = sanitizeHDFilePart(g_game.getWorldName and g_game.getWorldName() or nil)
+  local character = sanitizeHDFilePart(g_game.getCharacterName and g_game.getCharacterName() or nil)
+
+  -- Logout clears these before offline() runs, so keep the last known values.
+  if world ~= 'unknown' then lastHDWorld = world else world = lastHDWorld end
+  if character ~= 'unknown' then lastHDCharacter = character else character = lastHDCharacter end
+
+  return string.format('/minimap/minimap_%s_%s_%s_hd.otmm', version, world, character)
+end
+
+function isHDEnabled()
+  return g_settings.getBoolean('minimapHD', false)
+end
+
+-- Never blocks: the engine coalesces a request that arrives while a save runs.
+local function saveHDMap()
+  if not isHDEnabled() or not MinimapLoader.loaded then
+    return
+  end
+  g_minimap.saveOtmmHD(minimapHDFile())
+end
+
+function applyHDMode(enabled, reload)
+  g_minimap.setHDMode(enabled)
+  if minimapHDToggle then
+    minimapHDToggle:setOn(enabled)
+  end
+  if enabled and reload and g_game.isOnline() then
+    g_minimap.loadOtmmHD(minimapHDFile())
+  end
+end
+
+function toggleHD()
+  local enabled = not isHDEnabled()
+  if not enabled then
+    saveHDMap()   -- persist progress before leaving HD mode
+  end
+  g_settings.set('minimapHD', enabled)
+  g_settings.save()
+  applyHDMode(enabled, true)
+end
+
+-- Debug helper: modules.game_minimap.printHDStats()
+function printHDStats()
+  consoleln(g_minimap.getHDStats())
+end
+-------------------------------------------------------------------------------
+
 local function saveMap()
   if not MinimapLoader.loaded then
     return
   end
 
   g_minimap.saveOtmm(minimapFile)
+  saveHDMap()
   if minimapWidget then
     minimapWidget:save()
   end
@@ -874,6 +946,10 @@ function init()
     minimapButton:setOn(true)
   end
   minimapWidget = minimapWindow:recursiveGetChildById('minimap')
+  minimapHDToggle = minimapWindow:recursiveGetChildById('minimapHDToggle')
+  -- Reflect the persisted preference on the engine and the button. The saved tile
+  -- data is only loaded in online(), where the world and character are known.
+  applyHDMode(isHDEnabled(), false)
   local downloadMapButton = getDownloadMapButton()
   if downloadMapButton then
     local hasDownloadUrl = Services and type(Services.minimap) == 'string' and Services.minimap ~= ''
@@ -1112,6 +1188,12 @@ function online()
   if not MinimapLoader.loaded then
     loadMap(not preloaded)
   end
+  -- Restore saved HD tile data now that the world and character are known, so the
+  -- file identity cannot collide across worlds.
+  if isHDEnabled() then
+    g_minimap.loadOtmmHD(minimapHDFile())
+  end
+
   updateCameraPosition({x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 1})
   if minimapWidget then
     -- The camera has no position until the first setCameraPosition, which does not

--- a/modules/game_minimap/minimap.lua
+++ b/modules/game_minimap/minimap.lua
@@ -78,20 +78,39 @@ local function attachHDBase()
   return g_minimap.openHDBase(HD_BASE_FILE)
 end
 
--- One-off tool: builds HD_BASE_FILE from a server map. Needs items.otb loaded.
--- Example:
---   modules.game_minimap.generateHDBase('/world.otbm')
-function generateHDBase(otbmPath)
+-- One-off tool: builds HD_BASE_FILE from a server map.
+--
+-- The .otbm stores SERVER item ids, so items.otb is required to translate them
+-- into the client ids the sprites are indexed by. Nothing else in the client
+-- loads items.otb, so it is loaded here on demand. Both files must come from the
+-- same server as the assets in data/things, otherwise the ids will not line up.
+--
+--   modules.game_minimap.generateHDBase('/world.otbm', '/items.otb')
+function generateHDBase(otbmPath, otbPath)
   otbmPath = otbmPath or '/world.otbm'
+  otbPath = otbPath or '/items.otb'
+
   if not g_resources.fileExists(otbmPath) then
-    consoleln('HD baseline: ' .. otbmPath .. ' not found in the client write/read dirs.')
+    consoleln('HD baseline: ' .. otbmPath .. ' not found.')
     return false
   end
 
-  consoleln('HD baseline: generating from ' .. otbmPath .. ', this takes a while...')
+  if not g_things.isOtbLoaded() then
+    if not g_resources.fileExists(otbPath) then
+      consoleln('HD baseline: ' .. otbPath .. ' not found, and it is required to map server ids to client ids.')
+      return false
+    end
+    if not g_things.loadOtb(otbPath) then
+      consoleln('HD baseline: failed to load ' .. otbPath .. '.')
+      return false
+    end
+    consoleln('HD baseline: loaded ' .. otbPath .. '.')
+  end
+
+  consoleln('HD baseline: generating from ' .. otbmPath .. ', this takes a while and the client will freeze...')
   local ok = g_minimap.generateHDFromOtbm(otbmPath, '/minimap_hd_base.otmm')
   if ok then
-    consoleln('HD baseline: done. Move /minimap_hd_base.otmm into data/ and restart.')
+    consoleln('HD baseline: done. It is in the write dir; move it to data/ and restart.')
   else
     consoleln('HD baseline: failed, see the log.')
   end

--- a/modules/game_minimap/minimap.lua
+++ b/modules/game_minimap/minimap.lua
@@ -62,7 +62,46 @@ local function saveHDMap()
   g_minimap.saveOtmmHD(minimapHDFile())
 end
 
+-- Whole-world HD data generated offline from the server's .otbm. Shipped in data/
+-- like the bundled minimap; only its index is resident, blocks stream on demand.
+-- Without it, HD only covers what the player has actually walked, because
+-- minimap.otmm stores one colour per tile and no item ids.
+local HD_BASE_FILE = '/data/minimap_hd_base.otmm'
+
+local function attachHDBase()
+  if g_minimap.hasHDBase() then
+    return true
+  end
+  if not g_resources.fileExists(HD_BASE_FILE) then
+    return false
+  end
+  return g_minimap.openHDBase(HD_BASE_FILE)
+end
+
+-- One-off tool: builds HD_BASE_FILE from a server map. Needs items.otb loaded.
+-- Example:
+--   modules.game_minimap.generateHDBase('/world.otbm')
+function generateHDBase(otbmPath)
+  otbmPath = otbmPath or '/world.otbm'
+  if not g_resources.fileExists(otbmPath) then
+    consoleln('HD baseline: ' .. otbmPath .. ' not found in the client write/read dirs.')
+    return false
+  end
+
+  consoleln('HD baseline: generating from ' .. otbmPath .. ', this takes a while...')
+  local ok = g_minimap.generateHDFromOtbm(otbmPath, '/minimap_hd_base.otmm')
+  if ok then
+    consoleln('HD baseline: done. Move /minimap_hd_base.otmm into data/ and restart.')
+  else
+    consoleln('HD baseline: failed, see the log.')
+  end
+  return ok
+end
+
 function applyHDMode(enabled, reload)
+  if enabled then
+    attachHDBase()
+  end
   g_minimap.setHDMode(enabled)
   if minimapHDToggle then
     minimapHDToggle:setOn(enabled)

--- a/modules/game_minimap/minimap.otui
+++ b/modules/game_minimap/minimap.otui
@@ -226,3 +226,17 @@ MapMiniWindow
     tooltip: Download the complete minimap
     tooltip-delayed: true
     @onClick: modules.game_minimap.downloadFullMap()
+
+  Button
+    id: minimapHDToggle
+    !text: 'HD'
+    anchors.right: downloadMapButton.left
+    anchors.bottom: downloadMapButton.bottom
+    margin-right: 4
+    width: 26
+    height: 18
+    tooltip: Render the minimap from the real item sprites. Needs zoom 2x or closer.
+    tooltip-delayed: true
+    @onClick: modules.game_minimap.toggleHD()
+    $on:
+      color: #88ff88

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -200,6 +200,12 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_minimap", "saveImage", &Minimap::saveImage, &g_minimap);
     g_lua.bindSingletonFunction("g_minimap", "loadOtmm", &Minimap::loadOtmm, &g_minimap);
     g_lua.bindSingletonFunction("g_minimap", "saveOtmm", &Minimap::saveOtmm, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "setHDMode", &Minimap::setHDMode, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "isHDMode", &Minimap::isHDMode, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "loadOtmmHD", &Minimap::loadOtmmHD, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "saveOtmmHD", &Minimap::saveOtmmHD, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "isSavingHD", &Minimap::isSavingHD, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "getHDStats", &Minimap::getHDStats, &g_minimap);
 
     g_lua.registerSingletonClass("g_creatures");
     g_lua.bindSingletonFunction("g_creatures", "getCreatures", &CreatureManager::getCreatures, &g_creatures);

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -205,6 +205,10 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_minimap", "loadOtmmHD", &Minimap::loadOtmmHD, &g_minimap);
     g_lua.bindSingletonFunction("g_minimap", "saveOtmmHD", &Minimap::saveOtmmHD, &g_minimap);
     g_lua.bindSingletonFunction("g_minimap", "isSavingHD", &Minimap::isSavingHD, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "generateHDFromOtbm", &Minimap::generateHDFromOtbm, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "openHDBase", &Minimap::openHDBase, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "closeHDBase", &Minimap::closeHDBase, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "hasHDBase", &Minimap::hasHDBase, &g_minimap);
     g_lua.bindSingletonFunction("g_minimap", "getHDStats", &Minimap::getHDStats, &g_minimap);
 
     g_lua.registerSingletonClass("g_creatures");

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -23,9 +23,12 @@
 
 #include "minimap.h"
 #include "tile.h"
+#include "item.h"
 #include "game.h"
 #include "gameconfig.h"
 #include "spritemanager.h"
+#include "thingtypemanager.h"
+#include "thingtype.h"
 
 #include <framework/graphics/image.h>
 #include <framework/graphics/texture.h>
@@ -34,16 +37,126 @@
 #include <framework/graphics/framebuffermanager.h>
 #include <framework/core/resourcemanager.h>
 #include <framework/core/filestream.h>
+#include <framework/core/asyncdispatcher.h>
+#include <framework/core/eventdispatcher.h>
 #include <zlib.h>
 
 #include <framework/util/stats.h>
+#include <algorithm>
+#include <climits>
+#include <sstream>
+#include <thread>
+#include <unordered_map>
 
 Minimap g_minimap;
+
+// ---------------------------------------------------------------------------
+// HDBlockData
+// ---------------------------------------------------------------------------
+
+bool HDBlockData::setTileItems(uint16 tileIndex, const HDMinimapItem* items, uint16 count)
+{
+    if(tileIndex >= MMBLOCK_SIZE * MMBLOCK_SIZE)
+        return false;
+
+    if(m_slot.empty()) {
+        if(count == 0)
+            return false;   // nothing to store, stay unallocated
+        m_slot.assign(MMBLOCK_SIZE * MMBLOCK_SIZE, HD_NO_RECORD);
+    }
+
+    const uint16 recordIndex = m_slot[tileIndex];
+
+    if(recordIndex == HD_NO_RECORD) {
+        if(count == 0)
+            return false;
+
+        HDTileRecord record;
+        record.tileIndex = tileIndex;
+        record.count = count;
+        record.offset = (uint32)m_items.size();
+        m_items.insert(m_items.end(), items, items + count);
+
+        m_slot[tileIndex] = (uint16)m_records.size();
+        m_records.push_back(record);
+        ++m_contentRevision;
+        return true;
+    }
+
+    HDTileRecord& record = m_records[recordIndex];
+
+    if(count == record.count &&
+       std::equal(items, items + count, m_items.begin() + record.offset)) {
+        return false;   // unchanged, the common case while walking
+    }
+
+    if(count == 0) {
+        // Drop the record; swap-erase and repair the slot of the moved entry.
+        m_garbageItems += record.count;
+        m_slot[tileIndex] = HD_NO_RECORD;
+
+        const uint16 lastIndex = (uint16)(m_records.size() - 1);
+        if(recordIndex != lastIndex) {
+            m_records[recordIndex] = m_records[lastIndex];
+            m_slot[m_records[recordIndex].tileIndex] = recordIndex;
+        }
+        m_records.pop_back();
+        ++m_contentRevision;
+        compact();
+        return true;
+    }
+
+    if(count == record.count) {
+        std::copy(items, items + count, m_items.begin() + record.offset);
+    } else {
+        // Size changed: the old span becomes garbage and the new one is appended.
+        m_garbageItems += record.count;
+        record.offset = (uint32)m_items.size();
+        record.count = count;
+        m_items.insert(m_items.end(), items, items + count);
+    }
+
+    ++m_contentRevision;
+    compact();
+    return true;
+}
+
+void HDBlockData::compact()
+{
+    // Only worth it once the dead span outweighs the live data.
+    if(m_garbageItems <= 1024 || m_garbageItems * 2 <= m_items.size())
+        return;
+
+    std::vector<HDMinimapItem> packed;
+    packed.reserve(m_items.size() - m_garbageItems);
+
+    for(HDTileRecord& record : m_records) {
+        const uint32 offset = (uint32)packed.size();
+        packed.insert(packed.end(),
+                      m_items.begin() + record.offset,
+                      m_items.begin() + record.offset + record.count);
+        record.offset = offset;
+    }
+
+    m_items.swap(packed);
+    m_items.shrink_to_fit();
+    m_garbageItems = 0;
+}
+
+size_t HDBlockData::getByteSize() const
+{
+    return m_records.capacity() * sizeof(HDTileRecord) +
+           m_items.capacity() * sizeof(HDMinimapItem) +
+           m_slot.capacity() * sizeof(uint16);
+}
+
+// ---------------------------------------------------------------------------
 
 void MinimapBlock::clean()
 {
     m_tiles.fill(MinimapTile());
     m_texture.reset();
+    m_hd.reset();
     m_mustUpdate = false;
 }
 
@@ -86,11 +199,33 @@ void MinimapBlock::updateTile(int x, int y, const MinimapTile& tile)
 void Minimap::init()
 {
     m_tileBlocks.resize(g_gameConfig.getMapMaxZ() + 1);
+
+    // The HD minimap is a secondary feature: it never gets more than two workers,
+    // and on anything but a clearly wide machine it gets one. Gameplay owns the
+    // remaining cores.
+    const unsigned cores = std::thread::hardware_concurrency();
+    m_hdMaxWorkers = (cores > 8) ? 2 : 1;
 }
 
 void Minimap::terminate()
 {
+    // Invalidate first: any worker still running observes the new generation and
+    // throws its result away instead of touching state that is being torn down.
+    m_hdGeneration.fetch_add(1, std::memory_order_release);
+    m_hdMode.store(false, std::memory_order_relaxed);
+
+    {
+        std::lock_guard<std::mutex> lock(m_hdResultLock);
+        m_hdResults.clear();
+    }
+    m_hdPendingImageBytes.store(0, std::memory_order_release);
+    m_hdQueue.clear();
+    m_hdRunning.clear();
+
     clean();
+
+    // g_asyncDispatcher is joined by the framework during shutdown, so there is no
+    // detached thread and no this-capturing work left behind.
 }
 
 void Minimap::clean()
@@ -98,6 +233,11 @@ void Minimap::clean()
     std::lock_guard<std::mutex> lock(m_lock);
     for (auto& tileBlocks : m_tileBlocks)
         tileBlocks.clear();
+
+    // Dropping every block also drops their HD payloads; the generation bump is
+    // what stops async work started before the clean from touching new state.
+    m_hdDataBytes = 0;
+    m_hdGeneration.fetch_add(1, std::memory_order_release);
 }
 
 void Minimap::draw(const Rect& screenRect, const Position& mapCenter, float scale, const Color& color)
@@ -142,7 +282,627 @@ void Minimap::draw(const Rect& screenRect, const Position& mapCenter, float scal
         }
     }
 
+    // HD is drawn over the base layer, never instead of it. A block whose HD
+    // texture is missing, still rendering or evicted simply shows the standard
+    // minimap underneath: no holes, no flicker, and any HD failure degrades to
+    // exactly the behaviour of a client without the feature.
+    if(m_hdMode.load(std::memory_order_relaxed) && scale >= HD_MIN_SCALE)
+        drawHD(screenRect, mapCenter, scale, blockOff, start);
+
     g_drawQueue->setClip(drawQueueStart, screenRect);
+}
+
+bool Minimap::drawHD(const Rect& screenRect, const Position& mapCenter, float scale,
+                     const Point& blockOff, const Point& start)
+{
+    if(mapCenter.z >= m_tileBlocks.size())
+        return false;
+
+    const ticks_t now = stdext::millis();
+    const int blockPixels = (int)(MMBLOCK_SIZE * scale);
+    if(blockPixels <= 0)
+        return false;
+
+    const Rect hdSrc(0, 0, HD_BLOCK_TEXTURE_SIZE, HD_BLOCK_TEXTURE_SIZE);
+    const int centerBlockX = mapCenter.x / MMBLOCK_SIZE;
+    const int centerBlockY = mapCenter.y / MMBLOCK_SIZE;
+
+    // Block-space rectangle of what is on screen. Everything outside it (plus the
+    // prefetch ring) is eligible for eviction, including on the active floor.
+    int minBlockX = INT_MAX, minBlockY = INT_MAX, maxBlockX = INT_MIN, maxBlockY = INT_MIN;
+
+    {
+        std::lock_guard<std::mutex> lock(m_lock);
+        auto& blocks = m_tileBlocks[mapCenter.z];
+
+        for(int y = blockOff.y, ys = start.y; ys < screenRect.bottom(); y += MMBLOCK_SIZE, ys += blockPixels) {
+            if(y < 0 || y >= 65536)
+                continue;
+
+            for(int x = blockOff.x, xs = start.x; xs < screenRect.right(); x += MMBLOCK_SIZE, xs += blockPixels) {
+                if(x < 0 || x >= 65536)
+                    continue;
+
+                const int bx = x / MMBLOCK_SIZE;
+                const int by = y / MMBLOCK_SIZE;
+                minBlockX = std::min(minBlockX, bx); maxBlockX = std::max(maxBlockX, bx);
+                minBlockY = std::min(minBlockY, by); maxBlockY = std::max(maxBlockY, by);
+
+                const Position blockPos(x, y, mapCenter.z);
+                const uint blockIndex = getBlockIndex(blockPos);
+
+                auto it = blocks.find(blockIndex);
+                if(it == blocks.end() || !it->second)
+                    continue;
+
+                HDBlockData* hd = it->second->getHDData();
+                if(!hd)
+                    continue;
+
+                hd->markUsed(now);
+
+                if(hd->hasTexture()) {
+                    g_drawQueue->addTexturedRect(Rect(xs, ys, blockPixels, blockPixels),
+                                                hd->getTexture(), hdSrc);
+                    if(!hd->needsRender()) {
+                        ++m_hdCacheHits;
+                        continue;
+                    }
+                    // Stale but drawable: keep showing it while the new one builds.
+                }
+                ++m_hdCacheMisses;
+
+                const int priority = std::abs(bx - centerBlockX) + std::abs(by - centerBlockY);
+                queueHDBlock(*it->second, blockPos, blockIndex, priority);
+            }
+        }
+    }
+
+    dispatchHDJobs();
+    collectHDResults();
+
+    if(minBlockX != INT_MAX) {
+        const Rect visibleBlocks(minBlockX, minBlockY,
+                                 maxBlockX - minBlockX + 1, maxBlockY - minBlockY + 1);
+        enforceHDTextureBudget(mapCenter, visibleBlocks);
+    }
+
+    return true;
+}
+
+void Minimap::queueHDBlock(MinimapBlock& block, const Position& blockPos, uint blockIndex, int priority)
+{
+    HDBlockData* hd = block.getHDData();
+    if(!hd || hd->isEmpty())
+        return;
+
+    const uint32 revision = hd->getContentRevision();
+
+    // A worker is already producing exactly this revision.
+    for(const HDRunningJob& running : m_hdRunning) {
+        if(running.blockIndex == blockIndex && running.z == blockPos.z && running.revision == revision)
+            return;
+    }
+
+    // One entry per block, always the newest revision. This is the only place a
+    // job enters the queue, and the only bound that exists.
+    for(size_t i = 0; i < m_hdQueue.size(); ++i) {
+        if(m_hdQueue[i].blockIndex == blockIndex && m_hdQueue[i].blockPos.z == blockPos.z) {
+            if(m_hdQueue[i].revision == revision)
+                return;
+            m_hdQueue.erase(m_hdQueue.begin() + i);
+            break;
+        }
+    }
+
+    if(m_hdQueue.size() >= HD_MAX_QUEUED_JOBS) {
+        // Drop the worst queued job rather than the oldest: what matters is being
+        // close to the viewport, not arrival order.
+        auto worst = std::max_element(m_hdQueue.begin(), m_hdQueue.end(),
+            [](const HDRenderJob& a, const HDRenderJob& b) { return a.priority < b.priority; });
+        if(worst == m_hdQueue.end() || worst->priority <= priority)
+            return;   // the new job is not better than anything queued
+        m_hdQueue.erase(worst);
+    }
+
+    HDRenderJob job;
+    job.blockIndex = blockIndex;
+    job.blockPos = blockPos;
+    job.generation = m_hdGeneration.load(std::memory_order_acquire);
+    job.revision = revision;
+    job.priority = priority;
+
+    // Snapshot this block's tiles, plus the tiles of the neighbouring blocks that
+    // can spill sprites across the border. Only tiles that carry items are copied,
+    // so this stays proportional to real content.
+    const int margin = 3;
+    const int elevationMargin = 2;
+
+    for(int nby = -1; nby <= 1; ++nby) {
+        for(int nbx = -1; nbx <= 1; ++nbx) {
+            const int nx = blockPos.x + nbx * MMBLOCK_SIZE;
+            const int ny = blockPos.y + nby * MMBLOCK_SIZE;
+            if(nx < 0 || ny < 0 || nx >= 65536 || ny >= 65536)
+                continue;
+
+            const Position nbPos(nx, ny, blockPos.z);
+            auto nit = m_tileBlocks[blockPos.z].find(getBlockIndex(nbPos));
+            if(nit == m_tileBlocks[blockPos.z].end() || !nit->second)
+                continue;
+
+            const HDBlockData* nhd = nit->second->getHDData();
+            if(!nhd)
+                continue;
+
+            for(const HDTileRecord& record : nhd->getRecords()) {
+                const int localX = record.tileIndex % MMBLOCK_SIZE;
+                const int localY = record.tileIndex / MMBLOCK_SIZE;
+                const int gx = localX + nbx * MMBLOCK_SIZE;
+                const int gy = localY + nby * MMBLOCK_SIZE;
+
+                // Keep only what can actually touch this block's 512x512 target.
+                if(gx < -margin || gx >= MMBLOCK_SIZE + margin ||
+                   gy < -margin - elevationMargin || gy >= MMBLOCK_SIZE + margin)
+                    continue;
+
+                HDJobTile jobTile;
+                jobTile.gx = (int16)gx;
+                jobTile.gy = (int16)gy;
+                jobTile.first = (uint32)job.items.size();
+                jobTile.count = record.count;
+
+                const HDMinimapItem* src = nhd->getItemPool().data() + record.offset;
+                job.items.insert(job.items.end(), src, src + record.count);
+                job.tiles.push_back(jobTile);
+            }
+        }
+    }
+
+    if(job.tiles.empty())
+        return;
+
+    m_hdQueue.push_back(std::move(job));
+}
+
+void Minimap::dispatchHDJobs()
+{
+    while(m_hdRunningJobs.load(std::memory_order_acquire) < m_hdMaxWorkers && !m_hdQueue.empty()) {
+        // Do not start work whose output has nowhere to go yet.
+        if(m_hdPendingImageBytes.load(std::memory_order_acquire) + HD_BLOCK_TEXTURE_BYTES
+           > HD_PENDING_IMAGE_BUDGET_BYTES)
+            break;
+
+        auto best = std::min_element(m_hdQueue.begin(), m_hdQueue.end(),
+            [](const HDRenderJob& a, const HDRenderJob& b) { return a.priority < b.priority; });
+
+        HDRenderJob job = std::move(*best);
+        m_hdQueue.erase(best);
+
+        if(job.generation != m_hdGeneration.load(std::memory_order_acquire)) {
+            m_hdStaleDropped.fetch_add(1, std::memory_order_relaxed);
+            continue;
+        }
+
+        HDRenderTask task;
+        if(!buildHDTask(job, task))
+            continue;
+
+        m_hdRunningJobs.fetch_add(1, std::memory_order_release);
+        m_hdPendingImageBytes.fetch_add(HD_BLOCK_TEXTURE_BYTES, std::memory_order_release);
+        m_hdRunning.push_back({ task.blockIndex, task.z, task.revision });
+
+        // g_asyncDispatcher owns joinable threads and is stopped by the framework
+        // during shutdown, so nothing here can outlive the process teardown.
+        // Capturing g_minimap's `this` is safe: it is a global with static storage.
+        g_asyncDispatcher.dispatch([this, task = std::move(task)]() mutable {
+            // Always posts a result, even a cancelled one with a null image, so
+            // collectHDResults is the single place that retires in-flight state.
+            HDRenderResult result;
+            result.blockIndex = task.blockIndex;
+            result.z = task.z;
+            result.generation = task.generation;
+            result.revision = task.revision;
+            result.image = composeHDImage(task, m_hdGeneration);
+
+            {
+                std::lock_guard<std::mutex> lock(m_hdResultLock);
+                m_hdResults.push_back(std::move(result));
+            }
+
+            m_hdRunningJobs.fetch_sub(1, std::memory_order_release);
+        });
+    }
+}
+
+bool Minimap::buildHDTask(const HDRenderJob& job, HDRenderTask& task)
+{
+    task.blockIndex = job.blockIndex;
+    task.z = (uint8)job.blockPos.z;
+    task.generation = job.generation;
+    task.revision = job.revision;
+
+    // Protobuf (15.x) assets store the whole bounding square per layer; legacy .spr
+    // splits it into 32px cells.
+    const bool protobuf = g_sprites.isHdMod();
+    const int spriteSize = g_sprites.spriteSize() > 0 ? g_sprites.spriteSize() : 32;
+
+    // Sprite images and thing types are resolved HERE, on the dispatcher thread.
+    // SpriteManager decrypts in place and mutates an LRU, and ThingTypeManager has
+    // no synchronisation at all, so a worker must never reach either of them.
+    // Deduplicated so a wall repeated across a block decodes once.
+    std::unordered_map<int, ImagePtr> resolved;
+    auto spriteImage = [&](int spriteId) -> const ImagePtr& {
+        auto it = resolved.find(spriteId);
+        if(it == resolved.end())
+            it = resolved.emplace(spriteId, g_sprites.getSpriteImage(spriteId)).first;
+        return it->second;
+    };
+
+    // Two passes so full-ground tiles land under everything else, matching the
+    // stacking the game view uses.
+    for(int pass = 0; pass < 2; ++pass) {
+        for(const HDJobTile& jobTile : job.tiles) {
+            for(uint16 i = 0; i < jobTile.count; ++i) {
+                const HDMinimapItem& entry = job.items[jobTile.first + i];
+
+                if(!g_things.isValidDatId(entry.id, ThingCategoryItem))
+                    continue;
+
+                // Non-owning observer into g_things' own storage; valid for this
+                // synchronous scope only, which is why nothing here escapes to a worker.
+                ThingType* thingType = g_things.rawGetThingType(entry.id, ThingCategoryItem);
+                if(!thingType || !thingType->isLoaded())
+                    continue;
+
+                const bool fullGround = thingType->isFullGround();
+                if((pass == 0) != fullGround)
+                    continue;
+
+                const int layers = thingType->getLayers();
+                const int npx = std::max(1, thingType->getNumPatternX());
+                const int npy = std::max(1, thingType->getNumPatternY());
+                const int npz = std::max(1, thingType->getNumPatternZ());
+
+                int xPattern = 0, yPattern = 0;
+                if(thingType->isSplash() || thingType->isFluidContainer()) {
+                    int color = Otc::FluidTransparent;
+                    switch(entry.subtype) {
+                        case Otc::FluidNone:        color = Otc::FluidTransparent; break;
+                        case Otc::FluidWater:       color = Otc::FluidBlue;   break;
+                        case Otc::FluidMana:        color = Otc::FluidPurple; break;
+                        case Otc::FluidBeer:        color = Otc::FluidBrown;  break;
+                        case Otc::FluidOil:         color = Otc::FluidBrown;  break;
+                        case Otc::FluidBlood:       color = Otc::FluidRed;    break;
+                        case Otc::FluidSlime:       color = Otc::FluidGreen;  break;
+                        case Otc::FluidMud:         color = Otc::FluidBrown;  break;
+                        case Otc::FluidLemonade:    color = Otc::FluidYellow; break;
+                        case Otc::FluidMilk:        color = Otc::FluidWhite;  break;
+                        case Otc::FluidWine:        color = Otc::FluidPurple; break;
+                        case Otc::FluidHealth:      color = Otc::FluidRed;    break;
+                        case Otc::FluidUrine:       color = Otc::FluidYellow; break;
+                        case Otc::FluidRum:         color = Otc::FluidBrown;  break;
+                        case Otc::FluidFruidJuice:  color = Otc::FluidYellow; break;
+                        case Otc::FluidCoconutMilk: color = Otc::FluidWhite;  break;
+                        case Otc::FluidTea:         color = Otc::FluidBrown;  break;
+                        case Otc::FluidMead:        color = Otc::FluidBrown;  break;
+                        default:                    color = Otc::FluidTransparent; break;
+                    }
+                    xPattern = (color % 4) % npx;
+                    yPattern = (color / 4) % npy;
+                }
+
+                const std::vector<int> sprites = thingType->getSprites();
+                const int numSprites = (int)sprites.size();
+                if(numSprites <= 0)
+                    continue;
+
+                const int width = thingType->getWidth();
+                const int height = thingType->getHeight();
+
+                if(protobuf) {
+                    for(int l = 0; l < layers; ++l) {
+                        const int spriteIndex = ((0 * npy + yPattern) * npx + xPattern) * layers + l;
+                        if(spriteIndex < 0 || spriteIndex >= numSprites)
+                            continue;
+
+                        const ImagePtr& img = spriteImage(sprites[spriteIndex]);
+                        if(!img)
+                            continue;
+
+                        int cellsW = std::max(1, img->getWidth() / spriteSize);
+                        int cellsH = std::max(1, img->getHeight() / spriteSize);
+
+                        HDBlit blit;
+                        blit.image = img;
+                        // The tile is the bottom-right cell; the thing extends up/left.
+                        blit.destX = (int16)((jobTile.gx - (cellsW - 1)) * HD_TEXELS_PER_TILE);
+                        blit.destY = (int16)((jobTile.gy - (cellsH - 1)) * HD_TEXELS_PER_TILE);
+                        blit.width = (int16)(cellsW * HD_TEXELS_PER_TILE);
+                        blit.height = (int16)(cellsH * HD_TEXELS_PER_TILE);
+                        task.blits.push_back(std::move(blit));
+                    }
+                } else {
+                    for(int l = 0; l < layers; ++l) {
+                        for(int h = 0; h < height; ++h) {
+                            for(int w = 0; w < width; ++w) {
+                                const int spriteIndex =
+                                    ((((l * npz + 0) * npy + yPattern) * npx + xPattern)
+                                     * height + (height - h - 1)) * width + (width - w - 1);
+                                if(spriteIndex < 0 || spriteIndex >= numSprites)
+                                    continue;
+
+                                const ImagePtr& img = spriteImage(sprites[spriteIndex]);
+                                if(!img)
+                                    continue;
+
+                                HDBlit blit;
+                                blit.image = img;
+                                blit.destX = (int16)((jobTile.gx - (width - 1) + w) * HD_TEXELS_PER_TILE);
+                                blit.destY = (int16)((jobTile.gy - (height - 1) + h) * HD_TEXELS_PER_TILE);
+                                blit.width = HD_TEXELS_PER_TILE;
+                                blit.height = HD_TEXELS_PER_TILE;
+                                task.blits.push_back(std::move(blit));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return !task.blits.empty();
+}
+
+ImagePtr Minimap::composeHDImage(const HDRenderTask& task, const std::atomic<uint32>& generation)
+{
+    // Rendered straight at its final size. There is no oversized intermediate and
+    // no crop pass: peak memory for a render is exactly one 512x512 RGBA image.
+    ImagePtr target = std::make_shared<Image>(Size(HD_BLOCK_TEXTURE_SIZE, HD_BLOCK_TEXTURE_SIZE));
+    uint8* dstBase = target->getPixelData();
+
+    int sinceCheck = 0;
+    for(const HDBlit& blit : task.blits) {
+        // Early cancellation: a job invalidated by a toggle, relog or clean stops
+        // burning CPU instead of finishing and being thrown away at the end.
+        if(++sinceCheck >= 32) {
+            sinceCheck = 0;
+            if(generation.load(std::memory_order_acquire) != task.generation)
+                return nullptr;
+        }
+
+        const ImagePtr& src = blit.image;
+        if(!src || blit.width <= 0 || blit.height <= 0)
+            continue;
+
+        const int srcW = src->getWidth();
+        const int srcH = src->getHeight();
+        if(srcW <= 0 || srcH <= 0)
+            continue;
+
+        uint8* srcBase = src->getPixelData();
+
+        for(int oy = 0; oy < blit.height; ++oy) {
+            const int dy = blit.destY + oy;
+            if(dy < 0 || dy >= HD_BLOCK_TEXTURE_SIZE)
+                continue;
+
+            int sy0 = (oy * srcH) / blit.height;
+            int sy1 = ((oy + 1) * srcH) / blit.height;
+            if(sy1 <= sy0) sy1 = sy0 + 1;
+            if(sy1 > srcH) sy1 = srcH;
+
+            for(int ox = 0; ox < blit.width; ++ox) {
+                const int dx = blit.destX + ox;
+                if(dx < 0 || dx >= HD_BLOCK_TEXTURE_SIZE)
+                    continue;
+
+                int sx0 = (ox * srcW) / blit.width;
+                int sx1 = ((ox + 1) * srcW) / blit.width;
+                if(sx1 <= sx0) sx1 = sx0 + 1;
+                if(sx1 > srcW) sx1 = srcW;
+
+                // Box filter in premultiplied alpha so anti-aliased sprite edges
+                // average correctly and adjacent tiles connect instead of seaming.
+                uint32 accR = 0, accG = 0, accB = 0, accA = 0;
+                int samples = 0;
+                for(int sy = sy0; sy < sy1; ++sy) {
+                    const uint8* row = srcBase + ((size_t)sy * srcW + sx0) * 4;
+                    for(int sx = sx0; sx < sx1; ++sx, row += 4) {
+                        accR += (uint32)row[0] * row[3];
+                        accG += (uint32)row[1] * row[3];
+                        accB += (uint32)row[2] * row[3];
+                        accA += row[3];
+                        ++samples;
+                    }
+                }
+                if(samples == 0 || accA == 0)
+                    continue;
+
+                const uint8 outA = (uint8)(accA / samples);
+                if(outA == 0)
+                    continue;
+
+                const uint8 outR = (uint8)(accR / accA);
+                const uint8 outG = (uint8)(accG / accA);
+                const uint8 outB = (uint8)(accB / accA);
+
+                uint8* dst = dstBase + ((size_t)dy * HD_BLOCK_TEXTURE_SIZE + dx) * 4;
+                const int inv = 255 - outA;
+                dst[0] = (uint8)((outR * outA + dst[0] * inv) / 255);
+                dst[1] = (uint8)((outG * outA + dst[1] * inv) / 255);
+                dst[2] = (uint8)((outB * outA + dst[2] * inv) / 255);
+                dst[3] = (uint8)(outA + (dst[3] * inv) / 255);
+            }
+        }
+    }
+
+    return target;
+}
+
+void Minimap::collectHDResults()
+{
+    std::vector<HDRenderResult> results;
+    {
+        std::lock_guard<std::mutex> lock(m_hdResultLock);
+        results.swap(m_hdResults);
+    }
+
+    if(results.empty())
+        return;
+
+    const uint32 generation = m_hdGeneration.load(std::memory_order_acquire);
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    for(HDRenderResult& result : results) {
+        m_hdPendingImageBytes.fetch_sub(HD_BLOCK_TEXTURE_BYTES, std::memory_order_release);
+
+        // Retire the in-flight entry first, whatever the outcome, so the block
+        // becomes queueable again even if the render was cancelled or rejected.
+        for(size_t i = 0; i < m_hdRunning.size(); ++i) {
+            if(m_hdRunning[i].blockIndex == result.blockIndex &&
+               m_hdRunning[i].z == result.z &&
+               m_hdRunning[i].revision == result.revision) {
+                m_hdRunning.erase(m_hdRunning.begin() + i);
+                break;
+            }
+        }
+
+        if(!result.image || result.generation != generation) {
+            m_hdStaleDropped.fetch_add(1, std::memory_order_relaxed);
+            continue;   // the image dies here; nothing live is touched
+        }
+
+        if(result.z >= m_tileBlocks.size())
+            continue;
+
+        auto& blocks = m_tileBlocks[result.z];
+        auto it = blocks.find(result.blockIndex);
+        if(it == blocks.end() || !it->second)
+            continue;
+
+        HDBlockData* hd = it->second->getHDData();
+        if(!hd)
+            continue;   // HD data dropped while the job ran
+
+        const bool wasResident = hd->hasTexture();
+
+        // Constructing a Texture performs no GL call: it only holds the image
+        // until the main thread uploads it in Texture::update(). Marked
+        // non-cacheable so these 512x512 blocks never enter g_atlas, which is
+        // shared with the game view.
+        TexturePtr texture = std::make_shared<Texture>(result.image);
+        texture->setSmooth(true);
+        texture->setCanCache(false);
+
+        hd->setTexture(texture, result.revision);
+
+        if(!wasResident) {
+            m_hdTextureBytes += HD_BLOCK_TEXTURE_BYTES;
+            m_hdResident.emplace_back(result.z, result.blockIndex);
+        }
+    }
+}
+
+void Minimap::dropHDTextureAt(uint8 z, uint blockIndex)
+{
+    if(z >= m_tileBlocks.size())
+        return;
+
+    auto& blocks = m_tileBlocks[z];
+    auto it = blocks.find(blockIndex);
+    if(it == blocks.end() || !it->second)
+        return;
+
+    if(HDBlockData* hd = it->second->getHDData()) {
+        if(hd->hasTexture()) {
+            hd->dropTexture();
+            if(m_hdTextureBytes >= HD_BLOCK_TEXTURE_BYTES)
+                m_hdTextureBytes -= HD_BLOCK_TEXTURE_BYTES;
+            ++m_hdEvictions;
+        }
+    }
+}
+
+void Minimap::enforceHDTextureBudget(const Position& mapCenter, const Rect& visibleBlocks)
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    // Forget entries whose texture is already gone before deciding anything.
+    m_hdResident.erase(std::remove_if(m_hdResident.begin(), m_hdResident.end(),
+        [this](const std::pair<uint8, uint>& entry) {
+            if(entry.first >= m_tileBlocks.size())
+                return true;
+            auto& blocks = m_tileBlocks[entry.first];
+            auto it = blocks.find(entry.second);
+            if(it == blocks.end() || !it->second)
+                return true;
+            const HDBlockData* hd = it->second->getHDData();
+            return !hd || !hd->hasTexture();
+        }), m_hdResident.end());
+
+    if(m_hdTextureBytes <= HD_TEXTURE_BUDGET_BYTES)
+        return;
+
+    const int centerBlockX = mapCenter.x / MMBLOCK_SIZE;
+    const int centerBlockY = mapCenter.y / MMBLOCK_SIZE;
+
+    // Protected set: the visible blocks plus one ring of prefetch. Deliberately
+    // nothing else — the active floor gets no special treatment, which is exactly
+    // where the previous implementation accumulated without bound.
+    const Rect protectedBlocks(visibleBlocks.x() - HD_PROTECT_MARGIN_BLOCKS,
+                               visibleBlocks.y() - HD_PROTECT_MARGIN_BLOCKS,
+                               visibleBlocks.width() + 2 * HD_PROTECT_MARGIN_BLOCKS,
+                               visibleBlocks.height() + 2 * HD_PROTECT_MARGIN_BLOCKS);
+
+    struct Candidate { size_t residentIdx; int64_t score; };
+    std::vector<Candidate> candidates;
+    candidates.reserve(m_hdResident.size());
+
+    for(size_t i = 0; i < m_hdResident.size(); ++i) {
+        const uint8 z = m_hdResident[i].first;
+        const uint blockIndex = m_hdResident[i].second;
+        const Position blockPos = getIndexPosition(blockIndex, z);
+        const int bx = blockPos.x / MMBLOCK_SIZE;
+        const int by = blockPos.y / MMBLOCK_SIZE;
+
+        const bool sameFloor = (z == mapCenter.z);
+        if(sameFloor && protectedBlocks.contains(Point(bx, by)))
+            continue;
+
+        // Higher score evicts first: other floors go before the current one, then
+        // distance from the viewport centre, then least recently used.
+        int64_t score = 0;
+        if(!sameFloor)
+            score += 1000000;
+        score += (int64_t)(std::abs(bx - centerBlockX) + std::abs(by - centerBlockY)) * 100;
+
+        // find(), never operator[]: the latter would insert phantom null blocks.
+        auto blockIt = m_tileBlocks[z].find(blockIndex);
+        if(blockIt != m_tileBlocks[z].end() && blockIt->second) {
+            if(const HDBlockData* hd = blockIt->second->getHDData())
+                score += (int64_t)std::min<ticks_t>(stdext::millis() - hd->getLastUsed(), 60000) / 1000;
+        }
+
+        candidates.push_back({ i, score });
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+        [](const Candidate& a, const Candidate& b) { return a.score > b.score; });
+
+    std::vector<size_t> evicted;
+    for(const Candidate& candidate : candidates) {
+        if(m_hdTextureBytes <= HD_TEXTURE_BUDGET_BYTES)
+            break;
+        const auto& entry = m_hdResident[candidate.residentIdx];
+        dropHDTextureAt(entry.first, entry.second);
+        evicted.push_back(candidate.residentIdx);
+    }
+
+    if(!evicted.empty()) {
+        std::sort(evicted.begin(), evicted.end(), std::greater<size_t>());
+        for(size_t idx : evicted)
+            m_hdResident.erase(m_hdResident.begin() + idx);
+    }
 }
 
 Point Minimap::getTilePoint(const Position& pos, const Rect& screenRect, const Position& mapCenter, float scale)
@@ -208,7 +968,510 @@ void Minimap::updateTile(const Position& pos, const TilePtr& tile)
         Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
         block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
         block.justSaw();
+
+        // The whole cost of HD mode being off is this relaxed load. Nothing is
+        // collected, allocated or hashed unless HD is actually on.
+        if(m_hdMode.load(std::memory_order_relaxed))
+            collectHDTile(pos, tile);
     }
+}
+
+void Minimap::collectHDTile(const Position& pos, const TilePtr& tile)
+{
+    // Reused across calls, so after warm-up this collects a tile without any
+    // allocation. Safe as a member because updateTile only runs on the dispatcher
+    // thread.
+    std::vector<HDMinimapItem>& items = m_hdScratch;
+    items.clear();
+
+    if(tile) {
+        for(const ThingPtr& thing : tile->getThingsRef()) {
+            if(!thing || !thing->isItem())
+                continue;
+
+            const ItemPtr& item = thing->static_self_cast<Item>();
+            HDMinimapItem entry;
+            entry.id = (uint16)item->getId();
+            if(item->isSplash() || item->isFluidContainer())
+                entry.subtype = (uint16)item->getSubType();
+
+            items.push_back(entry);
+        }
+    }
+
+    const Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
+    const uint16 tileIndex = (uint16)(((pos.y - offsetPos.y) * MMBLOCK_SIZE) + (pos.x - offsetPos.x));
+
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    if(pos.z >= m_tileBlocks.size())
+        return;
+
+    auto& blocks = m_tileBlocks[pos.z];
+    auto it = blocks.find(getBlockIndex(pos));
+    if(it == blocks.end() || !it->second)
+        return;
+
+    MinimapBlock& block = *it->second;
+
+    // Never allocate an HD payload just to store "this tile is empty".
+    if(items.empty() && !block.getHDData())
+        return;
+
+    HDBlockData& hd = block.getOrCreateHDData();
+    const size_t before = hd.getByteSize();
+    hd.setTileItems(tileIndex, items.data(), (uint16)items.size());
+    m_hdDataBytes += hd.getByteSize() - before;
+
+    // A payload that emptied out is released instead of lingering as an 8 KiB
+    // slot table.
+    if(hd.isEmpty()) {
+        m_hdDataBytes -= hd.getByteSize();
+        block.dropHDData();
+    }
+}
+
+void Minimap::setHDMode(bool enabled)
+{
+    if(m_hdMode.load(std::memory_order_relaxed) == enabled)
+        return;
+
+    std::lock_guard<std::mutex> lock(m_lock);
+    m_hdMode.store(enabled, std::memory_order_relaxed);
+
+    // Leaving HD mode returns every HD byte. Entering it starts from nothing and
+    // fills in lazily, which is why the generation moves in both directions.
+    if(!enabled)
+        invalidateHDLocked();
+    else
+        m_hdGeneration.fetch_add(1, std::memory_order_release);
+}
+
+void Minimap::invalidateHDLocked()
+{
+    // Bumping first means any worker that finishes from here on discards its
+    // result instead of writing into state we are about to reset.
+    m_hdGeneration.fetch_add(1, std::memory_order_release);
+
+    for(auto& blocks : m_tileBlocks) {
+        for(auto& pair : blocks) {
+            if(pair.second)
+                pair.second->dropHDData();   // releases payload and texture together
+        }
+    }
+
+    m_hdDataBytes = 0;
+    m_hdTextureBytes = 0;
+    m_hdResident.clear();
+    m_hdResident.shrink_to_fit();
+    m_hdQueue.clear();
+    m_hdQueue.shrink_to_fit();
+    // Jobs still executing will post results that the generation check rejects.
+    m_hdRunning.clear();
+    m_hdRunning.shrink_to_fit();
+
+    // Images already produced are dropped; their reservation is released with them.
+    {
+        std::lock_guard<std::mutex> lock(m_hdResultLock);
+        for(size_t i = 0; i < m_hdResults.size(); ++i)
+            m_hdPendingImageBytes.fetch_sub(HD_BLOCK_TEXTURE_BYTES, std::memory_order_release);
+        m_hdResults.clear();
+    }
+}
+
+namespace {
+
+// "/minimap/foo_hd.otmm" + z=7 -> "/minimap/foo_hd_floor7.otmm"
+std::string hdFloorFileName(const std::string& baseName, int z)
+{
+    std::string stem = baseName;
+    const std::string ext = ".otmm";
+    if(stem.size() > ext.size() && stem.compare(stem.size() - ext.size(), ext.size(), ext) == 0)
+        stem.resize(stem.size() - ext.size());
+    return stem + "_floor" + std::to_string(z) + ext;
+}
+
+} // namespace
+
+void Minimap::saveOtmmHD(const std::string& fileName)
+{
+    if(fileName.empty())
+        return;
+
+    // Coalescing instead of waiting: a request arriving while a save runs simply
+    // replaces the pending one. The main thread never sleeps or polls on I/O.
+    if(m_hdSaving.exchange(true, std::memory_order_acq_rel)) {
+        m_hdSavePending = true;
+        m_hdSavePendingFile = fileName;
+        return;
+    }
+
+    const uint32 generation = m_hdGeneration.load(std::memory_order_acquire);
+
+    g_asyncDispatcher.dispatch([this, fileName, generation] {
+        try {
+            g_resources.makeDir("minimap");
+
+            const int maxZ = (int)m_tileBlocks.size() - 1;
+            for(int z = 0; z <= maxZ; ++z) {
+                if(generation != m_hdGeneration.load(std::memory_order_acquire))
+                    break;   // HD was reset under us; the file on disk stays as it was
+
+                // Decide whether this floor needs rewriting, and grab its block
+                // list, holding the lock only for that.
+                std::vector<uint> blockIndices;
+                bool floorDirty = false;
+                {
+                    std::lock_guard<std::mutex> lock(m_lock);
+                    if(z >= (int)m_tileBlocks.size())
+                        break;
+                    for(auto& pair : m_tileBlocks[z]) {
+                        if(!pair.second)
+                            continue;
+                        const HDBlockData* hd = pair.second->getHDData();
+                        if(!hd || hd->isEmpty())
+                            continue;
+                        blockIndices.push_back(pair.first);
+                        if(hd->isDirty())
+                            floorDirty = true;
+                    }
+                }
+
+                if(!floorDirty || blockIndices.empty())
+                    continue;
+
+                const std::string floorFile = hdFloorFileName(fileName, z);
+                const std::string tmpFile = floorFile + ".tmp";
+
+                FileStreamPtr fin = g_resources.createFile(tmpFile);
+                if(!fin)
+                    continue;
+
+                fin->addU32(OTMM_HD_SIGNATURE);
+                fin->addU16(0);                  // data start, patched below
+                fin->addU16(OTMM_HD_VERSION);
+                fin->addU32(0);                  // flags
+                fin->addString("OTMM HD 2.0");
+
+                const uint32 dataStart = fin->tell();
+                fin->seek(4);
+                fin->addU16(dataStart);
+                fin->seek(dataStart);
+
+                // Scratch buffers reused across every block: peak memory for the
+                // whole save is one block, not the whole structure.
+                std::vector<uint8> plain;
+                std::vector<uint8> compressed;
+                std::vector<std::pair<uint, uint32>> written;   // blockIndex, revision
+
+                for(uint blockIndex : blockIndices) {
+                    if(generation != m_hdGeneration.load(std::memory_order_acquire))
+                        break;
+
+                    uint32 revision = 0;
+                    plain.clear();
+
+                    // Serialise straight out of the packed pool while holding the
+                    // lock for this one block only.
+                    {
+                        std::lock_guard<std::mutex> lock(m_lock);
+                        if(z >= (int)m_tileBlocks.size())
+                            break;
+                        auto it = m_tileBlocks[z].find(blockIndex);
+                        if(it == m_tileBlocks[z].end() || !it->second)
+                            continue;
+                        const HDBlockData* hd = it->second->getHDData();
+                        if(!hd || hd->isEmpty())
+                            continue;
+
+                        revision = hd->getContentRevision();
+                        const std::vector<HDMinimapItem>& pool = hd->getItemPool();
+
+                        for(const HDTileRecord& record : hd->getRecords()) {
+                            if(record.count == 0 || record.count > HD_MAX_ITEMS_PER_TILE)
+                                continue;
+                            const size_t at = plain.size();
+                            plain.resize(at + 4 + (size_t)record.count * 4);
+                            uint8* out = plain.data() + at;
+                            stdext::writeULE16(out,     record.tileIndex);
+                            stdext::writeULE16(out + 2, record.count);
+                            out += 4;
+                            for(uint16 i = 0; i < record.count; ++i) {
+                                stdext::writeULE16(out,     pool[record.offset + i].id);
+                                stdext::writeULE16(out + 2, pool[record.offset + i].subtype);
+                                out += 4;
+                            }
+                        }
+                    }
+
+                    if(plain.empty())
+                        continue;
+
+                    ulong bound = compressBound((ulong)plain.size());
+                    if(compressed.size() < bound)
+                        compressed.resize(bound);
+
+                    ulong compressedLen = bound;
+                    if(compress2(compressed.data(), &compressedLen,
+                                 plain.data(), (ulong)plain.size(), 3) != Z_OK)
+                        continue;
+                    if(compressedLen > 0xFFFFFFFFul || plain.size() > HD_MAX_UNCOMPRESSED_BYTES)
+                        continue;
+
+                    const Position blockPos = getIndexPosition(blockIndex, z);
+                    fin->addU16(blockPos.x);
+                    fin->addU16(blockPos.y);
+                    fin->addU8((uint8)z);
+                    fin->addU32((uint32)plain.size());
+                    fin->addU32((uint32)compressedLen);
+                    fin->write(compressed.data(), compressedLen);
+
+                    written.emplace_back(blockIndex, revision);
+                }
+
+                // Terminator, mirroring the base OTMM format.
+                Position invalidPos;
+                fin->addU16(invalidPos.x);
+                fin->addU16(invalidPos.y);
+                fin->addU8(invalidPos.z);
+
+                fin->flush();
+                fin->close();
+
+                // Atomic replace so a crash mid-write cannot leave a half file.
+                std::filesystem::path finalPath(g_resources.getWriteDir());
+                std::filesystem::path tmpPath(g_resources.getWriteDir());
+                finalPath += floorFile;
+                tmpPath += tmpFile;
+                std::error_code ec;
+                std::filesystem::rename(tmpPath, finalPath, ec);
+                if(ec) {
+                    std::filesystem::remove(tmpPath, ec);
+                    continue;
+                }
+
+                // Only clear the dirty mark for blocks whose revision is still the
+                // one we actually wrote.
+                {
+                    std::lock_guard<std::mutex> lock(m_lock);
+                    if(generation != m_hdGeneration.load(std::memory_order_acquire))
+                        break;
+                    if(z >= (int)m_tileBlocks.size())
+                        break;
+                    for(const auto& entry : written) {
+                        auto it = m_tileBlocks[z].find(entry.first);
+                        if(it == m_tileBlocks[z].end() || !it->second)
+                            continue;
+                        if(HDBlockData* hd = it->second->getHDData()) {
+                            if(hd->getContentRevision() == entry.second)
+                                hd->setSavedRevision(entry.second);
+                        }
+                    }
+                }
+            }
+        } catch(std::exception& e) {
+            g_logger.error(stdext::format("failed to save HD minimap: %s", e.what()));
+        }
+
+        m_hdSaving.store(false, std::memory_order_release);
+
+        // Run the coalesced request, if one arrived while we were writing.
+        g_dispatcher.addEvent([this] {
+            if(m_hdSavePending) {
+                m_hdSavePending = false;
+                const std::string pending = m_hdSavePendingFile;
+                m_hdSavePendingFile.clear();
+                saveOtmmHD(pending);
+            }
+        });
+    });
+}
+
+bool Minimap::loadOtmmHD(const std::string& fileName)
+{
+    if(fileName.empty())
+        return false;
+
+    bool loadedAny = false;
+    const int maxZ = (int)m_tileBlocks.size() - 1;
+
+    for(int z = 0; z <= maxZ; ++z) {
+        const std::string floorFile = hdFloorFileName(fileName, z);
+        if(!g_resources.fileExists(floorFile))
+            continue;
+
+        try {
+            FileStreamPtr fin = g_resources.openFile(floorFile, g_game.getFeature(Otc::GameDontCacheFiles));
+            if(!fin)
+                continue;
+
+            // Nothing read below is trusted before being range-checked.
+            if(fin->size() < 12)
+                stdext::throw_exception("HD minimap file too small");
+
+            if(fin->getU32() != OTMM_HD_SIGNATURE)
+                stdext::throw_exception("invalid HD minimap signature");
+
+            const uint16 dataStart = fin->getU16();
+            const uint16 version = fin->getU16();
+            fin->getU32();   // flags
+
+            if(version != OTMM_HD_VERSION)
+                stdext::throw_exception("unsupported HD minimap version");
+            if(dataStart < 12 || dataStart > fin->size())
+                stdext::throw_exception("invalid HD minimap data offset");
+
+            fin->getString();   // description
+            fin->seek(dataStart);
+
+            std::vector<uint8> compressed;
+            std::vector<uint8> plain;
+            uint32 blocksRead = 0;
+
+            while(true) {
+                if(fin->tell() + 5 > fin->size())
+                    stdext::throw_exception("truncated HD minimap block header");
+
+                Position pos;
+                pos.x = fin->getU16();
+                pos.y = fin->getU16();
+                pos.z = fin->getU8();
+
+                if(!pos.isValid())
+                    break;   // terminator
+
+                if(pos.z != z || pos.z > maxZ)
+                    stdext::throw_exception("HD minimap block on the wrong floor");
+                if(++blocksRead > HD_MAX_BLOCKS_PER_FLOOR)
+                    stdext::throw_exception("too many HD minimap blocks");
+
+                if(fin->tell() + 8 > fin->size())
+                    stdext::throw_exception("truncated HD minimap block sizes");
+
+                const uint32 plainSize = fin->getU32();
+                const uint32 compressedSize = fin->getU32();
+
+                if(plainSize == 0 || compressedSize == 0 ||
+                   plainSize > HD_MAX_UNCOMPRESSED_BYTES ||
+                   compressedSize > HD_MAX_COMPRESSED_BYTES ||
+                   plainSize % 4 != 0 ||
+                   fin->tell() + compressedSize > fin->size())
+                    stdext::throw_exception("invalid HD minimap block sizes");
+
+                compressed.resize(compressedSize);
+                if(fin->read(compressed.data(), 1, compressedSize) != (int)compressedSize)
+                    stdext::throw_exception("truncated HD minimap payload");
+
+                plain.resize(plainSize);
+                ulong destLen = plainSize;
+                if(uncompress(plain.data(), &destLen, compressed.data(), compressedSize) != Z_OK ||
+                   destLen != plainSize)
+                    stdext::throw_exception("corrupt HD minimap payload");
+
+                // Decode into the block, validating every count against what is
+                // actually left in the buffer.
+                std::lock_guard<std::mutex> lock(m_lock);
+                auto& ptr = m_tileBlocks[z][getBlockIndex(pos)];
+                if(!ptr)
+                    ptr = std::make_shared<MinimapBlock>();
+
+                HDBlockData& hd = ptr->getOrCreateHDData();
+                const size_t bytesBefore = hd.getByteSize();
+                std::vector<HDMinimapItem> items;
+
+                size_t at = 0;
+                while(at + 4 <= plain.size()) {
+                    const uint16 tileIndex = stdext::readULE16(plain.data() + at);
+                    const uint16 itemCount = stdext::readULE16(plain.data() + at + 2);
+                    at += 4;
+
+                    if(tileIndex >= HD_MAX_TILES_PER_BLOCK ||
+                       itemCount == 0 || itemCount > HD_MAX_ITEMS_PER_TILE ||
+                       at + (size_t)itemCount * 4 > plain.size())
+                        stdext::throw_exception("invalid HD minimap tile record");
+
+                    items.clear();
+                    items.reserve(itemCount);
+                    for(uint16 i = 0; i < itemCount; ++i) {
+                        HDMinimapItem entry;
+                        entry.id = stdext::readULE16(plain.data() + at);
+                        entry.subtype = stdext::readULE16(plain.data() + at + 2);
+                        at += 4;
+                        items.push_back(entry);
+                    }
+
+                    hd.setTileItems(tileIndex, items.data(), itemCount);
+                }
+
+                // Loaded content matches what is on disk, so it is not dirty.
+                hd.setSavedRevision(hd.getContentRevision());
+                ptr->justSaw();
+                m_hdDataBytes += hd.getByteSize() - bytesBefore;
+                loadedAny = true;
+            }
+        } catch(std::exception& e) {
+            // A bad floor file is skipped, never fatal: the base minimap and the
+            // other floors keep working.
+            g_logger.error(stdext::format("failed to load HD minimap floor %d: %s", z, e.what()));
+        }
+    }
+
+    return loadedAny;
+}
+
+std::string Minimap::getHDStats()
+{
+    std::lock_guard<std::mutex> lock(m_lock);
+
+    size_t blocksWithData = 0;
+    size_t tilesWithData = 0;
+    size_t itemCount = 0;
+    size_t dataBytes = 0;
+    size_t dirtyBlocks = 0;
+
+    for(auto& blocks : m_tileBlocks) {
+        for(auto& pair : blocks) {
+            if(!pair.second)
+                continue;
+            if(const HDBlockData* hd = pair.second->getHDData()) {
+                ++blocksWithData;
+                tilesWithData += hd->getTileCount();
+                itemCount += hd->getItemPool().size();
+                dataBytes += hd->getByteSize();
+                if(hd->isDirty())
+                    ++dirtyBlocks;
+            }
+        }
+    }
+
+    const size_t pendingBytes = m_hdPendingImageBytes.load(std::memory_order_acquire);
+
+    std::ostringstream out;
+    out << "hdMode=" << (m_hdMode.load(std::memory_order_relaxed) ? 1 : 0)
+        << " generation=" << m_hdGeneration.load(std::memory_order_acquire)
+        << " texelsPerTile=" << (int)HD_TEXELS_PER_TILE << "\n"
+        << "blocksWithData=" << blocksWithData
+        << " tilesWithData=" << tilesWithData
+        << " items=" << itemCount
+        << " dataBytes=" << dataBytes << "\n"
+        << "residentTextures=" << m_hdResident.size()
+        << " textureBytes=" << m_hdTextureBytes
+        << " textureBudget=" << HD_TEXTURE_BUDGET_BYTES << "\n"
+        << "pendingImages=" << (pendingBytes / HD_BLOCK_TEXTURE_BYTES)
+        << " pendingImageBytes=" << pendingBytes
+        << " pendingBudget=" << HD_PENDING_IMAGE_BUDGET_BYTES << "\n"
+        << "queuedJobs=" << m_hdQueue.size()
+        << " runningJobs=" << m_hdRunningJobs.load(std::memory_order_acquire)
+        << " maxWorkers=" << m_hdMaxWorkers << "\n"
+        << "cacheHits=" << m_hdCacheHits
+        << " cacheMisses=" << m_hdCacheMisses
+        << " evictions=" << m_hdEvictions
+        << " staleDropped=" << m_hdStaleDropped.load(std::memory_order_relaxed) << "\n"
+        << "dirtyBlocks=" << dirtyBlocks
+        << " saving=" << (isSavingHD() ? 1 : 0)
+        << " savePending=" << (m_hdSavePending ? 1 : 0);
+
+    return out.str();
 }
 
 const MinimapTile& Minimap::getTile(const Position& pos)

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -24,6 +24,7 @@
 #include "minimap.h"
 #include "tile.h"
 #include "item.h"
+#include "map.h"
 #include "game.h"
 #include "gameconfig.h"
 #include "spritemanager.h"
@@ -307,9 +308,35 @@ bool Minimap::drawHD(const Rect& screenRect, const Position& mapCenter, float sc
     const int centerBlockX = mapCenter.x / MMBLOCK_SIZE;
     const int centerBlockY = mapCenter.y / MMBLOCK_SIZE;
 
-    // Block-space rectangle of what is on screen. Everything outside it (plus the
-    // prefetch ring) is eligible for eviction, including on the active floor.
+    // Block-space rectangle of what is on screen, resolved up front with the same
+    // stepping the draw loop uses. Everything outside it (plus the protection
+    // margin) is eligible for eviction, including on the active floor.
     int minBlockX = INT_MAX, minBlockY = INT_MAX, maxBlockX = INT_MIN, maxBlockY = INT_MIN;
+    for(int y = blockOff.y, ys = start.y; ys < screenRect.bottom(); y += MMBLOCK_SIZE, ys += blockPixels) {
+        if(y < 0 || y >= 65536)
+            continue;
+        for(int x = blockOff.x, xs = start.x; xs < screenRect.right(); x += MMBLOCK_SIZE, xs += blockPixels) {
+            if(x < 0 || x >= 65536)
+                continue;
+            const int bx = x / MMBLOCK_SIZE;
+            const int by = y / MMBLOCK_SIZE;
+            minBlockX = std::min(minBlockX, bx); maxBlockX = std::max(maxBlockX, bx);
+            minBlockY = std::min(minBlockY, by); maxBlockY = std::max(maxBlockY, by);
+        }
+    }
+
+    if(minBlockX == INT_MAX)
+        return false;
+
+    const Rect visibleBlocks(minBlockX, minBlockY,
+                             maxBlockX - minBlockX + 1, maxBlockY - minBlockY + 1);
+
+    // One-shot fill so switching HD on shows the current surroundings immediately
+    // instead of waiting for the player to walk into new updateTile() calls.
+    if(m_hdBootstrapPending) {
+        m_hdBootstrapPending = false;
+        bootstrapHDFromMap(mapCenter, visibleBlocks);
+    }
 
     {
         std::lock_guard<std::mutex> lock(m_lock);
@@ -325,9 +352,6 @@ bool Minimap::drawHD(const Rect& screenRect, const Position& mapCenter, float sc
 
                 const int bx = x / MMBLOCK_SIZE;
                 const int by = y / MMBLOCK_SIZE;
-                minBlockX = std::min(minBlockX, bx); maxBlockX = std::max(maxBlockX, bx);
-                minBlockY = std::min(minBlockY, by); maxBlockY = std::max(maxBlockY, by);
-
                 const Position blockPos(x, y, mapCenter.z);
                 const uint blockIndex = getBlockIndex(blockPos);
 
@@ -360,14 +384,55 @@ bool Minimap::drawHD(const Rect& screenRect, const Position& mapCenter, float sc
 
     dispatchHDJobs();
     collectHDResults();
-
-    if(minBlockX != INT_MAX) {
-        const Rect visibleBlocks(minBlockX, minBlockY,
-                                 maxBlockX - minBlockX + 1, maxBlockY - minBlockY + 1);
-        enforceHDTextureBudget(mapCenter, visibleBlocks);
-    }
+    enforceHDTextureBudget(mapCenter, visibleBlocks);
 
     return true;
+}
+
+void Minimap::bootstrapHDFromMap(const Position& mapCenter, const Rect& visibleBlocks)
+{
+    // Bounded by construction: the scan is the intersection of what the server has
+    // actually sent us (the aware range, a small window around the player) with the
+    // visible blocks plus one block of margin. It never walks the block map and
+    // never touches the OTMM data.
+    //
+    // Regions that exist only in the base minimap.otmm are deliberately left alone:
+    // that format stores one colour per tile and carries no item ids, so there is
+    // nothing there to rebuild sprites from. Those keep the standard minimap until
+    // the player walks through them.
+    const Position center = g_map.getCentralPosition();
+    if(!center.isValid() || center.z != mapCenter.z)
+        return;
+
+    const AwareRange range = g_map.getAwareRange();
+
+    const int blockMinX = (visibleBlocks.left() - HD_PROTECT_MARGIN_BLOCKS) * MMBLOCK_SIZE;
+    const int blockMaxX = (visibleBlocks.right() + HD_PROTECT_MARGIN_BLOCKS) * MMBLOCK_SIZE + MMBLOCK_SIZE - 1;
+    const int blockMinY = (visibleBlocks.top() - HD_PROTECT_MARGIN_BLOCKS) * MMBLOCK_SIZE;
+    const int blockMaxY = (visibleBlocks.bottom() + HD_PROTECT_MARGIN_BLOCKS) * MMBLOCK_SIZE + MMBLOCK_SIZE - 1;
+
+    const int minX = std::max({ 0, center.x - range.left, blockMinX });
+    const int maxX = std::min({ 65535, center.x + range.right, blockMaxX });
+    const int minY = std::max({ 0, center.y - range.top, blockMinY });
+    const int maxY = std::min({ 65535, center.y + range.bottom, blockMaxY });
+
+    if(minX > maxX || minY > maxY)
+        return;
+
+    for(int y = minY; y <= maxY; ++y) {
+        for(int x = minX; x <= maxX; ++x) {
+            const Position pos(x, y, mapCenter.z);
+            const TilePtr& tile = g_map.getTile(pos);
+            if(!tile)
+                continue;
+
+            // Reuses the normal collection path, so bootstrapped tiles are
+            // identical to walked ones and bump the same revision counters. The
+            // draw loop right after this picks the dirty blocks up and queues them
+            // with viewport priority, which is already the highest there is.
+            collectHDTile(pos, tile);
+        }
+    }
 }
 
 void Minimap::queueHDBlock(MinimapBlock& block, const Position& blockPos, uint blockIndex, int priority)
@@ -1039,12 +1104,16 @@ void Minimap::setHDMode(bool enabled)
     std::lock_guard<std::mutex> lock(m_lock);
     m_hdMode.store(enabled, std::memory_order_relaxed);
 
-    // Leaving HD mode returns every HD byte. Entering it starts from nothing and
-    // fills in lazily, which is why the generation moves in both directions.
-    if(!enabled)
+    // Leaving HD mode returns every HD byte. Entering it starts from nothing, so
+    // the next draw runs a one-shot bootstrap over the tiles g_map already holds
+    // instead of making the player walk to reveal their own surroundings.
+    if(!enabled) {
+        m_hdBootstrapPending = false;
         invalidateHDLocked();
-    else
+    } else {
         m_hdGeneration.fetch_add(1, std::memory_order_release);
+        m_hdBootstrapPending = true;
+    }
 }
 
 void Minimap::invalidateHDLocked()

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -30,6 +30,9 @@
 #include "spritemanager.h"
 #include "thingtypemanager.h"
 #include "thingtype.h"
+#include "itemtype.h"
+
+#include <framework/core/binarytree.h>
 
 #include <framework/graphics/image.h>
 #include <framework/graphics/texture.h>
@@ -45,6 +48,7 @@
 #include <framework/util/stats.h>
 #include <algorithm>
 #include <climits>
+#include <cstring>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
@@ -222,6 +226,7 @@ void Minimap::terminate()
     m_hdPendingImageBytes.store(0, std::memory_order_release);
     m_hdQueue.clear();
     m_hdRunning.clear();
+    closeHDBase();
 
     clean();
 
@@ -338,6 +343,8 @@ bool Minimap::drawHD(const Rect& screenRect, const Position& mapCenter, float sc
         bootstrapHDFromMap(mapCenter, visibleBlocks);
     }
 
+    int baseLoadsLeft = HD_BASE_LOADS_PER_FRAME;
+
     {
         std::lock_guard<std::mutex> lock(m_lock);
         auto& blocks = m_tileBlocks[mapCenter.z];
@@ -356,10 +363,19 @@ bool Minimap::drawHD(const Rect& screenRect, const Position& mapCenter, float sc
                 const uint blockIndex = getBlockIndex(blockPos);
 
                 auto it = blocks.find(blockIndex);
-                if(it == blocks.end() || !it->second)
-                    continue;
+                HDBlockData* hd = (it != blocks.end() && it->second) ? it->second->getHDData() : nullptr;
 
-                HDBlockData* hd = it->second->getHDData();
+                // Nothing decoded yet: pull this block out of the baseline archive.
+                // Rate limited so entering a new region cannot turn into a long
+                // synchronous read, and the rest arrives over the next frames.
+                if(!hd && baseLoadsLeft > 0) {
+                    if(loadHDBaseBlockLocked((uint8)mapCenter.z, blockIndex, blockPos)) {
+                        --baseLoadsLeft;
+                        it = blocks.find(blockIndex);
+                        hd = (it != blocks.end() && it->second) ? it->second->getHDData() : nullptr;
+                    }
+                }
+
                 if(!hd)
                     continue;
 
@@ -386,7 +402,98 @@ bool Minimap::drawHD(const Rect& screenRect, const Position& mapCenter, float sc
     collectHDResults();
     enforceHDTextureBudget(mapCenter, visibleBlocks);
 
+    {
+        std::lock_guard<std::mutex> lock(m_lock);
+        enforceHDDataBudgetLocked(mapCenter, visibleBlocks);
+    }
+
     return true;
+}
+
+void Minimap::enforceHDDataBudgetLocked(const Position& mapCenter, const Rect& visibleBlocks)
+{
+    // Without a baseline archive the decoded data IS the only copy, so there is
+    // nothing safe to drop and the budget does not apply.
+    if(!m_hdBaseFile || m_hdDataBytes <= HD_DATA_BUDGET_BYTES)
+        return;
+
+    // If the overage is all player data there is nothing to evict, and rescanning
+    // every frame would reintroduce exactly the per-frame full walk this design
+    // set out to remove. Back off after a scan that could not free anything.
+    const ticks_t now = stdext::millis();
+    if(now < m_hdDataBudgetNextScan)
+        return;
+
+    const Rect protectedBlocks(visibleBlocks.x() - HD_PROTECT_MARGIN_BLOCKS,
+                               visibleBlocks.y() - HD_PROTECT_MARGIN_BLOCKS,
+                               visibleBlocks.width() + 2 * HD_PROTECT_MARGIN_BLOCKS,
+                               visibleBlocks.height() + 2 * HD_PROTECT_MARGIN_BLOCKS);
+
+    struct Candidate { uint8 z; uint blockIndex; ticks_t lastUsed; bool otherFloor; };
+    std::vector<Candidate> candidates;
+
+    for(uint8 z = 0; z < (uint8)m_tileBlocks.size(); ++z) {
+        for(auto& pair : m_tileBlocks[z]) {
+            if(!pair.second)
+                continue;
+            const HDBlockData* hd = pair.second->getHDData();
+            // Only baseline-sourced, non-dirty data is reloadable. Anything the
+            // player collected stays until it has been written to the sidecar.
+            if(!hd || !hd->isReloadable())
+                continue;
+
+            const bool sameFloor = (z == mapCenter.z);
+            if(sameFloor) {
+                const Position blockPos = getIndexPosition(pair.first, z);
+                if(protectedBlocks.contains(Point(blockPos.x / MMBLOCK_SIZE, blockPos.y / MMBLOCK_SIZE)))
+                    continue;
+            }
+
+            candidates.push_back({ z, pair.first, hd->getLastUsed(), !sameFloor });
+        }
+    }
+
+    // Other floors first, then least recently used.
+    std::sort(candidates.begin(), candidates.end(),
+        [](const Candidate& a, const Candidate& b) {
+            if(a.otherFloor != b.otherFloor) return a.otherFloor;
+            return a.lastUsed < b.lastUsed;
+        });
+
+    for(const Candidate& candidate : candidates) {
+        if(m_hdDataBytes <= HD_DATA_BUDGET_BYTES)
+            break;
+
+        auto it = m_tileBlocks[candidate.z].find(candidate.blockIndex);
+        if(it == m_tileBlocks[candidate.z].end() || !it->second)
+            continue;
+
+        HDBlockData* hd = it->second->getHDData();
+        if(!hd || !hd->isReloadable())
+            continue;
+
+        const size_t bytes = hd->getByteSize();
+        // Dropping the payload releases its texture with it, so the texture
+        // accounting has to follow.
+        if(hd->hasTexture()) {
+            if(m_hdTextureBytes >= HD_BLOCK_TEXTURE_BYTES)
+                m_hdTextureBytes -= HD_BLOCK_TEXTURE_BYTES;
+            for(size_t i = 0; i < m_hdResident.size(); ++i) {
+                if(m_hdResident[i].first == candidate.z && m_hdResident[i].second == candidate.blockIndex) {
+                    m_hdResident.erase(m_hdResident.begin() + i);
+                    break;
+                }
+            }
+        }
+
+        it->second->dropHDData();
+        m_hdDataBytes -= std::min(m_hdDataBytes, bytes);
+        ++m_hdBaseDataEvictions;
+    }
+
+    // Still over after evicting everything reloadable: the rest is player data
+    // that must not be dropped, so stop scanning for a while.
+    m_hdDataBudgetNextScan = (m_hdDataBytes > HD_DATA_BUDGET_BYTES) ? now + 2000 : 0;
 }
 
 void Minimap::bootstrapHDFromMap(const Position& mapCenter, const Rect& visibleBlocks)
@@ -1085,7 +1192,11 @@ void Minimap::collectHDTile(const Position& pos, const TilePtr& tile)
 
     HDBlockData& hd = block.getOrCreateHDData();
     const size_t before = hd.getByteSize();
-    hd.setTileItems(tileIndex, items.data(), (uint16)items.size());
+    if(hd.setTileItems(tileIndex, items.data(), (uint16)items.size())) {
+        // The player has changed this block, so it can no longer be restored by
+        // re-reading the baseline archive: it stays resident even after a save.
+        hd.setFromBaseline(false);
+    }
     m_hdDataBytes += hd.getByteSize() - before;
 
     // A payload that emptied out is released instead of lingering as an 8 KiB
@@ -1161,6 +1272,376 @@ std::string hdFloorFileName(const std::string& baseName, int z)
 }
 
 } // namespace
+
+bool Minimap::generateHDFromOtbm(const std::string& otbmFile, const std::string& outputFile)
+{
+    // Offline tool, not a gameplay path. It still streams rather than loading the
+    // world: OTBM tile areas are 256x256 and always aligned, so each one maps onto
+    // exactly 16 whole 64x64 blocks with no sharing. That lets every area be
+    // encoded and flushed immediately, keeping peak memory at roughly one area
+    // instead of one floor, let alone the whole map.
+    if(!g_things.isOtbLoaded()) {
+        g_logger.error("HD baseline needs items.otb loaded to map server ids to client ids");
+        return false;
+    }
+
+    try {
+        FileStreamPtr fin = g_resources.openFile(otbmFile, true);
+        if(!fin)
+            stdext::throw_exception("unable to open otbm");
+
+        const std::string tmpFile = outputFile + ".tmp";
+        FileStreamPtr fout = g_resources.createFile(tmpFile);
+        if(!fout)
+            stdext::throw_exception("unable to create output file");
+
+        fout->addU32(OTMM_HD_BASE_SIGNATURE);
+        fout->addU16(OTMM_HD_BASE_VERSION);
+        fout->addU32(0);   // flags
+        fout->addU32(0);   // index offset, patched at the end
+        fout->addU32(0);   // block count, patched at the end
+
+        struct IndexRecord { uint16 bx, by; uint8 z; HDBaseEntry entry; };
+        std::vector<IndexRecord> index;
+
+        // Header layout mirrors Map::loadOtbm exactly.
+        char identifier[4];
+        if(fin->read(identifier, 1, 4) < 4)
+            stdext::throw_exception("could not read otbm identifier");
+        if(memcmp(identifier, "OTBM", 4) != 0 && memcmp(identifier, "\0\0\0\0", 4) != 0)
+            stdext::throw_exception("invalid otbm identifier");
+
+        BinaryTreePtr root = fin->getBinaryTree();
+        if(root->getU8())
+            stdext::throw_exception("could not read otbm root property");
+
+        const uint32 headerVersion = root->getU32();
+        if(headerVersion > 3)
+            stdext::throw_exception("unknown otbm version");
+
+        root->getU16();  // map width
+        root->getU16();  // map height
+        root->getU8();   // otb major
+        root->skip(3);
+        root->getU32();  // otb minor
+
+        std::vector<uint8> plain;
+        std::vector<uint8> compressed;
+        uint64 tilesSeen = 0;
+
+        BinaryTreePtr node = root->getChildren().at(0);
+        if(node->getU8() != OTBM_MAP_DATA)
+            stdext::throw_exception("could not read otbm root data node");
+
+        while(node->canRead()) {
+            node->getU8();       // attribute
+            node->getString();   // description / spawn file / house file
+        }
+
+        {
+            for(const BinaryTreePtr& nodeArea : node->getChildren()) {
+                if(nodeArea->getU8() != OTBM_TILE_AREA)
+                    continue;
+
+                Position basePos;
+                basePos.x = nodeArea->getU16();
+                basePos.y = nodeArea->getU16();
+                basePos.z = nodeArea->getU8();
+
+                // Blocks of this area only. Freed when the area is done.
+                std::unordered_map<uint, HDBlockData> areaBlocks;
+
+                for(const BinaryTreePtr& nodeTile : nodeArea->getChildren()) {
+                    const uint8 type = nodeTile->getU8();
+                    if(type != OTBM_TILE && type != OTBM_HOUSETILE)
+                        continue;
+
+                    const Position pos = basePos + nodeTile->getPoint();
+                    if(type == OTBM_HOUSETILE)
+                        nodeTile->getU32();   // house id
+
+                    std::vector<HDMinimapItem> items;
+
+                    auto addItem = [&](uint16 serverId) {
+                        if(serverId == 0 || !g_things.isValidOtbId(serverId))
+                            return;
+                        const uint16 clientId = g_things.getItemType(serverId)->getClientId();
+                        if(clientId == 0 || !g_things.isValidDatId(clientId, ThingCategoryItem))
+                            return;
+                        if(items.size() >= HD_MAX_ITEMS_PER_TILE)
+                            return;
+                        HDMinimapItem entry;
+                        entry.id = clientId;
+                        items.push_back(entry);
+                    };
+
+                    // Inline tile attributes. Unknown ones stop the inline scan
+                    // instead of aborting the whole generation: losing one ground
+                    // item is better than failing on a map variant.
+                    bool inlineOk = true;
+                    while(inlineOk && nodeTile->canRead()) {
+                        switch(nodeTile->getU8()) {
+                            case OTBM_ATTR_TILE_FLAGS: nodeTile->getU32(); break;
+                            case OTBM_ATTR_ITEM:       addItem(nodeTile->getU16()); break;
+                            default:                   inlineOk = false; break;
+                        }
+                    }
+
+                    // Item nodes. Each is its own subtree, so the id is all we read
+                    // and the tree structure skips the rest, including containers.
+                    for(const BinaryTreePtr& nodeItem : nodeTile->getChildren()) {
+                        if(nodeItem->getU8() != OTBM_ITEM)
+                            continue;
+                        addItem(nodeItem->getU16());
+                    }
+
+                    if(items.empty())
+                        continue;
+
+                    ++tilesSeen;
+                    const uint blockIndex = getBlockIndex(pos);
+                    const Point blockOffset = getBlockOffset(Point(pos.x, pos.y));
+                    const uint16 tileIndex =
+                        (uint16)(((pos.y - blockOffset.y) * MMBLOCK_SIZE) + (pos.x - blockOffset.x));
+
+                    areaBlocks[blockIndex].setTileItems(tileIndex, items.data(), (uint16)items.size());
+                }
+
+                // Encode and flush this area's blocks straight away.
+                for(auto& pair : areaBlocks) {
+                    HDBlockData& hd = pair.second;
+                    if(hd.isEmpty())
+                        continue;
+
+                    plain.clear();
+                    const std::vector<HDMinimapItem>& pool = hd.getItemPool();
+                    for(const HDTileRecord& record : hd.getRecords()) {
+                        const size_t at = plain.size();
+                        plain.resize(at + 4 + (size_t)record.count * 4);
+                        uint8* out = plain.data() + at;
+                        stdext::writeULE16(out,     record.tileIndex);
+                        stdext::writeULE16(out + 2, record.count);
+                        out += 4;
+                        for(uint16 i = 0; i < record.count; ++i) {
+                            stdext::writeULE16(out,     pool[record.offset + i].id);
+                            stdext::writeULE16(out + 2, pool[record.offset + i].subtype);
+                            out += 4;
+                        }
+                    }
+
+                    if(plain.empty())
+                        continue;
+
+                    ulong bound = compressBound((ulong)plain.size());
+                    if(compressed.size() < bound)
+                        compressed.resize(bound);
+
+                    ulong compressedLen = bound;
+                    if(compress2(compressed.data(), &compressedLen,
+                                 plain.data(), (ulong)plain.size(), 6) != Z_OK)
+                        continue;
+
+                    IndexRecord record;
+                    record.bx = (uint16)(basePos.x / MMBLOCK_SIZE);   // patched below
+                    record.by = (uint16)(basePos.y / MMBLOCK_SIZE);
+                    record.z = (uint8)basePos.z;
+                    record.entry.offset = fout->tell();
+                    record.entry.compressedSize = (uint32)compressedLen;
+                    record.entry.plainSize = (uint32)plain.size();
+
+                    // Recover the block's own coordinates from its index.
+                    const Position blockPos = getIndexPosition(pair.first, basePos.z);
+                    record.bx = (uint16)(blockPos.x / MMBLOCK_SIZE);
+                    record.by = (uint16)(blockPos.y / MMBLOCK_SIZE);
+
+                    fout->write(compressed.data(), (uint)compressedLen);
+                    index.push_back(record);
+                }
+            }
+        }
+
+        // Index goes last so the data section can be written in one forward pass.
+        const uint32 indexOffset = fout->tell();
+        for(const IndexRecord& record : index) {
+            fout->addU16(record.bx);
+            fout->addU16(record.by);
+            fout->addU8(record.z);
+            fout->addU32(record.entry.offset);
+            fout->addU32(record.entry.compressedSize);
+            fout->addU32(record.entry.plainSize);
+        }
+
+        fout->seek(10);
+        fout->addU32(indexOffset);
+        fout->addU32((uint32)index.size());
+
+        fout->flush();
+        fout->close();
+
+        std::filesystem::path finalPath(g_resources.getWriteDir());
+        std::filesystem::path tmpPath(g_resources.getWriteDir());
+        finalPath += outputFile;
+        tmpPath += tmpFile;
+        std::error_code ec;
+        std::filesystem::rename(tmpPath, finalPath, ec);
+        if(ec) {
+            std::filesystem::remove(tmpPath, ec);
+            stdext::throw_exception("unable to replace output file");
+        }
+
+        g_logger.info(stdext::format("HD baseline written: %d blocks, %d tiles",
+                                     (int)index.size(), (int)tilesSeen));
+        return true;
+    } catch(std::exception& e) {
+        g_logger.error(stdext::format("failed to generate HD baseline: %s", e.what()));
+        return false;
+    }
+}
+
+bool Minimap::openHDBase(const std::string& fileName)
+{
+    closeHDBase();
+
+    if(fileName.empty() || !g_resources.fileExists(fileName))
+        return false;
+
+    try {
+        FileStreamPtr fin = g_resources.openFile(fileName, true);
+        if(!fin || fin->size() < 18)
+            stdext::throw_exception("HD baseline too small");
+
+        if(fin->getU32() != OTMM_HD_BASE_SIGNATURE)
+            stdext::throw_exception("invalid HD baseline signature");
+        if(fin->getU16() != OTMM_HD_BASE_VERSION)
+            stdext::throw_exception("unsupported HD baseline version");
+
+        fin->getU32();   // flags
+        const uint32 indexOffset = fin->getU32();
+        const uint32 blockCount = fin->getU32();
+
+        if(blockCount > HD_MAX_BASE_BLOCKS)
+            stdext::throw_exception("HD baseline block count out of range");
+        if(indexOffset < 18 || indexOffset > fin->size())
+            stdext::throw_exception("HD baseline index offset out of range");
+        if((uint64)blockCount * 17ull > (uint64)(fin->size() - indexOffset))
+            stdext::throw_exception("HD baseline index truncated");
+
+        const int maxZ = (int)m_tileBlocks.size() - 1;
+        m_hdBaseIndex.assign(maxZ + 1, {});
+
+        fin->seek(indexOffset);
+        uint32 accepted = 0;
+        for(uint32 i = 0; i < blockCount; ++i) {
+            const uint16 bx = fin->getU16();
+            const uint16 by = fin->getU16();
+            const uint8 z = fin->getU8();
+            HDBaseEntry entry;
+            entry.offset = fin->getU32();
+            entry.compressedSize = fin->getU32();
+            entry.plainSize = fin->getU32();
+
+            if(z > maxZ)
+                continue;
+            if(entry.compressedSize == 0 || entry.compressedSize > HD_MAX_COMPRESSED_BYTES ||
+               entry.plainSize == 0 || entry.plainSize > HD_MAX_UNCOMPRESSED_BYTES ||
+               entry.plainSize % 4 != 0 ||
+               entry.offset < 18 || entry.offset > indexOffset ||
+               entry.compressedSize > indexOffset - entry.offset)
+                continue;   // reject the entry, keep the archive usable
+
+            const Position blockPos((int)bx * MMBLOCK_SIZE, (int)by * MMBLOCK_SIZE, z);
+            m_hdBaseIndex[z][getBlockIndex(blockPos)] = entry;
+            ++accepted;
+        }
+
+        m_hdBaseFile = fin;
+        m_hdBaseFileName = fileName;
+        g_logger.info(stdext::format("HD baseline attached: %d blocks", (int)accepted));
+        return accepted > 0;
+    } catch(std::exception& e) {
+        g_logger.error(stdext::format("failed to open HD baseline: %s", e.what()));
+        closeHDBase();
+        return false;
+    }
+}
+
+void Minimap::closeHDBase()
+{
+    m_hdBaseFile = nullptr;
+    m_hdBaseFileName.clear();
+    m_hdBaseIndex.clear();
+}
+
+bool Minimap::loadHDBaseBlockLocked(uint8 z, uint blockIndex, const Position& blockPos)
+{
+    if(!m_hdBaseFile || z >= m_hdBaseIndex.size())
+        return false;
+
+    auto entryIt = m_hdBaseIndex[z].find(blockIndex);
+    if(entryIt == m_hdBaseIndex[z].end())
+        return false;
+
+    const HDBaseEntry entry = entryIt->second;
+
+    try {
+        std::vector<uint8> compressed(entry.compressedSize);
+        m_hdBaseFile->seek(entry.offset);
+        if(m_hdBaseFile->read(compressed.data(), 1, entry.compressedSize) != (int)entry.compressedSize)
+            stdext::throw_exception("truncated baseline block");
+
+        std::vector<uint8> plain(entry.plainSize);
+        ulong destLen = entry.plainSize;
+        if(uncompress(plain.data(), &destLen, compressed.data(), entry.compressedSize) != Z_OK ||
+           destLen != entry.plainSize)
+            stdext::throw_exception("corrupt baseline block");
+
+        auto& ptr = m_tileBlocks[z][blockIndex];
+        if(!ptr)
+            ptr = std::make_shared<MinimapBlock>();
+
+        HDBlockData& hd = ptr->getOrCreateHDData();
+        const size_t bytesBefore = hd.getByteSize();
+        std::vector<HDMinimapItem> items;
+
+        size_t at = 0;
+        while(at + 4 <= plain.size()) {
+            const uint16 tileIndex = stdext::readULE16(plain.data() + at);
+            const uint16 itemCount = stdext::readULE16(plain.data() + at + 2);
+            at += 4;
+
+            if(tileIndex >= HD_MAX_TILES_PER_BLOCK ||
+               itemCount == 0 || itemCount > HD_MAX_ITEMS_PER_TILE ||
+               at + (size_t)itemCount * 4 > plain.size())
+                stdext::throw_exception("invalid baseline tile record");
+
+            items.clear();
+            items.reserve(itemCount);
+            for(uint16 i = 0; i < itemCount; ++i) {
+                HDMinimapItem item;
+                item.id = stdext::readULE16(plain.data() + at);
+                item.subtype = stdext::readULE16(plain.data() + at + 2);
+                at += 4;
+                items.push_back(item);
+            }
+
+            hd.setTileItems(tileIndex, items.data(), itemCount);
+        }
+
+        // Baseline content matches the archive, so it is not player data and may be
+        // evicted and re-read freely.
+        hd.setSavedRevision(hd.getContentRevision());
+        hd.setFromBaseline(true);
+        m_hdDataBytes += hd.getByteSize() - bytesBefore;
+        ++m_hdBaseLoads;
+        return true;
+    } catch(std::exception& e) {
+        // Drop this entry so a bad block is not retried every frame.
+        m_hdBaseIndex[z].erase(blockIndex);
+        g_logger.error(stdext::format("HD baseline block %d/%d failed: %s",
+                                      (int)z, (int)blockIndex, e.what()));
+        return false;
+    }
+}
 
 void Minimap::saveOtmmHD(const std::string& fileName)
 {
@@ -1513,6 +1994,10 @@ std::string Minimap::getHDStats()
         }
     }
 
+    size_t baseIndexed = 0;
+    for(const auto& floorIndex : m_hdBaseIndex)
+        baseIndexed += floorIndex.size();
+
     const size_t pendingBytes = m_hdPendingImageBytes.load(std::memory_order_acquire);
 
     std::ostringstream out;
@@ -1538,7 +2023,12 @@ std::string Minimap::getHDStats()
         << " staleDropped=" << m_hdStaleDropped.load(std::memory_order_relaxed) << "\n"
         << "dirtyBlocks=" << dirtyBlocks
         << " saving=" << (isSavingHD() ? 1 : 0)
-        << " savePending=" << (m_hdSavePending ? 1 : 0);
+        << " savePending=" << (m_hdSavePending ? 1 : 0) << "\n"
+        << "baseAttached=" << (m_hdBaseFile ? 1 : 0)
+        << " baseIndexed=" << baseIndexed
+        << " baseLoads=" << m_hdBaseLoads
+        << " dataBudget=" << HD_DATA_BUDGET_BYTES
+        << " dataEvictions=" << m_hdBaseDataEvictions;
 
     return out.str();
 }

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -342,6 +342,9 @@ private:
     // to the caller's base path by returning false when HD cannot be used.
     bool drawHD(const Rect& screenRect, const Position& mapCenter, float scale,
                 const Point& blockOff, const Point& start);
+    // One-shot fill from the tiles g_map currently holds, bounded to the viewport
+    // plus the protection margin. Runs once after HD is switched on.
+    void bootstrapHDFromMap(const Position& mapCenter, const Rect& visibleBlocks);
     // Builds the sparse snapshot of a block and inserts it into the bounded queue,
     // replacing any older entry for the same block.
     void queueHDBlock(MinimapBlock& block, const Position& blockPos, uint blockIndex, int priority);
@@ -378,6 +381,8 @@ private:
     // atomic read and nothing else.
     std::atomic<bool> m_hdMode{false};
     std::atomic<uint32> m_hdGeneration{1};
+    // Set when HD is switched on, consumed by the next draw. Dispatcher thread only.
+    bool m_hdBootstrapPending = false;
     size_t m_hdDataBytes = 0;   // guarded by m_lock
     // Scratch buffer for collectHDTile, reused so per-tile collection does not
     // allocate. Dispatcher thread only.

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -26,6 +26,9 @@
 
 #include "declarations.h"
 #include <framework/graphics/declarations.h>
+#include <atomic>
+#include <memory>
+#include <vector>
 
 enum {
     MMBLOCK_SIZE = 64,
@@ -33,11 +36,205 @@ enum {
     OTMM_VERSION = 1
 };
 
+// ---------------------------------------------------------------------------
+// HD minimap (optional layer, off by default)
+//
+// Blocks composited from the real item sprites instead of one colour per tile.
+// It is strictly additive: MinimapTile, OTMM_VERSION, loadOtmm/saveOtmm and the
+// whole base draw path are untouched, and if anything here fails the standard
+// minimap keeps working.
+//
+// Sizing rationale (see astraclient_hd_minimap_audit.html): the UI draws a tile
+// at `scale` screen pixels (zoom -5..+5 => scale 1/32..32). 8 texels per tile is
+// 1:1 at scale 8 and oversamples 2x at scale 4, which covers the usable zoom
+// range at 512*512*4 = 1 MiB per block.
+// ---------------------------------------------------------------------------
+enum {
+    HD_TEXELS_PER_TILE = 8,
+    HD_BLOCK_TEXTURE_SIZE = MMBLOCK_SIZE * HD_TEXELS_PER_TILE,  // 512
+    HD_NO_RECORD = 0xFFFF,
+
+    // Below this zoom a tile covers fewer than 2 screen pixels, so an HD texture
+    // would just be downsampled back into the flat colour the base minimap already
+    // draws. This is also what keeps the full map view cheap.
+    HD_MIN_SCALE = 2,
+
+    // Ring of blocks around the viewport that eviction leaves alone, so a step or
+    // two of movement does not immediately re-render what just scrolled off.
+    // Everything beyond it is evictable, including on the floor being explored.
+    HD_PROTECT_MARGIN_BLOCKS = 1,
+
+    // The one and only queue bound in the system.
+    HD_MAX_QUEUED_JOBS = 12,
+
+    // Separate HD sidecar format. minimap.otmm itself is never touched.
+    OTMM_HD_SIGNATURE = 0x4844544F,
+    OTMM_HD_VERSION = 2
+};
+
+// Budgets are expressed in bytes, not in block counts, because resources of very
+// different sizes share them.
+inline constexpr size_t HD_TEXTURE_BUDGET_BYTES = 64ull * 1024 * 1024;
+inline constexpr size_t HD_PENDING_IMAGE_BUDGET_BYTES = 8ull * 1024 * 1024;
+inline constexpr size_t HD_BLOCK_TEXTURE_BYTES =
+    (size_t)HD_BLOCK_TEXTURE_SIZE * HD_BLOCK_TEXTURE_SIZE * 4;   // 1 MiB
+
+// Defensive limits for the HD sidecar parser. Nothing read from a file is
+// trusted before being checked against these.
+inline constexpr uint32 HD_MAX_COMPRESSED_BYTES = 64u * 1024 * 1024;
+inline constexpr uint32 HD_MAX_UNCOMPRESSED_BYTES = 256u * 1024 * 1024;
+inline constexpr uint32 HD_MAX_BLOCKS_PER_FLOOR = 65536;
+inline constexpr uint16 HD_MAX_TILES_PER_BLOCK = MMBLOCK_SIZE * MMBLOCK_SIZE;
+inline constexpr uint16 HD_MAX_ITEMS_PER_TILE = 64;
+
+// One drawable item of a tile. Explicitly typed: the subtype has its own field
+// so it can never be mistaken for a client id (the old design pushed fluid
+// subtypes into the same uint16 list as item ids).
+struct HDMinimapItem
+{
+    uint16 id = 0;
+    uint16 subtype = 0;
+    bool operator==(const HDMinimapItem& o) const { return id == o.id && subtype == o.subtype; }
+    bool operator!=(const HDMinimapItem& o) const { return !(*this == o); }
+};
+
+// A tile that has items, plus its span inside HDBlockData::m_items.
+struct HDTileRecord
+{
+    uint16 tileIndex = 0;
+    uint16 count = 0;
+    uint32 offset = 0;
+};
+
+// Sparse, packed HD payload of one block.
+//
+// Only tiles that actually carry items exist here: the items of the whole block
+// live in one contiguous pool, addressed by a record list, with a flat slot table
+// for O(1) lookup. A 64x64 block therefore costs three allocations instead of the
+// 4096 independent std::vector the old design embedded in every MinimapBlock.
+class HDBlockData
+{
+public:
+    // Replaces the items of a tile. Returns true when the content actually
+    // changed, so callers only bump revisions on real changes.
+    bool setTileItems(uint16 tileIndex, const HDMinimapItem* items, uint16 count);
+
+    uint32 getContentRevision() const { return m_contentRevision; }
+    uint32 getSavedRevision() const { return m_savedRevision; }
+    void setSavedRevision(uint32 revision) { m_savedRevision = revision; }
+    bool isDirty() const { return m_contentRevision != m_savedRevision; }
+
+    bool isEmpty() const { return m_records.empty(); }
+    size_t getTileCount() const { return m_records.size(); }
+    const std::vector<HDTileRecord>& getRecords() const { return m_records; }
+    const std::vector<HDMinimapItem>& getItemPool() const { return m_items; }
+
+    // Approximate resident cost, used by the HD memory budget.
+    size_t getByteSize() const;
+
+    // --- render cache -------------------------------------------------------
+    // The texture lives here rather than in MinimapBlock so that a block without
+    // HD data carries no HD render state at all.
+    const TexturePtr& getTexture() const { return m_texture; }
+    void setTexture(const TexturePtr& texture, uint32 revision) {
+        m_texture = texture;
+        m_renderedRevision = revision;
+    }
+    void dropTexture() { m_texture = nullptr; m_renderedRevision = 0; }
+    bool hasTexture() const { return m_texture != nullptr; }
+
+    // Revision bookkeeping replaces re-hashing the block on every draw.
+    uint32 getRenderedRevision() const { return m_renderedRevision; }
+    bool needsRender() const { return m_renderedRevision != m_contentRevision; }
+
+    ticks_t getLastUsed() const { return m_lastUsed; }
+    void markUsed(ticks_t now) { m_lastUsed = now; }
+
+private:
+    void compact();
+
+    TexturePtr m_texture;
+    uint32 m_renderedRevision = 0;
+    ticks_t m_lastUsed = 0;
+
+    std::vector<HDTileRecord> m_records;   // one entry per non-empty tile
+    std::vector<HDMinimapItem> m_items;    // packed item pool
+    std::vector<uint16> m_slot;            // 4096 entries: tileIndex -> record index
+    uint32 m_contentRevision = 0;
+    uint32 m_savedRevision = 0;
+    uint32 m_garbageItems = 0;
+};
+
 enum MinimapTileFlags {
     MinimapTileWasSeen = 1,
     MinimapTileNotPathable = 2,
     MinimapTileNotWalkable = 4,
     MinimapTileEmpty = 8
+};
+
+// A tile inside a render job's grid, pointing at a span of HDRenderJob::items.
+struct HDJobTile
+{
+    int16 gx = 0;      // tile offset from the block origin, may be negative (margin)
+    int16 gy = 0;
+    uint32 first = 0;
+    uint16 count = 0;
+};
+
+// Queued unit of work. Deliberately cheap: it holds no sprite images and, above
+// all, no MinimapBlock_ptr — a queued render must never keep a region of the
+// minimap alive.
+struct HDRenderJob
+{
+    uint blockIndex = 0;
+    Position blockPos;
+    uint32 generation = 0;
+    uint32 revision = 0;
+    int priority = 0;                  // block distance to the viewport centre
+    std::vector<HDJobTile> tiles;
+    std::vector<HDMinimapItem> items;
+};
+
+// One resolved sprite blit. Produced on the dispatcher thread (where g_things and
+// g_sprites may be touched) and consumed by a worker, which therefore needs no
+// singleton at all.
+struct HDBlit
+{
+    ImagePtr image;
+    int16 destX = 0;   // texels in the target image
+    int16 destY = 0;
+    int16 width = 0;
+    int16 height = 0;
+};
+
+// What a worker actually receives.
+struct HDRenderTask
+{
+    uint blockIndex = 0;
+    uint8 z = 0;
+    uint32 generation = 0;
+    uint32 revision = 0;
+    std::vector<HDBlit> blits;
+};
+
+// What a worker hands back. A worker ALWAYS posts one of these, even when it
+// cancelled early (image is then null), so the in-flight bookkeeping is symmetric
+// and can never leak an entry.
+struct HDRenderResult
+{
+    uint blockIndex = 0;
+    uint8 z = 0;
+    uint32 generation = 0;
+    uint32 revision = 0;
+    ImagePtr image;
+};
+
+// A block currently being rendered by a worker.
+struct HDRunningJob
+{
+    uint blockIndex = 0;
+    uint8 z = 0;
+    uint32 revision = 0;
 };
 
 #pragma pack(push,1) // disable memory alignment
@@ -67,8 +264,22 @@ public:
     void mustUpdate() { m_mustUpdate = true; }
     void justSaw() { m_wasSeen = true; }
     bool wasSeen() { return m_wasSeen; }
+
+    // HD layer. Null unless HD mode has actually stored something for this block,
+    // so a block without HD data costs exactly one pointer on top of the base one.
+    HDBlockData* getHDData() const { return m_hd.get(); }
+    HDBlockData& getOrCreateHDData() {
+        if(!m_hd)
+            m_hd = std::make_unique<HDBlockData>();
+        return *m_hd;
+    }
+    void dropHDData() { m_hd.reset(); }
+
 private:
     TexturePtr m_texture;
+    // Kept next to m_texture (and before m_tiles) so it stays pointer-aligned
+    // under the #pragma pack(1) this declaration lives in.
+    std::unique_ptr<HDBlockData> m_hd;
     std::array<MinimapTile, MMBLOCK_SIZE * MMBLOCK_SIZE> m_tiles;
     stdext::boolean<true> m_mustUpdate;
     stdext::boolean<false> m_wasSeen;
@@ -101,7 +312,51 @@ public:
     bool loadOtmm(const std::string& fileName);
     void saveOtmm(const std::string& fileName);
 
+    // --- HD minimap ---------------------------------------------------------
+    // Turning HD off releases every HD allocation and invalidates outstanding
+    // async work through the generation counter.
+    void setHDMode(bool enabled);
+    bool isHDMode() const { return m_hdMode.load(std::memory_order_relaxed); }
+
+    // Every async HD result must belong to the current generation to be applied.
+    // Bumped on: HD on/off, clean(), map load, and shutdown.
+    uint32 getHDGeneration() const { return m_hdGeneration.load(std::memory_order_acquire); }
+
+    // HD sidecar persistence. Never touches minimap.otmm.
+    bool loadOtmmHD(const std::string& fileName);
+    void saveOtmmHD(const std::string& fileName);
+    bool isSavingHD() const { return m_hdSaving.load(std::memory_order_acquire); }
+
+    // Debug instrumentation. Cheap enough to call from Lua on demand; never logged
+    // on its own.
+    std::string getHDStats();
+
 private:
+    // Records the drawable items of one tile. Only ever called with HD mode on.
+    void collectHDTile(const Position& pos, const TilePtr& tile);
+    // Drops all HD payloads and bumps the generation. Caller must hold m_lock.
+    void invalidateHDLocked();
+
+    // --- HD render pipeline (dispatcher thread unless noted) ----------------
+    // Draws the HD layer for the visible area and keeps the cache fed. Falls back
+    // to the caller's base path by returning false when HD cannot be used.
+    bool drawHD(const Rect& screenRect, const Position& mapCenter, float scale,
+                const Point& blockOff, const Point& start);
+    // Builds the sparse snapshot of a block and inserts it into the bounded queue,
+    // replacing any older entry for the same block.
+    void queueHDBlock(MinimapBlock& block, const Position& blockPos, uint blockIndex, int priority);
+    // Pops the best queued jobs and starts them on the async dispatcher.
+    void dispatchHDJobs();
+    // Turns a snapshot into blits. Reads g_things/g_sprites, so dispatcher only.
+    bool buildHDTask(const HDRenderJob& job, HDRenderTask& task);
+    // Uploads finished images into textures.
+    void collectHDResults();
+    // Frees textures until the budget is respected. Protects only the viewport.
+    void enforceHDTextureBudget(const Position& mapCenter, const Rect& visibleBlocks);
+    void dropHDTextureAt(uint8 z, uint blockIndex);
+    // Worker entry point. Touches nothing but its own task.
+    static ImagePtr composeHDImage(const HDRenderTask& task, const std::atomic<uint32>& generation);
+
     Rect calcMapRect(const Rect& screenRect, const Position& mapCenter, float scale);
     bool hasBlock(const Position& pos) { return m_tileBlocks[pos.z].find(getBlockIndex(pos)) != m_tileBlocks[pos.z].end(); }
     MinimapBlock& getBlock(const Position& pos) { 
@@ -118,6 +373,45 @@ private:
     uint getBlockIndex(const Position& pos) { return ((pos.y / MMBLOCK_SIZE) * (65536 / MMBLOCK_SIZE)) + (pos.x / MMBLOCK_SIZE); }
     std::vector<std::unordered_map<uint, MinimapBlock_ptr>> m_tileBlocks;
     std::mutex m_lock;
+
+    // Read on the hot updateTile path with a relaxed load, so HD off costs one
+    // atomic read and nothing else.
+    std::atomic<bool> m_hdMode{false};
+    std::atomic<uint32> m_hdGeneration{1};
+    size_t m_hdDataBytes = 0;   // guarded by m_lock
+    // Scratch buffer for collectHDTile, reused so per-tile collection does not
+    // allocate. Dispatcher thread only.
+    std::vector<HDMinimapItem> m_hdScratch;
+
+    // Bounded priority queue, deduplicated by block. Dispatcher thread only.
+    std::vector<HDRenderJob> m_hdQueue;
+    // Blocks handed to a worker and not yet collected. Together with m_hdQueue this
+    // is the complete "already being worked on" set, so a dropped job can never
+    // leave a block permanently unqueueable. Dispatcher thread only.
+    std::vector<HDRunningJob> m_hdRunning;
+    // Blocks that currently hold an HD texture, so the budget never has to scan
+    // the whole block map (the old design walked every floor every frame).
+    std::vector<std::pair<uint8, uint>> m_hdResident;
+
+    // Worker hand-off.
+    std::mutex m_hdResultLock;
+    std::vector<HDRenderResult> m_hdResults;
+    std::atomic<int> m_hdRunningJobs{0};
+    std::atomic<size_t> m_hdPendingImageBytes{0};
+    int m_hdMaxWorkers = 1;
+    size_t m_hdTextureBytes = 0;
+
+    // Save coalescing: a request arriving while a save runs sets the pending flag
+    // instead of blocking or spawning a second save.
+    std::atomic<bool> m_hdSaving{false};
+    bool m_hdSavePending = false;
+    std::string m_hdSavePendingFile;
+
+    // Counters for getHDStats(). Only the stale counter is written by workers.
+    uint64 m_hdCacheHits = 0;
+    uint64 m_hdCacheMisses = 0;
+    uint64 m_hdEvictions = 0;
+    std::atomic<uint64> m_hdStaleDropped{0};
 };
 
 extern Minimap g_minimap;

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -69,7 +69,13 @@ enum {
 
     // Separate HD sidecar format. minimap.otmm itself is never touched.
     OTMM_HD_SIGNATURE = 0x4844544F,
-    OTMM_HD_VERSION = 2
+    OTMM_HD_VERSION = 2,
+
+    // Baseline archive generated offline from the server's .otbm. Unlike the
+    // player sidecar it is indexed and read one block at a time, because it covers
+    // the whole world and must never be resident in full.
+    OTMM_HD_BASE_SIGNATURE = 0x42445448,
+    OTMM_HD_BASE_VERSION = 3
 };
 
 // Budgets are expressed in bytes, not in block counts, because resources of very
@@ -86,6 +92,23 @@ inline constexpr uint32 HD_MAX_UNCOMPRESSED_BYTES = 256u * 1024 * 1024;
 inline constexpr uint32 HD_MAX_BLOCKS_PER_FLOOR = 65536;
 inline constexpr uint16 HD_MAX_TILES_PER_BLOCK = MMBLOCK_SIZE * MMBLOCK_SIZE;
 inline constexpr uint16 HD_MAX_ITEMS_PER_TILE = 64;
+inline constexpr uint32 HD_MAX_BASE_BLOCKS = 4u * 1024 * 1024;
+
+// Resident budget for decoded tile data. The baseline archive covers the entire
+// world, so payloads are streamed in and dropped again; only blocks carrying
+// unsaved player data are exempt from eviction.
+inline constexpr size_t HD_DATA_BUDGET_BYTES = 32ull * 1024 * 1024;
+// Blocks pulled from the baseline archive per frame, so entering a new region
+// cannot turn into a long synchronous read.
+inline constexpr int HD_BASE_LOADS_PER_FRAME = 2;
+
+// Where a block lives inside the baseline archive.
+struct HDBaseEntry
+{
+    uint32 offset = 0;
+    uint32 compressedSize = 0;
+    uint32 plainSize = 0;
+};
 
 // One drawable item of a tile. Explicitly typed: the subtype has its own field
 // so it can never be mistaken for a client id (the old design pushed fluid
@@ -123,6 +146,12 @@ public:
     uint32 getSavedRevision() const { return m_savedRevision; }
     void setSavedRevision(uint32 revision) { m_savedRevision = revision; }
     bool isDirty() const { return m_contentRevision != m_savedRevision; }
+
+    // Content that came from the read-only baseline archive can be thrown away and
+    // read again, so it is what the data budget evicts. Player data never is,
+    // until it has been saved.
+    void setFromBaseline(bool fromBaseline) { m_fromBaseline = fromBaseline; }
+    bool isReloadable() const { return m_fromBaseline && !isDirty(); }
 
     bool isEmpty() const { return m_records.empty(); }
     size_t getTileCount() const { return m_records.size(); }
@@ -163,6 +192,7 @@ private:
     uint32 m_contentRevision = 0;
     uint32 m_savedRevision = 0;
     uint32 m_garbageItems = 0;
+    bool m_fromBaseline = false;
 };
 
 enum MinimapTileFlags {
@@ -327,6 +357,17 @@ public:
     void saveOtmmHD(const std::string& fileName);
     bool isSavingHD() const { return m_hdSaving.load(std::memory_order_acquire); }
 
+    // Offline tool: reads a server .otbm and writes the whole-world HD baseline.
+    // The base minimap.otmm cannot feed HD because it stores one colour per tile
+    // and no item ids, so this is the only way to cover unexplored regions.
+    bool generateHDFromOtbm(const std::string& otbmFile, const std::string& outputFile);
+
+    // Attaches the generated baseline. Only its index becomes resident; block
+    // payloads are streamed on demand and evicted under the data budget.
+    bool openHDBase(const std::string& fileName);
+    void closeHDBase();
+    bool hasHDBase() const { return m_hdBaseFile != nullptr; }
+
     // Debug instrumentation. Cheap enough to call from Lua on demand; never logged
     // on its own.
     std::string getHDStats();
@@ -345,6 +386,11 @@ private:
     // One-shot fill from the tiles g_map currently holds, bounded to the viewport
     // plus the protection margin. Runs once after HD is switched on.
     void bootstrapHDFromMap(const Position& mapCenter, const Rect& visibleBlocks);
+    // Pulls one block's tile data out of the baseline archive. Caller holds m_lock.
+    bool loadHDBaseBlockLocked(uint8 z, uint blockIndex, const Position& blockPos);
+    // Frees decoded tile data until HD_DATA_BUDGET_BYTES is respected. Blocks with
+    // unsaved player edits are never dropped. Caller holds m_lock.
+    void enforceHDDataBudgetLocked(const Position& mapCenter, const Rect& visibleBlocks);
     // Builds the sparse snapshot of a block and inserts it into the bounded queue,
     // replacing any older entry for the same block.
     void queueHDBlock(MinimapBlock& block, const Position& blockPos, uint blockIndex, int priority);
@@ -405,6 +451,14 @@ private:
     std::atomic<size_t> m_hdPendingImageBytes{0};
     int m_hdMaxWorkers = 1;
     size_t m_hdTextureBytes = 0;
+
+    // Baseline archive: index resident, payloads streamed. Dispatcher thread only.
+    std::vector<std::unordered_map<uint, HDBaseEntry>> m_hdBaseIndex;
+    FileStreamPtr m_hdBaseFile;
+    std::string m_hdBaseFileName;
+    uint64 m_hdBaseLoads = 0;
+    uint64 m_hdBaseDataEvictions = 0;
+    ticks_t m_hdDataBudgetNextScan = 0;
 
     // Save coalescing: a request arriving while a save runs sets the pending flag
     // instead of blocking or spawning a second save.

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -103,6 +103,8 @@ public:
     std::vector<CreaturePtr> getCreatures();
     std::vector<CreaturePtr> getWalkingCreatures() { return m_walkingCreatures; }
     std::vector<ThingPtr> getThings() { return m_things; }
+    // Non-copying view for hot paths that only read (HD minimap tile collection).
+    const std::vector<ThingPtr>& getThingsRef() const { return m_things; }
     std::vector<EffectPtr> getEffects() { return m_effects; }
     ItemPtr getGround();
     int getGroundSpeed();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado modo opcional de minimapa em alta definição (HD), com botão de ativação e indicação visual do estado.
  * O minimapa HD utiliza sprites detalhados dos itens e mantém o mapa padrão como alternativa.
  * Mapas HD são carregados e salvos separadamente, com cache por cliente, mundo e personagem.
  * Configuração do modo HD permanece salva entre sessões.
  * Inclusas estatísticas de processamento, armazenamento e uso de recursos do minimapa HD.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->