### PR TITLE
Optimize UI index states and validate browse field

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1714,7 +1714,7 @@ void Game::answerModalDialog(uint32 dialog, int button, int choice)
 
 void Game::browseField(const Position& position)
 {
-    if(!canPerformGameAction())
+    if(!canPerformGameAction() || position.x == 0xFFFF)
         return;
     m_protocolGame->sendBrowseField(position);
 }

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -1523,11 +1523,16 @@ void UIWidget::updateChildrenIndexStates()
     if(m_destroyed)
         return;
 
+    int index = 1;
+    const UIWidgetPtr firstChild = getFirstChild();
+    const UIWidgetPtr lastChild = getLastChild();
+
     for(const UIWidgetPtr& child : m_children) {
-        child->updateState(Fw::FirstState);
-        child->updateState(Fw::MiddleState);
-        child->updateState(Fw::LastState);
-        child->updateState(Fw::AlternateState);
+        child->setState(Fw::FirstState, child == firstChild);
+        child->setState(Fw::MiddleState, child != firstChild && child != lastChild);
+        child->setState(Fw::LastState, child == lastChild);
+        child->setState(Fw::AlternateState, (index % 2) == 1);
+        ++index;
     }
 }
 

--- a/src/framework/ui/uiwidget.cpp
+++ b/src/framework/ui/uiwidget.cpp
@@ -1523,16 +1523,31 @@ void UIWidget::updateChildrenIndexStates()
     if(m_destroyed)
         return;
 
+    const UIWidgetList children = m_children;
+    const UIWidgetPtr firstChild = children.empty() ? nullptr : children.front();
+    const UIWidgetPtr lastChild = children.empty() ? nullptr : children.back();
     int index = 1;
-    const UIWidgetPtr firstChild = getFirstChild();
-    const UIWidgetPtr lastChild = getLastChild();
 
-    for(const UIWidgetPtr& child : m_children) {
+    for(const UIWidgetPtr& child : children) {
+        const bool alternate = (index++ % 2) == 1;
+        if(child->isDestroyed())
+            return;
+
         child->setState(Fw::FirstState, child == firstChild);
+        if(m_destroyed || child->isDestroyed())
+            return;
+
         child->setState(Fw::MiddleState, child != firstChild && child != lastChild);
+        if(m_destroyed || child->isDestroyed())
+            return;
+
         child->setState(Fw::LastState, child == lastChild);
-        child->setState(Fw::AlternateState, (index % 2) == 1);
-        ++index;
+        if(m_destroyed || child->isDestroyed())
+            return;
+
+        child->setState(Fw::AlternateState, alternate);
+        if(m_destroyed || child->isDestroyed())
+            return;
     }
 }
 


### PR DESCRIPTION
## Summary

This PR improves UI child-state updates and adds a safety check for Browse Field requests.

The changes are intentionally small and isolated: one reduces unnecessary work when recalculating UI index-based states, while the other prevents invalid virtual/container positions from being sent as Browse Field requests.

## Changes

### UI child index state optimization

`UIWidget::updateChildrenIndexStates()` previously called `updateState()` four times for every child to recalculate:

- `FirstState`
- `MiddleState`
- `LastState`
- `AlternateState`

The function now resolves the first and last child once, tracks the current index during the same iteration, and applies the resulting states directly with `setState()`.

This keeps the same state semantics while avoiding repeated index/parent lookups during a full child-state refresh.

The resulting behavior remains:

- first child → `FirstState`
- children between first and last → `MiddleState`
- last child → `LastState`
- odd child positions → `AlternateState`

This is especially useful for widgets that frequently add, remove, or reorder many children, such as lists, containers, bot/configuration interfaces, and other dynamic UI elements.

### Browse Field position validation

`Game::browseField()` now rejects positions where `position.x == 0xFFFF` before sending the request to the protocol layer.

`0xFFFF` is used by the client for virtual item positions such as inventory/container locations rather than normal map tiles. Browse Field is intended for map positions, so sending a request for one of these virtual positions is invalid.

The new guard prevents these invalid requests from reaching `ProtocolGame::sendBrowseField()`.

## Why

The UI change reduces unnecessary work in a frequently reused framework function without changing its visible behavior.

The Browse Field change adds defensive validation at the game-action boundary, preventing a malformed/invalid position from being serialized and sent to the server.

## Compatibility

- No protocol format changes.
- No Lua API changes.
- No OTUI syntax changes.
- Existing state names and styling behavior are preserved.
- Valid Browse Field requests are unaffected.
- The Browse Field guard only rejects virtual positions with `x == 0xFFFF`.

## Files changed

- `src/framework/ui/uiwidget.cpp`
- `src/client/game.cpp`

## Testing / validation

Recommended validation:

- Open and update UI lists with multiple children and verify first/middle/last/alternate styles remain correct.
- Add/remove/reorder children and verify alternating styles update correctly.
- Verify normal Browse Field requests on map tiles still work.
- Verify inventory/container virtual positions do not generate Browse Field requests.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR optimizes child index-state refreshes and prevents Browse Field requests for virtual positions.
- Replaces repeated index-state lookups with direct state calculations over a child snapshot.
- Rejects positions marked as inventory or container locations before protocol serialization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/framework/ui/uiwidget.cpp | Directly computes first, middle, last, and alternating child states while preserving the established static-state semantics. |
| src/client/game.cpp | Adds a guard preventing virtual inventory and container positions from reaching the Browse Field protocol request. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Guard UI child state callbacks"](https://github.com/mateuzkl/astraclient/commit/e6c4141327c9a7f704e1791cdcff066c3e8fb0ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57197219)</sub>

<!-- /greptile_comment -->