### PR TITLE
fix(mapview): sync floor rendering range and preserve central position

### DIFF
--- a/src/client/map.cpp
+++ b/src/client/map.cpp
@@ -595,16 +595,18 @@ void Map::setCentralPosition(const Position& centralPosition)
     // this fixes local player position when the local player is removed from the map,
     // the local player is removed from the map when there are too many creatures on his tile,
     // so there is no enough stackpos to the server send him
-    g_dispatcher.addEvent([this] {
+    const Position capturedCentralPosition = m_centralPosition;
+
+    g_dispatcher.addEvent([capturedCentralPosition] {
         LocalPlayerPtr localPlayer = g_game.getLocalPlayer();
-        if(!localPlayer || localPlayer->getPosition() == m_centralPosition)
+        if(!localPlayer || localPlayer->getPosition() == capturedCentralPosition)
             return;
         TilePtr tile = localPlayer->getTile();
         if(tile && tile->hasThing(localPlayer))
             return;
 
         Position oldPos = localPlayer->getPosition();
-        Position pos = m_centralPosition;
+        Position pos = capturedCentralPosition;
         if(oldPos != pos) {
             if(!localPlayer->isRemoved())
                 localPlayer->onDisappear();

--- a/src/client/mapview.cpp
+++ b/src/client/mapview.cpp
@@ -135,15 +135,13 @@ void MapView::drawMapBackground(const Rect& rect, const TilePtr& crosshairTile) 
                                                   std::max<int>(m_minimumAmbientLight * 255, ambientLight.intensity));
     }
 
-    for (int z = m_cachedLastVisibleFloor; z >= m_cachedFirstFadingFloor; --z) {
+    int firstFloor = m_floorFading > 0 ? m_cachedFirstFadingFloor : m_cachedFirstVisibleFloor;
+    for (int z = m_cachedLastVisibleFloor; z >= firstFloor; --z) {
         float fading = 1.0;
         if (m_floorFading > 0) {
-            fading = 0.;
-            if (m_floorFading > 0) {
-                fading = stdext::clamp<float>((float)m_fadingFloorTimers[z].elapsed_millis() / (float)m_floorFading, 0.f, 1.f);
-                if (z < m_cachedFirstVisibleFloor)
-                    fading = 1.0 - fading;
-            }
+            fading = stdext::clamp<float>((float)m_fadingFloorTimers[z].elapsed_millis() / (float)m_floorFading, 0.f, 1.f);
+            if (z < m_cachedFirstVisibleFloor)
+                fading = 1.0 - fading;
             if (fading == 0) break;
         }
 


### PR DESCRIPTION
## Summary

Fixes magic effects from a previous floor remaining visible after changing floors, especially when moving from `z=6` to `z=7`.

The fix keeps normal multifloor rendering intact while making the render range match the actual visible-floor range when floor fading is disabled. It also makes the deferred central-position correction use the position that belonged to that specific update instead of reading a newer mutable map center later.

## Root cause

`MapView::drawMapBackground()` always rendered starting from `m_cachedFirstFadingFloor`, even when `m_floorFading == 0`.

`m_cachedFirstFadingFloor` is intentionally broader than `m_cachedFirstVisibleFloor` because it exists to support floor transition/fading. With fading disabled, that broader range was still being rendered. As a result, a tile from the previous/upper floor could remain in the draw pass, and any magic effect stored in that tile's effect list was rendered by `drawFloor()` / `Tile::drawTop()` over the current floor.

In practice:

```text
player/effect on z=6
        ↓
player moves to z=7
        ↓
render loop still includes the fading floor range
        ↓
z=6 tile is drawn
        ↓
its magic effect is drawn on the z=7 view
```

This is why the effect appeared to "leak" between floors even though the effect itself still belonged to the correct `z` position.

There was also a synchronization issue in `Map::setCentralPosition()`: the deferred callback captured `this` and read `m_centralPosition` only when the event executed. If another map-center update happened first, the callback could use a newer position than the update that scheduled it.

## Fix

- When floor fading is enabled, continue rendering from `m_cachedFirstFadingFloor`.
- When floor fading is disabled, render only from `m_cachedFirstVisibleFloor`.
- Capture `m_centralPosition` by value before scheduling the deferred player-position correction.

```cpp
int firstFloor = m_floorFading > 0
    ? m_cachedFirstFadingFloor
    : m_cachedFirstVisibleFloor;
```

and:

```cpp
const Position capturedCentralPosition = m_centralPosition;
g_dispatcher.addEvent([capturedCentralPosition] {
    // use the position belonging to this update
});
```

## Result

- Magic effects no longer leak from the previous floor after a floor change.
- Normal multifloor map rendering is preserved.
- Floor fading behavior remains available when enabled.
- Deferred central-position updates can no longer accidentally use a newer map center.

Confirmed fixed in-game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções**
  - Corrigido o reposicionamento do jogador no mapa para usar a posição central válida no momento do agendamento, evitando resultados inconsistentes após alterações subsequentes.
  - Ajustado o desenho do fundo do mapa para iniciar no primeiro piso relevante, melhorando a exibição de pisos visíveis e efeitos de desvanecimento.
  - Preservado o comportamento de interrupção da renderização quando o efeito de desvanecimento termina.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR synchronizes map background rendering with the cached floor range and captures each central position by value for deferred local-player updates.
- Uses the first visible floor when floor fading is disabled.
- Preserves the position associated with each queued central-position update.
- Avoids capturing the `Map` instance in the deferred callback.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or quality issues identified.

The deferred position callbacks retain FIFO ordering and finish at the latest position, while the revised non-fading floor bound matches the tile cache’s existing population range.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/client/map.cpp | Captures the central position by value so deferred local-player synchronization uses the position associated with that update. |
| src/client/mapview.cpp | Aligns the non-fading background draw range with the visible-floor range used to populate the tile cache. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mapview): sync floor rendering range..."](https://github.com/mateuzkl/astraclient/commit/4e95b00782116f9b199c254274b45f1073cdffec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61067101)</sub>

<!-- /greptile_comment -->