### PR TITLE
Fix/minimap hd lifetime 1f2afa5

### DIFF
--- a/modules/game_minimap/minimap.lua
+++ b/modules/game_minimap/minimap.lua
@@ -7,6 +7,7 @@ end
 
 minimapWidget = nil
 minimapWindow = nil
+minimapHDToggle = nil
 otmm = true
 preloaded = false
 fullmapView = false
@@ -143,6 +144,9 @@ function init()
     end
   end)
 
+  minimapHDToggle = minimapWindow:recursiveGetChildById('minimapHDToggle')
+  applyHDMode(isHDEnabled(), false)
+
   minimapWindow.floorPosition.onMouseWheel = onMouseWheel
   connect(g_game, {
     onGameStart = online,
@@ -272,12 +276,70 @@ function offline()
   minimapWidget:clearWaypoints()
   minimapWidget:clearRoutePath()
 
+  if isHDEnabled() then
+    g_minimap.saveOtmmHDAsync(minimapHDFile())
+  end
+
   minimapWidget:save()
+end
+
+-- Bundled full-world minimap shipped in data/ (and so inside data.zip via
+-- tools/make_release.ps1). Pre-fills g_minimap once so every player opens with
+-- the whole map revealed instead of a black minimap they must walk to fill.
+local BUNDLED_OTMM = '/data/minimap.otmm'
+
+-- HD minimap: per-player file holding the real item ids of explored tiles, used to
+-- rebuild the HD textures (item sprites) offline. Stored in the write dir under
+-- /minimap; the engine splits it into one file per floor.
+-- Global (not local) so offline()/saveMap(), defined earlier in the chunk, can resolve
+-- it at call time - a local upvalue would be nil for those.
+function minimapHDFile()
+  return '/minimap/minimap' .. g_game.getClientVersion() .. '_hd.otmm'
+end
+
+function isHDEnabled()
+  return g_settings.getBoolean('minimapHD', false)
+end
+
+-- Apply HD mode to the engine and reflect it on the toggle button. When enabling
+-- while online, restore any previously saved HD data so already-explored areas
+-- render in HD right away.
+function applyHDMode(enabled, reload)
+  g_minimap.setHDMode(enabled)
+  if minimapHDToggle then
+    minimapHDToggle:setOn(enabled)
+  end
+  if enabled and reload and g_game.isOnline() then
+    g_minimap.loadOtmmHD(minimapHDFile())
+  end
+end
+
+function toggleHD()
+  local enabled = not isHDEnabled()
+  if not enabled and g_game.isOnline() then
+    -- persist HD progress before leaving HD mode
+    g_minimap.saveOtmmHDAsync(minimapHDFile())
+  end
+  g_settings.set('minimapHD', enabled)
+  g_settings.save()
+  applyHDMode(enabled, true)
 end
 
 function loadMap(clean)
   if clean and g_minimap.load then
     g_minimap.load(clean)
+  end
+
+  if not MinimapLoader.otmmLoaded then
+    if g_resources.fileExists(BUNDLED_OTMM) then
+      g_minimap.loadOtmm(BUNDLED_OTMM)
+    end
+    MinimapLoader.otmmLoaded = true
+  end
+
+  -- Restore the player's saved HD item data when HD mode is on.
+  if isHDEnabled() then
+    g_minimap.loadOtmmHD(minimapHDFile())
   end
 
   -- LoadTibiaMap()

--- a/modules/game_minimap/minimap.otui
+++ b/modules/game_minimap/minimap.otui
@@ -209,3 +209,15 @@ MapMiniWindow
     $pressed:
       image-clip: 0 0 20 20
       image-source: /images/game/minimap/automap-button-cyclopediamap-down
+
+  Button
+    id: minimapHDToggle
+    size: 30 18
+    !text: 'HD'
+    anchors.left: parent.left
+    anchors.bottom: fullSize.top
+    margin-left: 5
+    margin-bottom: 2
+    tooltip: Toggle HD minimap (renders real item sprites)
+    tooltip-delayed: true
+    @onClick: modules.game_minimap.toggleHD()

--- a/modules/game_protocol/protocol.lua
+++ b/modules/game_protocol/protocol.lua
@@ -855,12 +855,18 @@ function registerProtocol()
 
 	local action = msg:getU8()
 	local count = msg:getU8()
+	local expectedBytes = count * 2
+	unread = tonumber(msg:getUnreadSize()) or 0
+	if unread < expectedBytes then
+		if unread > 0 then
+			msg:skipBytes(unread)
+		end
+		return
+	end
+
 	local spellIds = {}
 
 	for i = 1, count do
-		if msg:getUnreadSize() < 2 then
-			break
-		end
 		spellIds[#spellIds + 1] = msg:getU16()
 	end
 

--- a/modules/game_protocol/protocol.lua
+++ b/modules/game_protocol/protocol.lua
@@ -26,6 +26,7 @@ local ServerPackets = {
 	ClientCheck = 0x63,
 	LootStats = 0xCF,
 	LootContainer = 0xC0,
+	StanceProtocol = 0xC1,
 	TournamentLeaderBoard = 0xC5,
 	CyclopediaCharacterInfo = 0xDA,
 	Tutorial = 0xDC,
@@ -58,6 +59,8 @@ local DAILY_REWARD_SYSTEM_TYPE_TWO = 2
 local DAILY_REWARD_SYSTEM_TYPE_OTHER = 1
 local DAILY_REWARD_SYSTEM_TYPE_PREY_REROLL = 2
 local DAILY_REWARD_SYSTEM_TYPE_XP_BOOST = 3
+
+local activeStanceSpellIds = {}
 
 local function drainUnreadMessage(msg)
   if msg and msg.getUnreadSize and msg.skipBytes then
@@ -173,6 +176,52 @@ function g_game.highscore(highscoreType, category, vocation, worldName, page, en
   msg:addU8(entriesPerPage)
   protocolGame:send(msg)
   return true
+end
+
+local function copyActiveStanceSpellIds()
+  local spellIds = {}
+  for i = 1, #activeStanceSpellIds do
+    spellIds[i] = activeStanceSpellIds[i]
+  end
+  return spellIds
+end
+
+function g_game.updateStanceProtocol(action, spellIds)
+  if tonumber(action) ~= 0x02 or type(spellIds) ~= "table" then
+    return
+  end
+
+  activeStanceSpellIds = {}
+  for _, spellId in ipairs(spellIds) do
+    spellId = tonumber(spellId)
+    if spellId then
+      activeStanceSpellIds[#activeStanceSpellIds + 1] = spellId
+    end
+  end
+
+  signalcall(g_game.onStanceProtocol, action, copyActiveStanceSpellIds())
+end
+
+function g_game.getActiveStanceSpellIds()
+  return copyActiveStanceSpellIds()
+end
+
+function g_game.getStanceSpellIds()
+  return copyActiveStanceSpellIds()
+end
+
+function g_game.hasActiveStanceSpell(spellId)
+  spellId = tonumber(spellId)
+  if not spellId then
+    return false
+  end
+
+  for _, activeSpellId in ipairs(activeStanceSpellIds) do
+    if activeSpellId == spellId then
+      return true
+    end
+  end
+  return false
 end
 
 function init()
@@ -795,6 +844,29 @@ function registerProtocol()
 	signalcall(g_game.onQuickLootContainers, fallback, lootList)
   end)
 
+  registerOpcode(ServerPackets.StanceProtocol, function(protocol, msg)
+	local unread = tonumber(msg:getUnreadSize()) or 0
+	if unread < 2 then
+		if unread > 0 then
+			msg:skipBytes(unread)
+		end
+		return
+	end
+
+	local action = msg:getU8()
+	local count = msg:getU8()
+	local spellIds = {}
+
+	for i = 1, count do
+		if msg:getUnreadSize() < 2 then
+			break
+		end
+		spellIds[#spellIds + 1] = msg:getU16()
+	end
+
+	g_game.updateStanceProtocol(action, spellIds)
+  end)
+
   registerOpcode(ServerPackets.ClientCheck, function(protocol, msg)
 	local size = msg:getU32() -- Data size
 	for i = 1, size do
@@ -925,6 +997,8 @@ function readContainerItems(msg, depth)
 end
 
 function unregisterProtocol()
+  activeStanceSpellIds = {}
+
   if registredOpcodes == nil then
     return
   end

--- a/modules/gamelib/protocol.lua
+++ b/modules/gamelib/protocol.lua
@@ -83,6 +83,7 @@ GameServerOpcodes = {
     GameServerWalkWait                  = 182,
     GameServerFloorChangeUp             = 190,
     GameServerFloorChangeDown           = 191,
+    GameServerStanceProtocol            = 193,
     GameServerChooseOutfit              = 200,
     GameServerVipAdd                    = 210,
     GameServerVipLogin                  = 211,

--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -190,6 +190,12 @@ void Client::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_minimap", "saveImage", &Minimap::saveImage, &g_minimap);
     g_lua.bindSingletonFunction("g_minimap", "loadOtmm", &Minimap::loadOtmm, &g_minimap);
     g_lua.bindSingletonFunction("g_minimap", "saveOtmm", &Minimap::saveOtmm, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "loadOtmmHD", &Minimap::loadOtmmHD, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "saveOtmmHD", &Minimap::saveOtmmHD, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "saveOtmmHDAsync", &Minimap::saveOtmmHDAsync, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "isSavingHD", &Minimap::isSavingHD, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "setHDMode", &Minimap::setHDMode, &g_minimap);
+    g_lua.bindSingletonFunction("g_minimap", "isHDMode", &Minimap::isHDMode, &g_minimap);
 
     g_lua.registerSingletonClass("g_creatures");
     g_lua.bindSingletonFunction("g_creatures", "getCreatures", &CreatureManager::getCreatures, &g_creatures);

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -23,8 +23,12 @@
 
 #include "minimap.h"
 #include "tile.h"
+#include "item.h"
 #include "game.h"
+#include "map.h"
 #include "spritemanager.h"
+#include "thingtype.h"
+#include "thingtypemanager.h"
 
 #include <framework/graphics/image.h>
 #include <framework/graphics/texture.h>
@@ -37,13 +41,24 @@
 
 #include <framework/util/stats.h>
 
+#include <sstream>
+#include <chrono>
+#include <unordered_set>
+
 Minimap g_minimap;
 
 void MinimapBlock::clean()
 {
     m_tiles.fill(MinimapTile());
+    m_tileItems.fill(std::vector<uint16>());
+    m_extendedTileItems.clear();
     m_texture.reset();
+    m_hdTexture.reset();
+    setPendingHDImage(nullptr);
+    m_isRendering.store(false);
     m_mustUpdate = false;
+    m_hdNeedsUpdate = true;
+    m_itemsHash = 0;
 }
 
 void MinimapBlock::update()
@@ -76,18 +91,43 @@ void MinimapBlock::update()
 
 void MinimapBlock::updateTile(int x, int y, const MinimapTile& tile)
 {
-    if(m_tiles[getTileIndex(x,y)].color != tile.color)
+    if(m_tiles[getTileIndex(x,y)].color != tile.color) {
         m_mustUpdate = true;
+        m_hdNeedsUpdate = true;
+        m_needsSave = true;
+    }
 
     m_tiles[getTileIndex(x,y)] = tile;
 }
 
 void Minimap::init()
 {
+    m_hdMode = false;
+
+    m_renderThreadRunning = true;
+    for(int i = 0; i < NUM_RENDER_THREADS; ++i) {
+        m_renderThreads[i] = std::thread(&Minimap::renderThreadFunc, this);
+    }
 }
 
 void Minimap::terminate()
 {
+    {
+        std::lock_guard<std::mutex> lock(m_renderMutex);
+        m_renderThreadRunning = false;
+        m_renderCondition.notify_all();
+    }
+
+    for(int i = 0; i < NUM_RENDER_THREADS; ++i) {
+        if(m_renderThreads[i].joinable()) {
+            m_renderThreads[i].join();
+        }
+    }
+
+    if(m_saveThread.joinable()) {
+        m_saveThread.join();
+    }
+
     clean();
 }
 
@@ -96,6 +136,186 @@ void Minimap::clean()
     std::lock_guard<std::mutex> lock(m_lock);
     for(int i=0;i<=Otc::MAX_Z;++i)
         m_tileBlocks[i].clear();
+}
+
+void Minimap::setHDMode(bool enabled)
+{
+    if(m_hdMode == enabled)
+        return;
+
+    m_hdMode = enabled;
+
+    // Drop any queued work; the per-block fields a worker would touch are reset below.
+    {
+        std::lock_guard<std::mutex> qlock(m_renderMutex);
+        while(!m_renderQueue.empty()) {
+            HDRenderJob& job = m_renderQueue.front();
+            if(job.block)
+                job.block->setRendering(false);
+            m_renderQueue.pop();
+        }
+        m_renderQueueSize.store(0);
+    }
+
+    // Reset per-block textures. m_lock guards the block map / base texture; the HD
+    // hand-off fields (m_hdTexture/m_pendingHDImage) are additionally guarded by
+    // m_renderMutex so this cannot race a worker's final hand-off.
+    std::lock_guard<std::mutex> lock(m_lock);
+    std::lock_guard<std::mutex> rlock(m_renderMutex);
+    for(int z = 0; z <= Otc::MAX_Z; ++z) {
+        for(auto& pair : m_tileBlocks[z]) {
+            if(!pair.second)
+                continue;
+            pair.second->m_hdNeedsUpdate = true;
+            pair.second->m_mustUpdate = true;
+            if(enabled) {
+                pair.second->m_texture.reset();
+            } else {
+                pair.second->m_hdTexture.reset();
+                pair.second->setPendingHDImage(nullptr);
+                pair.second->setRendering(false);
+            }
+        }
+    }
+}
+
+void Minimap::queueBlockHD(const MinimapBlock_ptr& block, const Position& blockPos, bool processLiveTiles)
+{
+    if(!block)
+        return;
+
+    // Already busy with this block, or a finished image is awaiting upload.
+    if(block->isRendering() || block->hasPendingHD())
+        return;
+
+    // Throttle: don't pile work on the render threads.
+    if(m_renderQueueSize.load() > 8) {
+        block->m_hdNeedsUpdate = true;
+        return;
+    }
+
+    // Up-to-date texture, nothing to do.
+    if(block->m_hdTexture && !block->m_hdNeedsUpdate) {
+        block->markUsed();
+        return;
+    }
+
+    if(!block->m_hdTexture)
+        block->m_hdNeedsUpdate = true;
+
+    // While moving, the block being traversed gets dirtied every step. Don't rebuild its
+    // (expensive 2048x2048) texture more than a few times a second — this is what keeps
+    // running smooth. New blocks (no texture yet) are never throttled, so they still
+    // appear immediately.
+    if(block->m_hdTexture && (stdext::millis() - block->m_lastRenderTime) < 350)
+        return;
+
+    const int margin = 3;
+    const int elevationMargin = 2;
+    const int side = MMBLOCK_SIZE + margin * 2;
+    const int height = side + elevationMargin;
+
+    HDRenderJob job;
+    job.blockPos = blockPos;
+    job.block = block;
+    job.side = side;
+    job.height = height;
+    job.protobuf = g_sprites.isUsingProtobuf();
+    job.spriteSize = g_sprites.spriteSize();
+    job.items.assign((size_t)side * height, {});
+    job.hook.assign((size_t)side * height, 0);
+
+    // 1) Snapshot the item ids of this block plus its neighbour margin straight from the
+    //    stored per-tile data (kept current by Minimap::updateTile). The old per-frame
+    //    g_map re-scan here was redundant with updateTile and a major CPU cost.
+    size_t newHash = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_lock);
+        for(int y = -margin - elevationMargin; y < MMBLOCK_SIZE + margin; ++y) {
+            for(int x = -margin; x < MMBLOCK_SIZE + margin; ++x) {
+                std::vector<uint16> ids;
+                if(x < 0 || x >= MMBLOCK_SIZE || y < 0 || y >= MMBLOCK_SIZE) {
+                    int boX = (x < 0) ? -1 : (x >= MMBLOCK_SIZE) ? 1 : 0;
+                    int boY = (y < 0) ? -1 : (y >= MMBLOCK_SIZE) ? 1 : 0;
+                    Position nb(blockPos.x + boX * MMBLOCK_SIZE, blockPos.y + boY * MMBLOCK_SIZE, blockPos.z);
+                    auto it = m_tileBlocks[nb.z].find(getBlockIndex(nb));
+                    if(it != m_tileBlocks[nb.z].end() && it->second)
+                        ids = it->second->getTileItems(x - boX * MMBLOCK_SIZE, y - boY * MMBLOCK_SIZE);
+                } else {
+                    ids = block->getTileItems(x, y);
+                }
+
+                if(!ids.empty()) {
+                    for(uint16 itemId : ids)
+                        newHash ^= std::hash<uint16>{}(itemId) + 0x9e3779b9 + (newHash << 6) + (newHash >> 2);
+                    job.items[(y + margin + elevationMargin) * side + (x + margin)] = std::move(ids);
+                }
+            }
+        }
+    }
+
+    // Nothing changed since the existing texture was built — bail BEFORE any g_map or
+    // sprite work. This is the common case while moving and is what keeps HD cheap.
+    if(newHash == block->m_itemsHash && block->m_hdTexture) {
+        block->m_hdNeedsUpdate = false;
+        return;
+    }
+
+    // 2) Resolve hangable hook orientation from the live map (main thread only), and only
+    //    for tiles that actually have items — far fewer g_map lookups than the full grid.
+    if(processLiveTiles) {
+        for(int y = -margin - elevationMargin; y < MMBLOCK_SIZE + margin; ++y) {
+            for(int x = -margin; x < MMBLOCK_SIZE + margin; ++x) {
+                int gi = (y + margin + elevationMargin) * side + (x + margin);
+                if(job.items[gi].empty())
+                    continue;
+                TilePtr mapTile = g_map.getTile(Position(blockPos.x + x, blockPos.y + y, blockPos.z));
+                if(!mapTile)
+                    continue;
+                if(mapTile->mustHookSouth())
+                    job.hook[gi] = 1;
+                else if(mapTile->mustHookEast())
+                    job.hook[gi] = 2;
+            }
+        }
+    }
+
+    block->m_itemsHash = newHash;
+    block->m_hdNeedsUpdate = false;
+    block->setRendering(true);
+
+    // 3) Pre-fetch each sprite the worker may need, on the main thread (g_sprites is not
+    //    thread-safe). Dedupe item ids so a wall repeated across the block resolves its
+    //    sprites once instead of once per tile.
+    {
+        std::unordered_set<uint16> seenItems;
+        for(const std::vector<uint16>& tileItems : job.items) {
+            for(uint16 itemId : tileItems) {
+                if(!seenItems.insert(itemId).second)
+                    continue;
+                ThingTypePtr thingType = g_things.getThingType(itemId, ThingCategoryItem);
+                if(!thingType)
+                    continue;
+                for(int spriteId : thingType->getSprites()) {
+                    if(job.spriteImages.find(spriteId) == job.spriteImages.end())
+                        job.spriteImages.emplace(spriteId, g_sprites.getSpriteImage(spriteId));
+                }
+            }
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> qlock(m_renderMutex);
+        if((int)m_renderQueue.size() < 15) {
+            block->m_lastRenderTime = stdext::millis();
+            m_renderQueue.push(std::move(job));
+            m_renderQueueSize.store((int)m_renderQueue.size());
+            m_renderCondition.notify_one();
+        } else {
+            block->setRendering(false);
+            block->m_hdNeedsUpdate = true;
+        }
+    }
 }
 
 void Minimap::draw(const Rect& screenRect, const Position& mapCenter, float scale, const Color& color)
@@ -115,6 +335,212 @@ void Minimap::draw(const Rect& screenRect, const Position& mapCenter, float scal
     Point off = Point((mapRect.size() * scale).toPoint() - screenRect.size().toPoint())/2;
     Point start = screenRect.topLeft() -(mapRect.topLeft() - blockOff)*scale - off;
 
+    if(!m_hdMode) {
+        // Standard single-colour minimap (unchanged behaviour).
+        for(int y = blockOff.y, ys = start.y;ys<screenRect.bottom();y += MMBLOCK_SIZE, ys += MMBLOCK_SIZE*scale) {
+            if(y < 0 || y >= 65536)
+                continue;
+
+            for(int x = blockOff.x, xs = start.x;xs<screenRect.right();x += MMBLOCK_SIZE, xs += MMBLOCK_SIZE*scale) {
+                if(x < 0 || x >= 65536)
+                    continue;
+
+                Position blockPos(x, y, mapCenter.z);
+                if(!hasBlock(blockPos))
+                    continue;
+
+                MinimapBlock& block = getBlock(Position(x, y, mapCenter.z));
+                block.update();
+
+                const TexturePtr& tex = block.getTexture();
+                if(tex) {
+                    Rect src(0, 0, MMBLOCK_SIZE, MMBLOCK_SIZE);
+                    Rect dest(xs, ys, MMBLOCK_SIZE * scale, MMBLOCK_SIZE * scale);
+
+                    g_drawQueue->addTexturedRect(dest, tex, src);
+                }
+            }
+        }
+
+        g_drawQueue->setClip(drawQueueStart, screenRect);
+        return;
+    }
+
+    // ---- HD minimap mode ----
+
+    // Drop stale work if the render queue is backing up.
+    {
+        std::unique_lock<std::mutex> lock(m_renderMutex, std::try_to_lock);
+        if(lock.owns_lock() && m_renderQueue.size() > 20) {
+            int toRemove = std::min(5, (int)m_renderQueue.size() - 15);
+            for(int i = 0; i < toRemove && !m_renderQueue.empty(); ++i) {
+                HDRenderJob& item = m_renderQueue.front();
+                if(item.block) {
+                    item.block->setRendering(false);
+                }
+                m_renderQueue.pop();
+            }
+            m_renderQueueSize.store((int)m_renderQueue.size());
+        }
+    }
+
+    // Upload any HD images finished by the render threads (GL upload must run here).
+    processCompletedRenders();
+
+    // HD textures are large (2048x2048); periodically free far-away/old ones.
+    static int cleanupCounter = 0;
+    if(++cleanupCounter > 300) {
+        cleanupCounter = 0;
+
+        // Take m_lock (block map / base texture) and m_renderMutex (HD hand-off
+        // fields) together so resetting m_hdTexture/m_pendingHDImage cannot race a
+        // worker's final hand-off. Skip this frame if either is contended.
+        std::unique_lock<std::mutex> cleanupLock(m_lock, std::try_to_lock);
+        std::unique_lock<std::mutex> cleanupRenderLock(m_renderMutex, std::try_to_lock);
+        if(cleanupLock.owns_lock() && cleanupRenderLock.owns_lock()) {
+            const ticks_t currentTime = stdext::millis();
+            const ticks_t maxAge = 20000;
+            const int maxDistance = MMBLOCK_SIZE * 12;
+
+            int totalHDBlocks = 0;
+            int blocksWithData = 0;
+
+            if(mapCenter.z <= Otc::MAX_Z) {
+                for(auto& pair : m_tileBlocks[mapCenter.z]) {
+                    if(pair.second) {
+                        if(pair.second->wasSeen()) blocksWithData++;
+                        if(pair.second->m_hdTexture) totalHDBlocks++;
+                    }
+                }
+            }
+
+            const int maxAllowedHD = 250;
+            const int maxAllowedBase = 3500;
+            bool aggressiveCleanup = totalHDBlocks > maxAllowedHD || blocksWithData > maxAllowedBase;
+
+            int maxCleanupsPerFrame = aggressiveCleanup ? 8 : 4;
+            int cleanupsDone = 0;
+
+            for(uint8_t z = 0; z <= Otc::MAX_Z && cleanupsDone < maxCleanupsPerFrame; ++z) {
+                if(std::abs((int)z - (int)mapCenter.z) <= 1) continue;
+
+                for(auto& pair : m_tileBlocks[z]) {
+                    if(cleanupsDone >= maxCleanupsPerFrame) break;
+                    if(!pair.second) continue;
+
+                    // Don't disturb a block being rendered or awaiting upload.
+                    if(pair.second->isRendering() || pair.second->hasPendingHD()) continue;
+
+                    Position blockPos = getIndexPosition(pair.first, z);
+                    int dx = std::abs(blockPos.x - mapCenter.x);
+                    int dy = std::abs(blockPos.y - mapCenter.y);
+                    ticks_t age = currentTime - pair.second->getLastUsedTime();
+
+                    bool isFarAway = (dx > maxDistance || dy > maxDistance);
+
+                    if(pair.second->m_hdTexture) {
+                        bool shouldCleanHD = (isFarAway && age > maxAge) ||
+                                            (aggressiveCleanup && age > 8000);
+
+                        if(shouldCleanHD) {
+                            pair.second->m_hdTexture.reset();
+                            pair.second->setPendingHDImage(nullptr);
+                            pair.second->m_hdNeedsUpdate = true;
+                            cleanupsDone++;
+                        }
+                    }
+
+                    if(pair.second->m_texture && cleanupsDone < maxCleanupsPerFrame) {
+                        bool shouldCleanBase = (isFarAway && age > maxAge) ||
+                                              (aggressiveCleanup && age > 8000);
+
+                        if(shouldCleanBase) {
+                            pair.second->m_texture.reset();
+                            cleanupsDone++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Stack the floors above (surface) with a slight offset, then dim them.
+    if(mapCenter.z < 7) {
+        for(int floorOffset = (7 - mapCenter.z); floorOffset >= 1; --floorOffset) {
+            int floorZ = mapCenter.z + floorOffset;
+            int offsetPixels = (int)(floorOffset * scale);
+
+            for(int y = blockOff.y, ys = start.y; ys < screenRect.bottom(); y += MMBLOCK_SIZE, ys += MMBLOCK_SIZE*scale) {
+                if(y < 0 || y >= 65536)
+                    continue;
+
+                for(int x = blockOff.x, xs = start.x; xs < screenRect.right(); x += MMBLOCK_SIZE, xs += MMBLOCK_SIZE*scale) {
+                    if(x < 0 || x >= 65536)
+                        continue;
+
+                    Position blockPos(x, y, floorZ);
+                    if(!hasBlock(blockPos))
+                        continue;
+
+                    MinimapBlock& block = getBlock(blockPos);
+                    block.markUsed();
+
+                    Rect dest(xs + offsetPixels, ys + offsetPixels, MMBLOCK_SIZE * scale, MMBLOCK_SIZE * scale);
+
+                    queueBlockHD(block.shared_from_this(), blockPos, false);
+                    const TexturePtr& tex = block.getHDTexture();
+                    if(tex) {
+                        Rect src(0, 0, MMBLOCK_SIZE * 32, MMBLOCK_SIZE * 32);
+                        g_drawQueue->addTexturedRect(dest, tex, src);
+                    }
+                }
+            }
+        }
+
+        Rect darkOverlayRect = screenRect;
+        Color darknessOverlay = Color::black;
+        darknessOverlay.setAlpha(120);
+        g_drawQueue->addFilledRect(darkOverlayRect, darknessOverlay);
+    }
+
+    // Hint the floor directly below (underground) with a small offset.
+    if(mapCenter.z >= 8 && mapCenter.z < 15) {
+        int belowFloorZ = mapCenter.z + 1;
+        int offsetPixels = (int)scale;
+
+        for(int y = blockOff.y, ys = start.y; ys < screenRect.bottom(); y += MMBLOCK_SIZE, ys += MMBLOCK_SIZE*scale) {
+            if(y < 0 || y >= 65536)
+                continue;
+
+            for(int x = blockOff.x, xs = start.x; xs < screenRect.right(); x += MMBLOCK_SIZE, xs += MMBLOCK_SIZE*scale) {
+                if(x < 0 || x >= 65536)
+                    continue;
+
+                Position blockPos(x, y, belowFloorZ);
+                if(!hasBlock(blockPos))
+                    continue;
+
+                MinimapBlock& block = getBlock(blockPos);
+                block.markUsed();
+
+                bool hasValidHDTexture = block.getHDTexture() != nullptr;
+                bool needsRender = !hasValidHDTexture || block.needsHDUpdate();
+
+                if(needsRender) {
+                    queueBlockHD(block.shared_from_this(), blockPos, false);
+                }
+
+                const TexturePtr& tex = block.getHDTexture();
+                if(tex) {
+                    Rect src(0, 0, MMBLOCK_SIZE * 32, MMBLOCK_SIZE * 32);
+                    Rect dest(xs + offsetPixels, ys + offsetPixels, MMBLOCK_SIZE * scale, MMBLOCK_SIZE * scale);
+                    g_drawQueue->addTexturedRect(dest, tex, src);
+                }
+            }
+        }
+    }
+
+    // Current floor.
     for(int y = blockOff.y, ys = start.y;ys<screenRect.bottom();y += MMBLOCK_SIZE, ys += MMBLOCK_SIZE*scale) {
         if(y < 0 || y >= 65536)
             continue;
@@ -128,13 +554,24 @@ void Minimap::draw(const Rect& screenRect, const Position& mapCenter, float scal
                 continue;
 
             MinimapBlock& block = getBlock(Position(x, y, mapCenter.z));
-            block.update();
+            block.markUsed();
 
-            const TexturePtr& tex = block.getTexture();
+            int dx = std::abs(blockPos.x - mapCenter.x);
+            int dy = std::abs(blockPos.y - mapCenter.y);
+
+            bool processLive = (dx < MMBLOCK_SIZE / 2 && dy < MMBLOCK_SIZE / 2);
+
+            bool hasValidHDTexture = block.getHDTexture() != nullptr;
+            bool needsRender = !hasValidHDTexture || block.needsHDUpdate();
+
+            if(needsRender) {
+                queueBlockHD(block.shared_from_this(), blockPos, processLive);
+            }
+
+            const TexturePtr& tex = block.getHDTexture();
             if(tex) {
-                Rect src(0, 0, MMBLOCK_SIZE, MMBLOCK_SIZE);
+                Rect src(0, 0, MMBLOCK_SIZE * 32, MMBLOCK_SIZE * 32);
                 Rect dest(xs, ys, MMBLOCK_SIZE * scale, MMBLOCK_SIZE * scale);
-
                 g_drawQueue->addTexturedRect(dest, tex, src);
             }
         }
@@ -187,6 +624,8 @@ Rect Minimap::calcMapRect(const Rect& screenRect, const Position& mapCenter, flo
 void Minimap::updateTile(const Position& pos, const TilePtr& tile)
 {
     MinimapTile minimapTile;
+    std::vector<uint16> itemIds;
+
     if(tile) {
         minimapTile.color = tile->getMinimapColorByte();
         minimapTile.flags |= MinimapTileWasSeen;
@@ -195,6 +634,20 @@ void Minimap::updateTile(const Position& pos, const TilePtr& tile)
         if(!tile->isPathable())
             minimapTile.flags |= MinimapTileNotPathable;
         minimapTile.speed = std::min<int>((int)std::ceil(tile->getGroundSpeed() / 10.0f), 255);
+
+        // HD: remember the real item ids of this tile so the HD texture can be
+        // composited from their sprites. Does not affect the base MinimapTile/OTMM.
+        auto things = tile->getThings();
+        for(const ThingPtr& thing : things) {
+            if(thing && thing->isItem()) {
+                ItemPtr item = thing->static_self_cast<Item>();
+                itemIds.push_back(item->getId());
+
+                if(item->isSplash() || item->isFluidContainer()) {
+                    itemIds.push_back(item->getSubType());
+                }
+            }
+        }
     } else {
         minimapTile.color = 255;
         minimapTile.flags |= MinimapTileEmpty;
@@ -202,10 +655,21 @@ void Minimap::updateTile(const Position& pos, const TilePtr& tile)
     }
 
     if(minimapTile != MinimapTile()) {
-        MinimapBlock& block = getBlock(pos);
         Point offsetPos = getBlockOffset(Point(pos.x, pos.y));
-        block.updateTile(pos.x - offsetPos.x, pos.y - offsetPos.y, minimapTile);
-        block.justSaw();
+        int tileX = pos.x - offsetPos.x;
+        int tileY = pos.y - offsetPos.y;
+
+        // Hold m_lock across the block mutation so the per-tile item data writes are
+        // serialised with the async HD saver and the snapshot builder, which read it
+        // under the same lock.
+        std::lock_guard<std::mutex> lock(m_lock);
+        auto& ptr = m_tileBlocks[pos.z][getBlockIndex(pos)];
+        if(!ptr)
+            ptr = std::make_shared<MinimapBlock>();
+        ptr->updateTile(tileX, tileY, minimapTile);
+        if(!itemIds.empty())
+            ptr->setTileItems(tileX, tileY, itemIds);
+        ptr->justSaw();
     }
 }
 
@@ -223,7 +687,7 @@ const MinimapTile& Minimap::getTile(const Position& pos)
 std::pair<MinimapBlock_ptr, MinimapTile> Minimap::threadGetTile(const Position& pos) {
     std::lock_guard<std::mutex> lock(m_lock);
     static MinimapTile nulltile;
-    
+
     if (pos.z <= Otc::MAX_Z && hasBlock(pos)) {
         MinimapBlock_ptr block = m_tileBlocks[pos.z][getBlockIndex(pos)];
         if (block) {
@@ -480,5 +944,647 @@ void Minimap::saveOtmm(const std::string& fileName)
         g_logger.error(stdext::format("failed to save OTMM minimap: %s", e.what()));
     } catch (std::exception& e) {
         g_logger.error(stdext::format("failed to save OTMM minimap: %s", e.what()));
+    }
+}
+
+void Minimap::saveOtmmHD(const std::string& fileName)
+{
+    try {
+        size_t minimapPos = fileName.find("/minimap/");
+        if(minimapPos == std::string::npos) {
+            minimapPos = fileName.find("\\minimap\\");
+        }
+
+        std::string baseName;
+        std::string minimapDir = "/minimap";
+
+        if(minimapPos != std::string::npos) {
+            baseName = fileName.substr(minimapPos + 9);
+        } else {
+            baseName = fileName;
+            size_t lastSlash = fileName.find_last_of("/\\");
+            if(lastSlash != std::string::npos) {
+                baseName = fileName.substr(lastSlash + 1);
+            }
+        }
+
+        if(!baseName.empty() && baseName[0] == '/') {
+            baseName = baseName.substr(1);
+        }
+
+        baseName = baseName.substr(0, baseName.find("_hd.otmm"));
+
+        g_resources.makeDir("minimap");
+
+        struct BlockData {
+            Position pos;
+            std::vector<uint16> tileItems[MMBLOCK_SIZE * MMBLOCK_SIZE];
+            std::map<uint64_t, std::vector<uint16>> extendedItems;
+        };
+
+        for(uint8_t z = 0; z <= Otc::MAX_Z; ++z) {
+            std::vector<BlockData> blocksToSave;
+            bool floorHasDirtyBlocks = false;
+
+            {
+                std::lock_guard<std::mutex> lock(m_lock);
+
+                for(auto& it : m_tileBlocks[z]) {
+                    if(!it.second) continue;
+
+                    MinimapBlock& block = *it.second;
+                    if(!block.wasSeen())
+                        continue;
+
+                    int tilesWithItems = 0;
+                    for(int i = 0; i < MMBLOCK_SIZE * MMBLOCK_SIZE; ++i) {
+                        if(!block.m_tileItems[i].empty())
+                            tilesWithItems++;
+                    }
+                    for(const auto& e : block.m_extendedTileItems)
+                        if(!e.second.empty()) tilesWithItems++;
+
+                    if(tilesWithItems == 0)
+                        continue;
+
+                    if(block.m_needsSave) {
+                        floorHasDirtyBlocks = true;
+                    }
+
+                    BlockData data;
+                    data.pos = getIndexPosition(it.first, z);
+                    for(int i = 0; i < MMBLOCK_SIZE * MMBLOCK_SIZE; ++i) {
+                        data.tileItems[i] = block.m_tileItems[i];
+                    }
+                    data.extendedItems = block.m_extendedTileItems;
+                    blocksToSave.push_back(data);
+
+                    if(block.m_needsSave) {
+                        block.m_needsSave = false;
+                    }
+                }
+            }
+
+            if(blocksToSave.empty()) {
+                continue;
+            }
+
+            if(!floorHasDirtyBlocks) {
+                continue;
+            }
+
+            std::string floorFileName = minimapDir + "/" + baseName + "_floor" + std::to_string((int)z) + "_hd.otmm";
+
+            FileStreamPtr fin;
+            int retryCount = 0;
+            const int MAX_RETRIES = 3;
+
+            while(retryCount < MAX_RETRIES) {
+                try {
+                    fin = g_resources.createFile(floorFileName);
+                    break;
+                } catch(...) {
+                    retryCount++;
+                    if(retryCount >= MAX_RETRIES) {
+                        throw;
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                }
+            }
+
+            fin->addU32(OTMM_HD_SIGNATURE);
+            fin->addU16(0);
+            fin->addU16(OTMM_HD_VERSION);
+            fin->addU32(0);
+
+            fin->addString("OTMM HD 1.0");
+
+            uint32 start = fin->tell();
+            fin->seek(4);
+            fin->addU16(start);
+            fin->seek(start);
+
+            std::ostringstream uncompressedStream;
+
+            for(auto& blockData : blocksToSave) {
+                int tilesWithItems = 0;
+                for(int i = 0; i < MMBLOCK_SIZE * MMBLOCK_SIZE; ++i) {
+                    if(!blockData.tileItems[i].empty())
+                        tilesWithItems++;
+                }
+                // Count must match the write predicate below (which skips empty
+                // vectors); otherwise the header over-counts and desyncs the stream.
+                for(const auto& e : blockData.extendedItems)
+                    if(!e.second.empty()) tilesWithItems++;
+
+                uint16 bx = blockData.pos.x;
+                uint16 by = blockData.pos.y;
+                uint8 bz = blockData.pos.z;
+                uint16 tilesWithItems16 = (uint16)tilesWithItems;
+                uncompressedStream.write((char*)&bx, sizeof(uint16));
+                uncompressedStream.write((char*)&by, sizeof(uint16));
+                uncompressedStream.write((char*)&bz, sizeof(uint8));
+                uncompressedStream.write((char*)&tilesWithItems16, sizeof(uint16));
+
+                for(int ty = 0; ty < MMBLOCK_SIZE; ++ty) {
+                    for(int tx = 0; tx < MMBLOCK_SIZE; ++tx) {
+                        const std::vector<uint16>& items = blockData.tileItems[ty * MMBLOCK_SIZE + tx];
+                        if(!items.empty()) {
+                            uint8 xu8 = (uint8)tx;
+                            uint8 yu8 = (uint8)ty;
+                            uint16 size = (uint16)items.size();
+                            uncompressedStream.write((char*)&xu8, sizeof(uint8));
+                            uncompressedStream.write((char*)&yu8, sizeof(uint8));
+                            uncompressedStream.write((char*)&size, sizeof(uint16));
+                            for(uint16 itemId : items) {
+                                uncompressedStream.write((char*)&itemId, sizeof(uint16));
+                            }
+                        }
+                    }
+                }
+
+                for(const auto& extPair : blockData.extendedItems) {
+                    uint64_t key = extPair.first;
+                    const std::vector<uint16>& items = extPair.second;
+                    if(!items.empty()) {
+                        int16_t ex = (int16_t)(key >> 32);
+                        int16_t ey = (int16_t)(key & 0xFFFF);
+                        uint8 xu8 = (uint8_t)ex;
+                        uint8 yu8 = (uint8_t)ey;
+                        uint16 size = (uint16)items.size();
+                        uncompressedStream.write((char*)&xu8, sizeof(uint8));
+                        uncompressedStream.write((char*)&yu8, sizeof(uint8));
+                        uncompressedStream.write((char*)&size, sizeof(uint16));
+                        for(uint16 itemId : items) {
+                            uncompressedStream.write((char*)&itemId, sizeof(uint16));
+                        }
+                    }
+                }
+            }
+
+            std::string uncompressed = uncompressedStream.str();
+            uLongf uncompressedSize = uncompressed.size();
+            uLongf compressedSize = compressBound(uncompressedSize);
+            std::vector<uint8_t> compressed(compressedSize);
+
+            int result = compress2(compressed.data(), &compressedSize,
+                                  (const Bytef*)uncompressed.data(), uncompressedSize,
+                                  Z_DEFAULT_COMPRESSION);
+
+            if(result != Z_OK) {
+                throw stdext::exception("Compression failed");
+            }
+
+            fin->addU32(uncompressedSize);
+            fin->addU32(compressedSize);
+            fin->write(compressed.data(), compressedSize);
+
+            fin->flush();
+            fin->close();
+        }
+
+    } catch (stdext::exception& e) {
+        g_logger.error(stdext::format("failed to save OTMM HD minimap: %s", e.what()));
+    } catch (std::exception& e) {
+        g_logger.error(stdext::format("failed to save OTMM HD minimap: %s", e.what()));
+    }
+}
+
+void Minimap::saveOtmmHDAsync(const std::string& fileName)
+{
+    if(m_isSavingHD.exchange(true)) {
+        return;
+    }
+
+    if(m_saveThread.joinable()) {
+        m_saveThread.detach();
+    }
+
+    m_saveThread = std::thread([this, fileName]() {
+        try {
+            saveOtmmHD(fileName);
+        } catch(std::exception& e) {
+            g_logger.error(stdext::format("failed to save OTMM HD minimap: %s", e.what()));
+        } catch(...) {
+            g_logger.error("failed to save OTMM HD minimap: unknown error");
+        }
+        m_isSavingHD = false;
+    });
+}
+
+bool Minimap::loadOtmmHD(const std::string& fileName)
+{
+    int waitCount = 0;
+    while(m_isSavingHD && waitCount < 50) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        waitCount++;
+    }
+
+    if(m_isSavingHD) {
+        return false;
+    }
+
+    size_t minimapPos = fileName.find("/minimap/");
+    if(minimapPos == std::string::npos) {
+        minimapPos = fileName.find("\\minimap\\");
+    }
+
+    std::string baseName;
+    std::string minimapDir = "/minimap";
+
+    if(minimapPos != std::string::npos) {
+        baseName = fileName.substr(minimapPos + 9);
+    } else {
+        baseName = fileName;
+        size_t lastSlash = fileName.find_last_of("/\\");
+        if(lastSlash != std::string::npos) {
+            baseName = fileName.substr(lastSlash + 1);
+        }
+    }
+
+    if(!baseName.empty() && baseName[0] == '/') {
+        baseName = baseName.substr(1);
+    }
+
+    baseName = baseName.substr(0, baseName.find("_hd.otmm"));
+
+    bool loadedAny = false;
+
+    for(uint8_t z = 0; z <= Otc::MAX_Z; ++z) {
+        std::string floorFileName = minimapDir + "/" + baseName + "_floor" + std::to_string((int)z) + "_hd.otmm";
+
+        try {
+            FileStreamPtr fin = g_resources.openFile(floorFileName, g_game.getFeature(Otc::GameDontCacheFiles));
+            if(!fin) {
+                continue;
+            }
+
+            uint32 signature = fin->getU32();
+            if(signature != OTMM_HD_SIGNATURE)
+                stdext::throw_exception("invalid OTMM HD file");
+
+            uint16 start = fin->getU16();
+            uint16 version = fin->getU16();
+            fin->getU32();
+
+            if(version != OTMM_HD_VERSION)
+                stdext::throw_exception("OTMM HD version not supported");
+
+            fin->getString();
+            fin->seek(start);
+
+            uint32 uncompressedSize = fin->getU32();
+            uint32 compressedSize = fin->getU32();
+            std::vector<uint8_t> compressed(compressedSize);
+            fin->read((char*)compressed.data(), compressedSize);
+
+            std::vector<uint8_t> uncompressed(uncompressedSize);
+            uLongf destLen = uncompressedSize;
+            int result = uncompress(uncompressed.data(), &destLen,
+                                   compressed.data(), compressedSize);
+
+            if(result != Z_OK) {
+                continue;
+            }
+            std::istringstream dataStream(std::string((char*)uncompressed.data(), uncompressedSize));
+
+            while(dataStream.tellg() < (std::streampos)uncompressedSize) {
+                Position pos;
+                uint16 x, y;
+                uint8 bz;
+                dataStream.read((char*)&x, sizeof(uint16));
+                dataStream.read((char*)&y, sizeof(uint16));
+                dataStream.read((char*)&bz, sizeof(uint8));
+                pos.x = x;
+                pos.y = y;
+                pos.z = bz;
+
+                if(!pos.isValid() || pos.z >= Otc::MAX_Z+1)
+                    break;
+
+                uint16 tilesWithItems;
+                dataStream.read((char*)&tilesWithItems, sizeof(uint16));
+
+                MinimapBlock& block = getBlock(pos);
+
+                for(uint16 i = 0; i < tilesWithItems; ++i) {
+                    uint8 xu8, yu8;
+                    uint16 itemCount;
+                    dataStream.read((char*)&xu8, sizeof(uint8));
+                    dataStream.read((char*)&yu8, sizeof(uint8));
+                    dataStream.read((char*)&itemCount, sizeof(uint16));
+
+                    int8_t tx = (int8_t)xu8;
+                    int8_t ty = (int8_t)yu8;
+
+                    std::vector<uint16> items;
+                    items.reserve(itemCount);
+                    for(uint16 j = 0; j < itemCount; ++j) {
+                        uint16 itemId;
+                        dataStream.read((char*)&itemId, sizeof(uint16));
+                        items.push_back(itemId);
+                    }
+
+                    block.setTileItems(tx, ty, items, false);
+                }
+
+                if(tilesWithItems > 0) {
+                    // Mark seen so a later saveOtmmHD re-emits these blocks
+                    // (getBlock does not flag seen on its own).
+                    block.justSaw();
+                    block.m_hdNeedsUpdate = true;
+                }
+            }
+
+            fin->close();
+
+            loadedAny = true;
+
+        } catch(stdext::exception&) {
+            continue;
+        }
+    }
+
+    return loadedAny;
+}
+
+void Minimap::renderThreadFunc()
+{
+    while(m_renderThreadRunning) {
+        HDRenderJob job;
+        {
+            std::unique_lock<std::mutex> lock(m_renderMutex);
+
+            m_renderCondition.wait(lock, [this] {
+                return !m_renderQueue.empty() || !m_renderThreadRunning;
+            });
+
+            if(!m_renderThreadRunning)
+                break;
+
+            if(m_renderQueue.empty())
+                continue;
+
+            job = std::move(m_renderQueue.front());
+            m_renderQueue.pop();
+            m_renderQueueSize.store((int)m_renderQueue.size());
+        }
+
+        // From here the worker reads ONLY the immutable snapshot (job.items/job.hook)
+        // plus read-only sprite/thingtype data — never g_map, m_tileBlocks or live
+        // MinimapBlock data.
+        const int tilePixelsHD = 32;
+        const int margin = 3;
+        const int elevationMargin = 2;
+        const int gridSide = job.side;       // MMBLOCK_SIZE + 2*margin
+        const int gridHeight = job.height;   // gridSide + elevationMargin
+
+        ImagePtr imageHD(new Image(Size(gridSide * tilePixelsHD, gridHeight * tilePixelsHD)));
+
+        // Box-filter downsample a source sprite image into the [baseX,baseX+regionW) x
+        // [baseY,baseY+regionH) tile-aligned region of imageHD, alpha-compositing
+        // (source-over) over whatever is already there. Premultiplied-alpha averaging
+        // preserves anti-aliased edges so adjacent tiles connect instead of seaming.
+        auto blitScaled = [&](const ImagePtr& src, int baseX, int baseY, int regionW, int regionH) {
+            if(!src || regionW <= 0 || regionH <= 0)
+                return;
+            int fw = src->getWidth();
+            int fh = src->getHeight();
+            if(fw <= 0 || fh <= 0)
+                return;
+            for(int oy = 0; oy < regionH; ++oy) {
+                int dY = baseY + oy;
+                if(dY < 0 || dY >= gridHeight * tilePixelsHD)
+                    continue;
+                int sy0 = (oy * fh) / regionH;
+                int sy1 = ((oy + 1) * fh) / regionH;
+                if(sy1 <= sy0) sy1 = sy0 + 1;
+                if(sy1 > fh) sy1 = fh;
+                for(int ox = 0; ox < regionW; ++ox) {
+                    int dX = baseX + ox;
+                    if(dX < 0 || dX >= gridSide * tilePixelsHD)
+                        continue;
+                    int sx0 = (ox * fw) / regionW;
+                    int sx1 = ((ox + 1) * fw) / regionW;
+                    if(sx1 <= sx0) sx1 = sx0 + 1;
+                    if(sx1 > fw) sx1 = fw;
+
+                    uint32_t accR = 0, accG = 0, accB = 0, accA = 0;
+                    int samples = 0;
+                    for(int sy = sy0; sy < sy1; ++sy) {
+                        for(int sx = sx0; sx < sx1; ++sx) {
+                            uint8_t* p = src->getPixel(sx, sy);
+                            if(!p) continue;
+                            accR += (uint32_t)p[0] * p[3];
+                            accG += (uint32_t)p[1] * p[3];
+                            accB += (uint32_t)p[2] * p[3];
+                            accA += p[3];
+                            ++samples;
+                        }
+                    }
+                    if(samples == 0 || accA == 0) continue;
+                    uint8_t outA = (uint8_t)(accA / samples);
+                    if(outA == 0) continue;
+                    uint8_t outR = (uint8_t)(accR / accA);
+                    uint8_t outG = (uint8_t)(accG / accA);
+                    uint8_t outB = (uint8_t)(accB / accA);
+
+                    uint8_t* dst = imageHD->getPixel(dX, dY);
+                    if(!dst) continue;
+                    int inv = 255 - outA;
+                    dst[0] = (uint8_t)((outR * outA + dst[0] * inv) / 255);
+                    dst[1] = (uint8_t)((outG * outA + dst[1] * inv) / 255);
+                    dst[2] = (uint8_t)((outB * outA + dst[2] * inv) / 255);
+                    dst[3] = (uint8_t)(outA + (dst[3] * inv) / 255);
+                }
+            }
+        };
+
+        for(int y = -margin - elevationMargin; y < MMBLOCK_SIZE + margin; ++y) {
+            for(int x = -margin; x < MMBLOCK_SIZE + margin; ++x) {
+                int gi = (y + margin + elevationMargin) * gridSide + (x + margin);
+                if(gi < 0 || gi >= (int)job.items.size())
+                    continue;
+
+                const std::vector<uint16>& itemIds = job.items[gi];
+                if(itemIds.empty()) continue;
+
+                uint8_t tileHook = job.hook[gi];
+
+                for(int pass = 0; pass < 2; ++pass) {
+                    for(size_t idx = 0; idx < itemIds.size(); ++idx) {
+                        uint16 itemId = itemIds[idx];
+
+                        ThingTypePtr thingType = g_things.getThingType(itemId, ThingCategoryItem);
+                        if(!thingType) continue;
+
+                        bool isFullGround = thingType->isFullGround();
+
+                        if(pass == 0 && !isFullGround) continue;
+                        if(pass == 1 && isFullGround) continue;
+
+                    int width = thingType->getWidth();
+                    int height = thingType->getHeight();
+                    int layers = thingType->getLayers();
+
+                    int xPattern = 0, yPattern = 0, zPattern = 0;
+
+                    if(thingType->isHangable()) {
+                        // Hook orientation was resolved from the live map on the main
+                        // thread (job.hook); the worker never touches g_map.
+                        if(tileHook == 1) {
+                            xPattern = thingType->getNumPatternX() >= 2 ? 1 : 0;
+                        } else if(tileHook == 2) {
+                            xPattern = thingType->getNumPatternX() >= 3 ? 2 : 0;
+                        }
+                    } else if(thingType->isSplash() || thingType->isFluidContainer()) {
+                        if(idx + 1 < itemIds.size()) {
+                            uint16 fluidType = itemIds[idx + 1];
+                            int color = Otc::FluidTransparent;
+
+                            switch(fluidType) {
+                                case Otc::FluidNone: color = Otc::FluidTransparent; break;
+                                case Otc::FluidWater: color = Otc::FluidBlue; break;
+                                case Otc::FluidMana: color = Otc::FluidPurple; break;
+                                case Otc::FluidBeer: color = Otc::FluidBrown; break;
+                                case Otc::FluidOil: color = Otc::FluidBrown; break;
+                                case Otc::FluidBlood: color = Otc::FluidRed; break;
+                                case Otc::FluidSlime: color = Otc::FluidGreen; break;
+                                case Otc::FluidMud: color = Otc::FluidBrown; break;
+                                case Otc::FluidLemonade: color = Otc::FluidYellow; break;
+                                case Otc::FluidMilk: color = Otc::FluidWhite; break;
+                                case Otc::FluidWine: color = Otc::FluidPurple; break;
+                                case Otc::FluidHealth: color = Otc::FluidRed; break;
+                                case Otc::FluidUrine: color = Otc::FluidYellow; break;
+                                case Otc::FluidRum: color = Otc::FluidBrown; break;
+                                case Otc::FluidFruidJuice: color = Otc::FluidYellow; break;
+                                case Otc::FluidCoconutMilk: color = Otc::FluidWhite; break;
+                                case Otc::FluidTea: color = Otc::FluidBrown; break;
+                                case Otc::FluidMead: color = Otc::FluidBrown; break;
+                                default: color = Otc::FluidTransparent; break;
+                            }
+
+                            xPattern = (color % 4) % thingType->getNumPatternX();
+                            yPattern = (color / 4) % thingType->getNumPatternY();
+                            ++idx;
+                        }
+                    }
+
+                    std::vector<int> sprites = thingType->getSprites();
+                    const int numSprites = (int)sprites.size();
+
+                    if(job.protobuf) {
+                        // Protobuf (15.x) assets: each layer's sprite IS the full bounding
+                        // square (all cells of a multi-tile thing), exactly as
+                        // ThingType::drawToImage uses it. The old legacy w/h sub-sprite
+                        // indexing fetched the wrong cells — that is what made walls and
+                        // multi-tile items render broken ("tile by tile").
+                        const int ss = job.spriteSize > 0 ? job.spriteSize : tilePixelsHD;
+                        const int npx = thingType->getNumPatternX();
+                        const int npy = thingType->getNumPatternY();
+                        const int npz = thingType->getNumPatternZ();
+                        const int xp = xPattern % npx;
+                        const int yp = yPattern % npy;
+                        const int zp = zPattern % npz;
+                        for(int l = 0; l < layers; ++l) {
+                            // Protobuf full-square sprite index — matches ThingType::
+                            // getSpriteIndex(w=-1, h=-1, l, x, y, z, a=0).
+                            int spriteIndex = ((zp * npy + yp) * npx + xp) * layers + l;
+                            if(spriteIndex < 0 || spriteIndex >= numSprites) continue;
+                            auto sit = job.spriteImages.find(sprites[spriteIndex]);
+                            if(sit == job.spriteImages.end() || !sit->second) continue;
+                            ImagePtr spriteImg = sit->second;
+
+                            int cellsW = spriteImg->getWidth() / ss;  if(cellsW < 1) cellsW = 1;
+                            int cellsH = spriteImg->getHeight() / ss; if(cellsH < 1) cellsH = 1;
+                            // tile (x,y) is the bottom-right cell; the thing extends up/left.
+                            int baseX = ((x - (cellsW - 1)) + margin) * tilePixelsHD;
+                            int baseY = ((y - (cellsH - 1)) + margin + elevationMargin) * tilePixelsHD;
+                            blitScaled(spriteImg, baseX, baseY, cellsW * tilePixelsHD, cellsH * tilePixelsHD);
+                        }
+                    } else {
+                        // Legacy .spr assets: the bounding square is split into w*h 32px
+                        // sub-sprites placed individually.
+                        for(int l = 0; l < layers; ++l) {
+                            for(int h = 0; h < height; ++h) {
+                                for(int w = 0; w < width; ++w) {
+                                    int spriteIndex = ((((l * thingType->getNumPatternZ() + zPattern) *
+                                                        thingType->getNumPatternY() + yPattern) *
+                                                        thingType->getNumPatternX() + xPattern) *
+                                                        height + (height - h - 1)) * width + (width - w - 1);
+                                    if(spriteIndex < 0 || spriteIndex >= numSprites) continue;
+                                    auto sit = job.spriteImages.find(sprites[spriteIndex]);
+                                    if(sit == job.spriteImages.end() || !sit->second) continue;
+                                    int destTileX = x + margin + (-(width - 1) + w);
+                                    int destTileY = y + margin + elevationMargin + (-(height - 1) + h);
+                                    blitScaled(sit->second, destTileX * tilePixelsHD, destTileY * tilePixelsHD,
+                                               tilePixelsHD, tilePixelsHD);
+                                }
+                            }
+                        }
+                    }
+
+                    }
+                }
+            }
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(m_renderMutex);
+            job.block->setPendingHDImage(imageHD);
+            job.block->setRendering(false);
+        }
+    }
+}
+
+void Minimap::processCompletedRenders()
+{
+    std::unique_lock<std::mutex> lock(m_renderMutex, std::try_to_lock);
+    if(!lock.owns_lock()) {
+        return;
+    }
+
+    // Each HD texture is 2048x2048 (~16 MB); uploading too many per frame stutters the
+    // main thread while running. Spread them out — they appear over a few frames.
+    const int MAX_BLOCKS_PER_FRAME = 2;
+    int processedCount = 0;
+
+    for(int z = 0; z <= Otc::MAX_Z && processedCount < MAX_BLOCKS_PER_FRAME; ++z) {
+        for(auto& it : m_tileBlocks[z]) {
+            if(processedCount >= MAX_BLOCKS_PER_FRAME) break;
+
+            MinimapBlock_ptr block = it.second;
+            if(!block || !block->hasPendingHD()) continue;
+
+            ImagePtr pendingHDImage = block->getPendingHDImage();
+            if(!pendingHDImage) continue;
+
+            const int tilePixelsHD = 32;
+            const int margin = 3;
+            const int elevationMargin = 2;
+            const int blockSizePixels = MMBLOCK_SIZE * tilePixelsHD;
+            const int marginPixelsX = margin * tilePixelsHD;
+            const int marginPixelsY = (margin + elevationMargin) * tilePixelsHD;
+
+            ImagePtr croppedImage(new Image(Size(blockSizePixels, blockSizePixels)));
+
+            const size_t bytesPerLine = blockSizePixels * 4;
+            for(int y = 0; y < blockSizePixels; ++y) {
+                uint8_t* srcLine = pendingHDImage->getPixel(marginPixelsX, y + marginPixelsY);
+                uint8_t* dstLine = croppedImage->getPixel(0, y);
+                if(srcLine && dstLine) {
+                    memcpy(dstLine, srcLine, bytesPerLine);
+                }
+            }
+
+            block->setPendingHDImage(nullptr);
+
+            TexturePtr texture = TexturePtr(new Texture(croppedImage));
+            texture->setSmooth(true);
+            block->m_hdTexture = texture;
+            block->m_hdNeedsUpdate = false;
+
+            processedCount++;
+        }
     }
 }

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -26,11 +26,23 @@
 
 #include "declarations.h"
 #include <framework/graphics/declarations.h>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <atomic>
+#include <map>
+#include <unordered_map>
 
 enum {
     MMBLOCK_SIZE = 64,
     OTMM_SIGNATURE = 0x4D4d544F,
-    OTMM_VERSION = 1
+    OTMM_VERSION = 1,
+    // HD minimap: a separate per-floor file format that stores the real item ids
+    // of each tile so the HD textures (rendered from item sprites) can be rebuilt
+    // offline. Independent of the base OTMM format above.
+    OTMM_HD_SIGNATURE = 0x4844544F,
+    OTMM_HD_VERSION = 1
 };
 
 enum MinimapTileFlags {
@@ -52,34 +64,105 @@ struct MinimapTile
     bool operator==(const MinimapTile& other) const { return color == other.color && flags == other.flags && speed == other.speed; }
     bool operator!=(const MinimapTile& other) const { return !(*this == other); }
 };
+#pragma pack(pop)
 
-class MinimapBlock
+class MinimapBlock : public std::enable_shared_from_this<MinimapBlock>
 {
+    friend class Minimap;
 public:
     void clean();
     void update();
     void updateTile(int x, int y, const MinimapTile& tile);
+    // HD: the real item ids of each tile, used to composite the HD texture. A small
+    // negative/over-range margin (neighbouring blocks) is kept in m_extendedTileItems.
+    // All access to these containers is serialised by Minimap::m_lock (the snapshot
+    // builder, the async saver and updateTile all hold it).
+    void setTileItems(int x, int y, const std::vector<uint16>& items, bool markDirty = true) {
+        if(x >= 0 && x < MMBLOCK_SIZE && y >= 0 && y < MMBLOCK_SIZE) {
+            m_tileItems[getTileIndex(x,y)] = items;
+        } else {
+            uint64_t key = ((uint64_t)(int16_t)x << 32) | (uint64_t)(uint16_t)(int16_t)y;
+            m_extendedTileItems[key] = items;
+        }
+        if(markDirty) {
+            m_hdNeedsUpdate = true;
+        }
+    }
+    const std::vector<uint16>& getTileItems(int x, int y) {
+        if(x >= 0 && x < MMBLOCK_SIZE && y >= 0 && y < MMBLOCK_SIZE) {
+            return m_tileItems[getTileIndex(x,y)];
+        } else {
+            uint64_t key = ((uint64_t)(int16_t)x << 32) | (uint64_t)(uint16_t)(int16_t)y;
+            static std::vector<uint16> emptyVec;
+            auto it = m_extendedTileItems.find(key);
+            return (it != m_extendedTileItems.end()) ? it->second : emptyVec;
+        }
+    }
     MinimapTile& getTile(int x, int y) { return m_tiles[getTileIndex(x,y)]; }
     void resetTile(int x, int y) { m_tiles[getTileIndex(x,y)] = MinimapTile(); }
     uint getTileIndex(int x, int y) { return ((y % MMBLOCK_SIZE) * MMBLOCK_SIZE) + (x % MMBLOCK_SIZE); }
     const TexturePtr& getTexture() { return m_texture; }
+    const TexturePtr& getHDTexture() { return m_hdTexture; }
     std::array<MinimapTile, MMBLOCK_SIZE * MMBLOCK_SIZE>& getTiles() { return m_tiles; }
     void mustUpdate() { m_mustUpdate = true; }
     void justSaw() { m_wasSeen = true; }
     bool wasSeen() { return m_wasSeen; }
+    void markUsed() { m_lastUsedTime = stdext::millis(); }
+    ticks_t getLastUsedTime() const { return m_lastUsedTime; }
+    bool needsHDUpdate() const { return m_hdNeedsUpdate; }
+
+    // Render hand-off flags. m_isRendering/m_hasPendingHD are atomic so the draw
+    // thread can test them lock-free; m_pendingHDImage itself is only ever touched
+    // while Minimap::m_renderMutex is held (worker, processCompletedRenders, the
+    // draw-thread cleanup and setHDMode).
+    bool isRendering() const { return m_isRendering.load(); }
+    void setRendering(bool rendering) { m_isRendering.store(rendering); }
+    bool hasPendingHD() const { return m_hasPendingHD.load(); }
+    ImagePtr getPendingHDImage() const { return m_pendingHDImage; }
+    void setPendingHDImage(ImagePtr img) { m_pendingHDImage = img; m_hasPendingHD.store(img != nullptr); }
+
 private:
     TexturePtr m_texture;
+    TexturePtr m_hdTexture;
     std::array<MinimapTile, MMBLOCK_SIZE * MMBLOCK_SIZE> m_tiles;
+    std::array<std::vector<uint16>, MMBLOCK_SIZE * MMBLOCK_SIZE> m_tileItems;
+    std::map<uint64_t, std::vector<uint16>> m_extendedTileItems;
+    size_t m_itemsHash = 0;
+    ticks_t m_lastUsedTime = 0;
+    ticks_t m_lastRenderTime = 0;
     stdext::boolean<true> m_mustUpdate;
+    stdext::boolean<true> m_hdNeedsUpdate;
     stdext::boolean<false> m_wasSeen;
-};
+    stdext::boolean<false> m_needsSave;
 
-#pragma pack(pop)
+    ImagePtr m_pendingHDImage;
+    std::atomic<bool> m_isRendering{false};
+    std::atomic<bool> m_hasPendingHD{false};
+};
 
 using MinimapBlock_ptr = std::shared_ptr<MinimapBlock>;
 
+// Self-contained unit of work handed to the HD render threads. It carries an
+// immutable snapshot of everything a worker needs (the item ids of the block and
+// its neighbour margin, plus the hook orientation resolved from the live map on the
+// main thread), so the worker never touches g_map, m_tileBlocks or live block data.
+struct HDRenderJob
+{
+    Position blockPos;
+    MinimapBlock_ptr block;                  // result delivery target only
+    int side = 0;                            // grid width  (MMBLOCK_SIZE + 2*margin)
+    int height = 0;                          // grid height (side + elevationMargin)
+    bool protobuf = false;                   // g_sprites.isUsingProtobuf() (full-square sprites)
+    int spriteSize = 0;                      // g_sprites.spriteSize() (HD-scaled cell size)
+    std::vector<std::vector<uint16>> items;  // size side*height, idx = gy*side + gx
+    std::vector<uint8_t> hook;               // size side*height: 0 none, 1 south, 2 east
+    // Sprite images pre-fetched on the main thread (g_sprites is not thread-safe).
+    std::unordered_map<int, ImagePtr> spriteImages;
+};
+
 class Minimap
 {
+    friend class MinimapBlock;
 
 public:
     void init();
@@ -96,15 +179,32 @@ public:
     const MinimapTile& getTile(const Position& pos);
     std::pair<MinimapBlock_ptr, MinimapTile> threadGetTile(const Position& pos);
 
+    // HD minimap mode: render blocks from real item sprites instead of a single
+    // colour per tile. Heavy (large textures + background render threads), so it is
+    // off by default and toggled from the minimap UI.
+    void setHDMode(bool enabled);
+    bool isHDMode() { return m_hdMode; }
+
     bool loadImage(const std::string& fileName, const Position& topLeft, float colorFactor);
     void saveImage(const std::string& fileName, int minX, int minY, int maxX, int maxY, short z);
     bool loadOtmm(const std::string& fileName);
     void saveOtmm(const std::string& fileName);
+    bool loadOtmmHD(const std::string& fileName);
+    void saveOtmmHD(const std::string& fileName);
+    void saveOtmmHDAsync(const std::string& fileName);
+    bool isSavingHD() { return m_isSavingHD.load(); }
+
+    void renderThreadFunc();
+    void processCompletedRenders();
 
 private:
+    // Builds the immutable snapshot for an HD block render on the main thread and
+    // enqueues it for the worker pool. Handles the busy/throttle/no-change early-outs.
+    void queueBlockHD(const MinimapBlock_ptr& block, const Position& blockPos, bool processLiveTiles);
+
     Rect calcMapRect(const Rect& screenRect, const Position& mapCenter, float scale);
     bool hasBlock(const Position& pos) { return m_tileBlocks[pos.z].find(getBlockIndex(pos)) != m_tileBlocks[pos.z].end(); }
-    MinimapBlock& getBlock(const Position& pos) { 
+    MinimapBlock& getBlock(const Position& pos) {
         std::lock_guard<std::mutex> lock(m_lock);
         auto& ptr = m_tileBlocks[pos.z][getBlockIndex(pos)];
         if (!ptr)
@@ -118,6 +218,17 @@ private:
     uint getBlockIndex(const Position& pos) { return ((pos.y / MMBLOCK_SIZE) * (65536 / MMBLOCK_SIZE)) + (pos.x / MMBLOCK_SIZE); }
     std::unordered_map<uint, MinimapBlock_ptr> m_tileBlocks[Otc::MAX_Z+1];
     std::mutex m_lock;
+    bool m_hdMode = false;
+
+    static constexpr int NUM_RENDER_THREADS = 6;
+    std::thread m_renderThreads[NUM_RENDER_THREADS];
+    std::mutex m_renderMutex;
+    std::condition_variable m_renderCondition;
+    std::queue<HDRenderJob> m_renderQueue;
+    std::atomic<int> m_renderQueueSize{0};       // mirrors m_renderQueue.size() for lock-free reads
+    std::atomic<bool> m_renderThreadRunning{false};
+    std::atomic<bool> m_isSavingHD{false};
+    std::thread m_saveThread;
 };
 
 extern Minimap g_minimap;

--- a/src/client/protocolcodes.h
+++ b/src/client/protocolcodes.h
@@ -178,6 +178,7 @@ namespace Proto {
         GameServerFloorChangeUp             = 190,
         GameServerFloorChangeDown           = 191,
         GameServerLootContainers            = 192,
+        GameServerStanceProtocol            = 193,
         GameServerWeaponProficiencyInfo      = 196,
         GameServerMonsterPodium              = 194,
         GameServerTournamentLeaderboard     = 197,

--- a/src/client/protocolgame.h
+++ b/src/client/protocolgame.h
@@ -313,6 +313,7 @@ private:
     void parseDailyRewardHistory(const InputMessagePtr& msg);
     void parseKillTracker(const InputMessagePtr& msg);
     void parseLootContainers(const InputMessagePtr& msg);
+    void parseStanceProtocol(const InputMessagePtr& msg);
     void parseSupplyStash(const InputMessagePtr& msg);
     void parseSpecialContainer(const InputMessagePtr& msg);
     void parseDepotState(const InputMessagePtr& msg);

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -3853,14 +3853,19 @@ void ProtocolGame::parseStanceProtocol(const InputMessagePtr& msg)
 
     const uint8_t action = msg->getU8();
     const uint8_t count = msg->getU8();
+    const int requiredBytes = static_cast<int>(count) * 2;
+
+    unreadSize = msg->getUnreadSize();
+    if (unreadSize < requiredBytes) {
+        if (unreadSize > 0)
+            msg->skipBytes(static_cast<uint32_t>(unreadSize));
+        return;
+    }
 
     std::vector<uint16_t> spellIds;
     spellIds.reserve(count);
 
     for (uint8_t i = 0; i < count; ++i) {
-        if (msg->getUnreadSize() < 2)
-            break;
-
         spellIds.emplace_back(msg->getU16());
     }
 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -631,6 +631,9 @@ void ProtocolGame::parseMessage(const InputMessagePtr& msg)
             case Proto::GameServerLootContainers:
                 parseLootContainers(msg);
                 break;
+            case Proto::GameServerStanceProtocol:
+                parseStanceProtocol(msg);
+                break;
             case Proto::GameServerSupplyStash:
                 parseSupplyStash(msg);
                 break;
@@ -3837,6 +3840,31 @@ void ProtocolGame::parseLootContainers(const InputMessagePtr& msg)
 
     g_lua.callGlobalField("g_game", "onParseLootContainers", quickLootFallbackToMainContainer ? 1 : 0, lootContainers, obtainContainers);
     g_lua.callGlobalField("g_game", "onQuickLootContainers", quickLootFallbackToMainContainer, lootList);
+}
+
+void ProtocolGame::parseStanceProtocol(const InputMessagePtr& msg)
+{
+    int unreadSize = msg->getUnreadSize();
+    if (unreadSize < 2) {
+        if (unreadSize > 0)
+            msg->skipBytes(static_cast<uint32_t>(unreadSize));
+        return;
+    }
+
+    const uint8_t action = msg->getU8();
+    const uint8_t count = msg->getU8();
+
+    std::vector<uint16_t> spellIds;
+    spellIds.reserve(count);
+
+    for (uint8_t i = 0; i < count; ++i) {
+        if (msg->getUnreadSize() < 2)
+            break;
+
+        spellIds.emplace_back(msg->getU16());
+    }
+
+    g_lua.callGlobalField("g_game", "updateStanceProtocol", action, spellIds);
 }
 
 void ProtocolGame::parseSupplyStash(const InputMessagePtr& msg)

--- a/src/client/spritemanager.h
+++ b/src/client/spritemanager.h
@@ -54,6 +54,7 @@ public:
     int spriteSize() { return m_spriteSize; }
     float getOffsetFactor() const { return static_cast<float>(m_spriteSize) / 32.0f; }
     bool isHdMod() const { return m_isHdMod; }
+    bool isUsingProtobuf() const { return m_isHdMod; }
     void setScaleFactor(int factor);
     int getScaleFactor() { return m_scaleFactor; }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Novos Recursos**
  * Adicionado modo HD ao minimapa, com renderização aprimorada, carregamento de mapa pré-instalado e salvamento automático por jogador.
  * Incluído botão “HD” no minimapa para alternar o modo em tempo real.
  * Adicionado suporte a atualizações de feitiços de stance recebidas do servidor.
  * O minimapa mantém o modo convencional quando o HD está desativado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an optional sprite-rendered HD minimap with background rendering, per-floor persistence, bundled map loading, and a UI toggle, while also introducing stance-protocol state handling.
- Adds a six-thread HD block rendering pipeline, texture lifecycle management, and Lua bindings.
- Saves and restores per-tile item IDs through per-floor compressed HD OTMM files.
- Adds opcode 193 stance parsing and Lua accessors for active stance spell IDs.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until emptied HD tiles clear their stored item data and failed saves retain retryable dirty state.

Current tile-removal handling preserves stale objects in rendered and persisted minimap data, while file failures can mark unsaved floor data clean and prevent subsequent retries; the duplicate stance parser is additionally non-blocking maintenance debt.

**Files Needing Attention:** src/client/minimap.cpp, modules/game_protocol/protocol.lua, src/client/protocolgameparse.cpp

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/client/minimap.cpp | Implements HD rendering and persistence, but fails to clear item snapshots for emptied tiles and clears save-dirty state before durable writes. |
| src/client/minimap.h | Adds HD block state, render jobs, synchronization primitives, and worker/save thread ownership. |
| modules/game_minimap/minimap.lua | Adds HD-mode settings, toggle behavior, bundled minimap loading, and asynchronous persistence calls. |
| modules/game_protocol/protocol.lua | Adds stance state helpers and a Lua parser that shadows the newly added native parser. |
| src/client/protocolgameparse.cpp | Adds native stance packet parsing, although the Lua opcode callback consumes the same opcode first. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Live map tile update] --> B[Capture minimap colors and item IDs]
    B --> C[MinimapBlock item snapshot]
    C --> D[HD render queue]
    D --> E[Background sprite composition]
    E --> F[Main-thread texture upload]
    C --> G[Async per-floor HD OTMM save]
    G --> H[HD OTMM reload]
    H --> C
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/client/minimap.cpp:670-671
**Empty tiles retain stale items**

When an explored tile loses its last item, `setTileItems` is skipped, leaving the previous item IDs to be rendered and persisted so removed objects remain on the HD minimap.

```suggestion
        ptr->setTileItems(tileX, tileY, itemIds);
```

### Issue 2
src/client/minimap.cpp:1022-1024
**Dirty state clears before write**

When creating, compressing, flushing, or closing a floor file fails, these blocks have already been marked clean, causing later saves to skip the floor and permanently lose the affected HD minimap progress.

### Issue 3
modules/game_protocol/protocol.lua:847-874
**Lua parser shadows native parser**

This callback consumes opcode `0xC1` before the native switch runs, leaving the newly added C++ stance parser unreachable and creating duplicate protocol definitions that can diverge.

```suggestion

```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(minimap): HD minimap mode rendering..."](https://github.com/mateuzkl/astraclient/commit/1f2afa5cc65e8996f335d6347ca0f0214b93f29d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56243940)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->