### PR TITLE
fix(ui): robust bindAutoPress lifecycle, debounce and blink fixes

### DIFF
--- a/modules/corelib/mouse.lua
+++ b/modules/corelib/mouse.lua
@@ -12,6 +12,9 @@ function g_mouse.bindAutoPress(widget, callback, delay, button, loopingDelay)
   if loopingDelay == nil then
     loopingDelay = 30
   end
+  if delay == nil then
+    delay = loopingDelay
+  end
 
   -- Ensure per-widget state table exists
   if not widget._autoPressState then

--- a/modules/corelib/mouse.lua
+++ b/modules/corelib/mouse.lua
@@ -1,23 +1,117 @@
 -- @docclass
+
+-- Per-widget autopress state, keyed by widget then by mouse button.
+-- Stored on the widget itself as widget._autoPressState[button].
+-- Each entry: { generation = number, repeatEvent = eventHandle,
+--               onPress = func, onRelease = func, onDestroy = func }
+
 function g_mouse.bindAutoPress(widget, callback, delay, button, loopingDelay)
-  if not loopingDelay then
+  if not widget then return end
+
+  button = button or MouseLeftButton
+  if loopingDelay == nil then
     loopingDelay = 30
   end
 
-  local button = button or MouseLeftButton
-  connect(widget, { onMousePress = function(widget, mousePos, mouseButton)
+  -- Ensure per-widget state table exists
+  if not widget._autoPressState then
+    widget._autoPressState = {}
+  end
+
+  -- If there is a previous binding for this button, disconnect it first (idempotent)
+  local prev = widget._autoPressState[button]
+  if prev then
+    -- Cancel any pending repeat
+    removeEvent(prev.repeatEvent)
+    prev.repeatEvent = nil
+    prev.generation = prev.generation + 1 -- invalidate stale callbacks
+    -- Disconnect old handlers
+    disconnect(widget, { onMousePress = prev.onPress })
+    disconnect(widget, { onMouseRelease = prev.onRelease })
+    disconnect(widget, { onDestroy = prev.onDestroy })
+    widget._autoPressState[button] = nil
+  end
+
+  local state = {
+    generation = 0,
+    repeatEvent = nil
+  }
+
+  -- Press handler: immediate callback + schedule first repeat after delay
+  local function onPress(w, mousePos, mouseButton)
     if mouseButton ~= button then
       return false
     end
+
+    -- Invalidate any lingering callback from a previous press
+    state.generation = state.generation + 1
+    removeEvent(state.repeatEvent)
+    state.repeatEvent = nil
+
+    local gen = state.generation
     local startTime = g_clock.millis()
-    callback(widget, mousePos, mouseButton, 0)
-    periodicalEvent(function()
-      callback(widget, g_window.getMousePosition(), mouseButton, g_clock.millis() - startTime)
-    end, function()
-      return g_mouse.isPressed(mouseButton)
-    end, loopingDelay, delay)
+
+    -- Immediate callback
+    callback(w, mousePos, mouseButton, 0)
+
+    -- Schedule repeats using explicit scheduleEvent handles
+    local function doRepeat()
+      -- Guard: stale generation
+      if gen ~= state.generation then
+        return
+      end
+      -- Guard: widget destroyed
+      if not w or w:isDestroyed() then
+        state.repeatEvent = nil
+        return
+      end
+      -- Guard: mouse button no longer pressed
+      if not g_mouse.isPressed(mouseButton) then
+        state.repeatEvent = nil
+        return
+      end
+
+      callback(w, g_window.getMousePosition(), mouseButton, g_clock.millis() - startTime)
+
+      -- Schedule next repeat at loopingDelay
+      if gen == state.generation then
+        state.repeatEvent = scheduleEvent(doRepeat, loopingDelay)
+      end
+    end
+
+    -- First repeat after the initial delay
+    state.repeatEvent = scheduleEvent(doRepeat, delay)
     return true
-  end })
+  end
+
+  -- Release handler: cancel pending repeat, invalidate generation
+  local function onRelease(w, mousePos, mouseButton)
+    if mouseButton ~= button then
+      return false
+    end
+
+    state.generation = state.generation + 1
+    removeEvent(state.repeatEvent)
+    state.repeatEvent = nil
+    return false
+  end
+
+  -- Destroy handler: full cleanup
+  local function onDestroy(w)
+    state.generation = state.generation + 1
+    removeEvent(state.repeatEvent)
+    state.repeatEvent = nil
+  end
+
+  -- Save references for idempotent disconnect
+  state.onPress = onPress
+  state.onRelease = onRelease
+  state.onDestroy = onDestroy
+  widget._autoPressState[button] = state
+
+  connect(widget, { onMousePress = onPress })
+  connect(widget, { onMouseRelease = onRelease })
+  connect(widget, { onDestroy = onDestroy })
 end
 
 function g_mouse.bindPressMove(widget, callback)

--- a/modules/corelib/ui/effects.lua
+++ b/modules/corelib/ui/effects.lua
@@ -2,6 +2,10 @@
 g_effects = {}
 
 function g_effects.fadeIn(widget, time, elapsed)
+  if not widget or widget:isDestroyed() then
+    return
+  end
+
   if not elapsed then elapsed = 0 end
   if not time then time = 300 end
   widget:setOpacity(math.min(elapsed/time, 1))
@@ -16,6 +20,10 @@ function g_effects.fadeIn(widget, time, elapsed)
 end
 
 function g_effects.fadeOut(widget, time, elapsed, hideOnFinish)
+  if not widget or widget:isDestroyed() then
+    return
+  end
+
   if not elapsed then elapsed = 0 end
   if not time then time = 300 end
 
@@ -37,6 +45,10 @@ function g_effects.fadeOut(widget, time, elapsed, hideOnFinish)
 end
 
 function g_effects.cancelFade(widget)
+  if not widget or widget:isDestroyed() then
+    return
+  end
+
   removeEvent(widget.fadeEvent)
   widget.fadeEvent = nil
 end
@@ -93,6 +105,10 @@ function g_effects.cancelMove(widget)
 end
 
 function g_effects.startBlink(widget, duration, interval, clickCancel)
+  if not widget or widget:isDestroyed() then
+    return
+  end
+
   duration = duration or 0 -- until stop is called
   interval = interval or 500
   if clickCancel == nil then
@@ -104,11 +120,6 @@ function g_effects.startBlink(widget, duration, interval, clickCancel)
 
   widget.blinkEvent = cycleEvent(function()
     if not widget or widget:isDestroyed() then
-      -- Cancel the recurring event so it stops polling
-      removeEvent(widget.blinkEvent)
-      widget.blinkEvent = nil
-      removeEvent(widget.blinkStopEvent)
-      widget.blinkStopEvent = nil
       return
     end
     widget:setOn(not widget:isOn())
@@ -116,7 +127,9 @@ function g_effects.startBlink(widget, duration, interval, clickCancel)
 
   if duration > 0 then
     widget.blinkStopEvent = scheduleEvent(function()
-      if not widget or widget:isDestroyed() then return end
+      if not widget or widget:isDestroyed() then
+        return
+      end
       g_effects.stopBlink(widget)
     end, duration)
   end
@@ -127,40 +140,44 @@ function g_effects.startBlink(widget, duration, interval, clickCancel)
   end
 
   -- Install onDestroy to cancel events when widget is destroyed
-  widget._blinkOnDestroy = function()
+  local function onDestroy()
     removeEvent(widget.blinkEvent)
     removeEvent(widget.blinkStopEvent)
-    widget.blinkEvent = nil
-    widget.blinkStopEvent = nil
-    widget._blinkClickCancel = nil
-    widget._blinkOnDestroy = nil
   end
-  connect(widget, { onDestroy = widget._blinkOnDestroy })
+  widget._blinkOnDestroy = onDestroy
+  connect(widget, { onDestroy = onDestroy })
 end
 
 function g_effects.stopBlink(widget)
-  if not widget then return end
+  if not widget or widget:isDestroyed() then
+    return
+  end
+
   -- Cancel events before any widget-state operations
   removeEvent(widget.blinkEvent)
   removeEvent(widget.blinkStopEvent)
   widget.blinkEvent = nil
   widget.blinkStopEvent = nil
-  -- Disconnect handlers (only if widget is still alive)
-  if not widget:isDestroyed() then
-    if widget._blinkClickCancel then
-      disconnect(widget, { onClick = g_effects.stopBlink })
-    end
-    if widget._blinkOnDestroy then
-      disconnect(widget, { onDestroy = widget._blinkOnDestroy })
-    end
-    widget:setOn(false)
+
+  -- Disconnect handlers while widget is still alive
+  if widget._blinkClickCancel then
+    disconnect(widget, { onClick = g_effects.stopBlink })
   end
   widget._blinkClickCancel = nil
-  widget._blinkOnDestroy = nil
+
+  if widget._blinkOnDestroy then
+    disconnect(widget, { onDestroy = widget._blinkOnDestroy })
+    widget._blinkOnDestroy = nil
+  end
+
+  widget:setOn(false)
 end
 
 function g_effects.startBorderBlink(widget, duration, interval, size)
-  if not widget or widget:isDestroyed() then return end
+  if not widget or widget:isDestroyed() then
+    return
+  end
+
   duration = duration or 250
   interval = interval or 500
 
@@ -169,11 +186,6 @@ function g_effects.startBorderBlink(widget, duration, interval, size)
 
   widget.borderBlinkEvent = cycleEvent(function()
     if not widget or widget:isDestroyed() then
-      -- Cancel the recurring event so it stops polling
-      removeEvent(widget.borderBlinkEvent)
-      widget.borderBlinkEvent = nil
-      removeEvent(widget.borderBlinkStopEvent)
-      widget.borderBlinkStopEvent = nil
       return
     end
     widget:setBorderWidth(widget:getBorderLeftWidth() == 0 and size or 0)
@@ -181,35 +193,40 @@ function g_effects.startBorderBlink(widget, duration, interval, size)
 
   if duration > 0 then
     widget.borderBlinkStopEvent = scheduleEvent(function()
-      if not widget or widget:isDestroyed() then return end
+      if not widget or widget:isDestroyed() then
+        return
+      end
       g_effects.stopBorderBlink(widget, size)
     end, duration)
   end
 
   -- Install onDestroy to cancel events when widget is destroyed
-  widget._borderBlinkOnDestroy = function()
+  local function onDestroy()
     removeEvent(widget.borderBlinkEvent)
     removeEvent(widget.borderBlinkStopEvent)
-    widget.borderBlinkEvent = nil
-    widget.borderBlinkStopEvent = nil
-    widget._borderBlinkOnDestroy = nil
   end
-  connect(widget, { onDestroy = widget._borderBlinkOnDestroy })
+  widget._borderBlinkOnDestroy = onDestroy
+  connect(widget, { onDestroy = onDestroy })
 end
 
 function g_effects.stopBorderBlink(widget, defaultSize)
-  if not widget then return end
+  if not widget or widget:isDestroyed() then
+    return
+  end
+
   -- Cancel events before any widget-state operations
   removeEvent(widget.borderBlinkEvent)
   removeEvent(widget.borderBlinkStopEvent)
   widget.borderBlinkEvent = nil
   widget.borderBlinkStopEvent = nil
-  -- Widget-state operations only if still alive
-  if not widget:isDestroyed() then
-    if widget._borderBlinkOnDestroy then
-      disconnect(widget, { onDestroy = widget._borderBlinkOnDestroy })
-    end
+
+  -- Disconnect handlers while widget is still alive
+  if widget._borderBlinkOnDestroy then
+    disconnect(widget, { onDestroy = widget._borderBlinkOnDestroy })
+    widget._borderBlinkOnDestroy = nil
+  end
+
+  if defaultSize ~= nil then
     widget:setBorderWidth(defaultSize)
   end
-  widget._borderBlinkOnDestroy = nil
 end

--- a/modules/corelib/ui/effects.lua
+++ b/modules/corelib/ui/effects.lua
@@ -103,7 +103,14 @@ function g_effects.startBlink(widget, duration, interval, clickCancel)
   g_effects.stopBlink(widget)
 
   widget.blinkEvent = cycleEvent(function()
-    if not widget or widget:isDestroyed() then return end
+    if not widget or widget:isDestroyed() then
+      -- Cancel the recurring event so it stops polling
+      removeEvent(widget.blinkEvent)
+      widget.blinkEvent = nil
+      removeEvent(widget.blinkStopEvent)
+      widget.blinkStopEvent = nil
+      return
+    end
     widget:setOn(not widget:isOn())
   end, interval)
 
@@ -118,19 +125,38 @@ function g_effects.startBlink(widget, duration, interval, clickCancel)
   if clickCancel then
     connect(widget, { onClick = g_effects.stopBlink })
   end
+
+  -- Install onDestroy to cancel events when widget is destroyed
+  widget._blinkOnDestroy = function()
+    removeEvent(widget.blinkEvent)
+    removeEvent(widget.blinkStopEvent)
+    widget.blinkEvent = nil
+    widget.blinkStopEvent = nil
+    widget._blinkClickCancel = nil
+    widget._blinkOnDestroy = nil
+  end
+  connect(widget, { onDestroy = widget._blinkOnDestroy })
 end
 
 function g_effects.stopBlink(widget)
-  if not widget or widget:isDestroyed() then return end
-  if widget._blinkClickCancel then
-    disconnect(widget, { onClick = g_effects.stopBlink })
-  end
+  if not widget then return end
+  -- Cancel events before any widget-state operations
   removeEvent(widget.blinkEvent)
   removeEvent(widget.blinkStopEvent)
   widget.blinkEvent = nil
   widget.blinkStopEvent = nil
+  -- Disconnect handlers (only if widget is still alive)
+  if not widget:isDestroyed() then
+    if widget._blinkClickCancel then
+      disconnect(widget, { onClick = g_effects.stopBlink })
+    end
+    if widget._blinkOnDestroy then
+      disconnect(widget, { onDestroy = widget._blinkOnDestroy })
+    end
+    widget:setOn(false)
+  end
   widget._blinkClickCancel = nil
-  widget:setOn(false)
+  widget._blinkOnDestroy = nil
 end
 
 function g_effects.startBorderBlink(widget, duration, interval, size)
@@ -142,7 +168,14 @@ function g_effects.startBorderBlink(widget, duration, interval, size)
   g_effects.stopBorderBlink(widget, size)
 
   widget.borderBlinkEvent = cycleEvent(function()
-    if not widget or widget:isDestroyed() then return end
+    if not widget or widget:isDestroyed() then
+      -- Cancel the recurring event so it stops polling
+      removeEvent(widget.borderBlinkEvent)
+      widget.borderBlinkEvent = nil
+      removeEvent(widget.borderBlinkStopEvent)
+      widget.borderBlinkStopEvent = nil
+      return
+    end
     widget:setBorderWidth(widget:getBorderLeftWidth() == 0 and size or 0)
   end, interval)
 
@@ -152,13 +185,32 @@ function g_effects.startBorderBlink(widget, duration, interval, size)
       g_effects.stopBorderBlink(widget, size)
     end, duration)
   end
+
+  -- Install onDestroy to cancel events when widget is destroyed
+  widget._borderBlinkOnDestroy = function()
+    removeEvent(widget.borderBlinkEvent)
+    removeEvent(widget.borderBlinkStopEvent)
+    widget.borderBlinkEvent = nil
+    widget.borderBlinkStopEvent = nil
+    widget._borderBlinkOnDestroy = nil
+  end
+  connect(widget, { onDestroy = widget._borderBlinkOnDestroy })
 end
 
 function g_effects.stopBorderBlink(widget, defaultSize)
-  if not widget or widget:isDestroyed() then return end
+  if not widget then return end
+  -- Cancel events before any widget-state operations
   removeEvent(widget.borderBlinkEvent)
   removeEvent(widget.borderBlinkStopEvent)
   widget.borderBlinkEvent = nil
   widget.borderBlinkStopEvent = nil
-  widget:setBorderWidth(defaultSize)
+  -- Widget-state operations only if still alive
+  if not widget:isDestroyed() then
+    if widget._borderBlinkOnDestroy then
+      disconnect(widget, { onDestroy = widget._borderBlinkOnDestroy })
+    end
+    widget:setBorderWidth(defaultSize)
+  end
+  widget._borderBlinkOnDestroy = nil
 end
+

--- a/modules/corelib/ui/effects.lua
+++ b/modules/corelib/ui/effects.lua
@@ -7,7 +7,6 @@ function g_effects.fadeIn(widget, time, elapsed)
   widget:setOpacity(math.min(elapsed/time, 1))
   removeEvent(widget.fadeEvent)
   if elapsed < time then
-    removeEvent(widget.fadeEvent)
     widget.fadeEvent = scheduleEvent(function()
       g_effects.fadeIn(widget, time, elapsed + 30)
     end, 30)
@@ -96,55 +95,70 @@ end
 function g_effects.startBlink(widget, duration, interval, clickCancel)
   duration = duration or 0 -- until stop is called
   interval = interval or 500
-  clickCancel = clickCancel or true
+  if clickCancel == nil then
+    clickCancel = true
+  end
 
-  removeEvent(widget.blinkEvent)
-  removeEvent(widget.blinkStopEvent)
+  -- Stop any previous blink cleanly before starting a new one
+  g_effects.stopBlink(widget)
 
   widget.blinkEvent = cycleEvent(function()
+    if not widget or widget:isDestroyed() then return end
     widget:setOn(not widget:isOn())
   end, interval)
 
   if duration > 0 then
     widget.blinkStopEvent = scheduleEvent(function()
+      if not widget or widget:isDestroyed() then return end
       g_effects.stopBlink(widget)
     end, duration)
   end
 
-  connect(widget, { onClick = g_effects.stopBlink })
+  widget._blinkClickCancel = clickCancel
+  if clickCancel then
+    connect(widget, { onClick = g_effects.stopBlink })
+  end
 end
 
 function g_effects.stopBlink(widget)
-  disconnect(widget, { onClick = g_effects.stopBlink })
+  if not widget or widget:isDestroyed() then return end
+  if widget._blinkClickCancel then
+    disconnect(widget, { onClick = g_effects.stopBlink })
+  end
   removeEvent(widget.blinkEvent)
   removeEvent(widget.blinkStopEvent)
   widget.blinkEvent = nil
   widget.blinkStopEvent = nil
+  widget._blinkClickCancel = nil
   widget:setOn(false)
 end
 
 function g_effects.startBorderBlink(widget, duration, interval, size)
+  if not widget or widget:isDestroyed() then return end
   duration = duration or 250
   interval = interval or 500
 
-  removeEvent(widget.borderBlinkEvent)
-  removeEvent(widget.borderBlinkStopEvent)
+  -- Stop previous border blink cleanly
+  g_effects.stopBorderBlink(widget, size)
 
   widget.borderBlinkEvent = cycleEvent(function()
+    if not widget or widget:isDestroyed() then return end
     widget:setBorderWidth(widget:getBorderLeftWidth() == 0 and size or 0)
   end, interval)
 
   if duration > 0 then
     widget.borderBlinkStopEvent = scheduleEvent(function()
+      if not widget or widget:isDestroyed() then return end
       g_effects.stopBorderBlink(widget, size)
     end, duration)
   end
 end
 
 function g_effects.stopBorderBlink(widget, defaultSize)
+  if not widget or widget:isDestroyed() then return end
   removeEvent(widget.borderBlinkEvent)
   removeEvent(widget.borderBlinkStopEvent)
   widget.borderBlinkEvent = nil
   widget.borderBlinkStopEvent = nil
-  widget:setBorderWidth(defaultSize)  
+  widget:setBorderWidth(defaultSize)
 end

--- a/modules/corelib/ui/effects.lua
+++ b/modules/corelib/ui/effects.lua
@@ -213,4 +213,3 @@ function g_effects.stopBorderBlink(widget, defaultSize)
   end
   widget._borderBlinkOnDestroy = nil
 end
-

--- a/modules/corelib/ui/uispinbox.lua
+++ b/modules/corelib/ui/uispinbox.lua
@@ -44,7 +44,13 @@ function UISpinBox:onKeyPress()
     self:setText('')
   end
 
-  scheduleEvent(function() self.firstchange = true end, 800)
+  removeEvent(self.firstChangeEvent)
+  self.firstChangeEvent = scheduleEvent(function()
+    if not self:isDestroyed() then
+      self.firstchange = true
+      self.firstChangeEvent = nil
+    end
+  end, 800)
   return false
 end
 


### PR DESCRIPTION
## Summary

Fixes a UI event-lifecycle bug where old `g_mouse.bindAutoPress()` repeat callbacks could survive a mouse release and fire during a later click, causing controls to increment/decrement multiple times from a single click.

This PR also fixes related timer/debounce and blink-state issues in core UI helpers.

## Root cause

`g_mouse.bindAutoPress()` previously used `periodicalEvent()`. The initial callback ran immediately, but the scheduled repeat had no owned event handle that `bindAutoPress()` could cancel on mouse release.

As a result, a callback created by an earlier click could wake up during a later click. Because the old implementation only checked whether the mouse button was currently pressed, the stale callback could incorrectly treat the new click as part of the old press.

Typical symptom:

```text
single click -> +2 / +3 / +4 instead of +1
```

This affected controls using auto-press behavior, including scrollbars, spin boxes, Game Helper controls and other buttons using `g_mouse.bindAutoPress()`.

## Changes

### `modules/corelib/mouse.lua`

- Reworked `g_mouse.bindAutoPress()` to own explicit `scheduleEvent()` handles.
- Added per-binding state and a generation token to invalidate stale callbacks.
- Cancels pending repeat events on `onMouseRelease`.
- Cancels active repeat state on `onDestroy`.
- Adds destroyed-widget checks before repeat callbacks.
- Makes repeated bindings for the same widget/button idempotent by disconnecting the previous handlers before installing new ones.
- Preserves existing behavior:
  - callback fires immediately on press;
  - first repeat waits for `delay`;
  - following repeats use `loopingDelay`.

### `modules/corelib/ui/uispinbox.lua`

- Converts `UISpinBox:onKeyPress()` into a real debounce.
- Cancels the previous 800 ms event before scheduling a new one.
- Prevents an older keypress timer from resetting `firstchange` while the user is still typing.
- Adds a destroyed-widget guard to the delayed callback.

### `modules/corelib/ui/effects.lua`

- Fixes `clickCancel = false` in `g_effects.startBlink()`; previously `clickCancel = clickCancel or true` forced `false` back to `true`.
- Only connects the blink click-cancel handler when requested.
- Cleans up the click handler consistently when stopping blink.
- Adds destroyed-widget guards to blink/border-blink callbacks.
- Stops an existing blink/border-blink before starting a replacement.
- Removes a duplicated `removeEvent(widget.fadeEvent)` call in `fadeIn()`.

## Expected behavior

### Auto press

```text
press -> immediate callback -> delay -> repeat -> loopingDelay -> repeat...
release/destroy -> pending repeat cancelled + generation invalidated
```

Fast separate clicks must remain separate: an event created by Click #1 must never execute as part of Click #2.

### Spin box

Each keypress resets the debounce timer, so only the most recent timer can restore `firstchange`.

### Blink

`clickCancel = true` keeps the existing click-to-stop behavior, while `clickCancel = false` now correctly leaves the blink active after a click.

## Scope

Changed files only:

- `modules/corelib/mouse.lua`
- `modules/corelib/ui/effects.lua`
- `modules/corelib/ui/uispinbox.lua`

No protocol, networking, game logic or asset behavior is changed.

## Validation

- Repository Content validation workflow passes on this PR head.
- PR is currently mergeable.

Manual regression testing should cover single clicks, rapid clicks, hold/repeat, release-before-delay, widget destruction/reload, spin-box typing and blink start/stop behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Melhorada a reconfiguração e o cancelamento de cliques automáticos, evitando repetições obsoletas e preservando o estado correto dos botões.
  * Efeitos de fade e piscar agora lidam com segurança com widgets destruídos e cancelamentos anteriores.
  * O piscar pode ser cancelado ao clicar, conforme configuração.
  * Corrigido o reset de alterações no controle numérico para evitar eventos atrasados em widgets destruídos.
  * O atraso padrão de repetição agora utiliza o atraso de loop quando não informado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->