### PR TITLE
Fix ScheduledEvent 64-bit deadline truncation

### DIFF
--- a/src/framework/core/scheduledevent.h
+++ b/src/framework/core/scheduledevent.h
@@ -35,8 +35,8 @@ public:
     void execute();
     bool nextCycle();
 
-    int ticks() { return m_ticks; }
-    int remainingTicks() { return m_ticks - g_clock.millis(); }
+    ticks_t ticks() { return m_ticks; }
+    ticks_t remainingTicks() { return m_ticks - g_clock.millis(); }
     int delay() { return m_delay; }
     int cyclesExecuted() { return m_cyclesExecuted; }
     int maxCycles() { return m_maxCycles; }


### PR DESCRIPTION
## Problem

`ScheduledEvent` stores deadlines in `ticks_t` (64-bit), but `ticks()` and `remainingTicks()` returned `int` (32-bit). When an absolute deadline crossed `INT_MAX`, the value could be truncated and corrupt the priority-queue ordering.

Because `EventDispatcher::poll()` only inspects the event at the top and stops when that event is still in the future, a long event ordered incorrectly could block shorter scheduled events behind it. This could delay scheduled removals/updates used by effects and texts.

## Fix

Preserve the full 64-bit deadline width:

```diff
- int ticks()
- int remainingTicks()
+ ticks_t ticks()
+ ticks_t remainingTicks()
```

No other scheduler semantics were changed.

## Validation

- DirectX x64 build: passed.
- Real `INT_MAX` delay + short scheduled event test: passed.
- Boundary tests passed for `0`, `1`, `20`, `10000`, `INT_MAX - 1000`, `INT_MAX - 1`, and `INT_MAX`.
- The short event executes normally while the long event remains pending.

## Notes

The scheduler bug itself is confirmed and fixed. A natural gameplay caller that spontaneously generates a very large delay was not found, so this PR does not claim that every visual effect/text issue in production came from this one bug.