### PR TITLE
fix(items): guard stale rarity widgets after relog

### DIFF
--- a/mods/game_store/store.lua
+++ b/mods/game_store/store.lua
@@ -491,10 +491,10 @@ end
 function onStoreTransactionHistory(currentPage, pageCount, offers)
   Store.ensureWindow()
 
+  Offers:stopAllEvents()
   if Offers.displayPanel then
     Offers.displayPanel:destroy()
   end
-  Offers:stopAllEvents()
 
   Offers.displayPanel = g_ui.createWidget('HistoryPanel', StoreWindow.contentPanel)
   Offers.displayPanel:setId("history")
@@ -513,34 +513,49 @@ function onStoreTransactionHistory(currentPage, pageCount, offers)
     end
   end
 
-  for _, child in pairs(Offers.displayPanel.historyListPanel:getChildren()) do
-    child:destroy()
-    child = nil
-  end
-
+  local displayPanel = Offers.displayPanel
+  local generation = Offers.buildGeneration
+  local nextOfferIndex = 1
   local count = 0
-  for key, item in pairs(offers) do
-    local itemBox = g_ui.createWidget('HistoryLabel', Offers.displayPanel.historyListPanel)
-    local color = (count % 2) == 0 and '#484848' or '#414141'
-    itemBox:setBackgroundColor(color)
-
-    if count == 0 then
-      itemBox:setMarginTop(16)
+  local function renderNextHistoryBatch()
+    if generation ~= Offers.buildGeneration or Offers.displayPanel ~= displayPanel then
+      return
     end
 
-    count = count + 1
-    itemBox.date:setText(short_text(item.description, 20))
-    itemBox.date.desc:setTooltip(item.description)
-    if item.price < 0 then
-      itemBox.balance:setText(item.price)
-      itemBox.balance:setColor("$var-text-cip-store-red")
+    local lastOfferIndex = math.min(nextOfferIndex + 3, #offers)
+    while nextOfferIndex <= lastOfferIndex do
+      local item = offers[nextOfferIndex]
+      local itemBox = g_ui.createWidget('HistoryLabel', displayPanel.historyListPanel)
+      local color = (count % 2) == 0 and '#484848' or '#414141'
+      itemBox:setBackgroundColor(color)
+
+      if count == 0 then
+        itemBox:setMarginTop(16)
+      end
+
+      count = count + 1
+      itemBox.date:setText(short_text(item.description, 20))
+      itemBox.date.desc:setTooltip(item.description)
+      if item.price < 0 then
+        itemBox.balance:setText(item.price)
+        itemBox.balance:setColor("$var-text-cip-store-red")
+      else
+        itemBox.balance:setText("+" .. item.price)
+        itemBox.balance:setColor("$var-text-cip-color-green")
+      end
+      itemBox.description:setText(short_text(item.name, 35))
+      itemBox.description.desc:setTooltip(item.name)
+      nextOfferIndex = nextOfferIndex + 1
+    end
+
+    if nextOfferIndex <= #offers then
+      Offers.loadOffersEvent = scheduleEvent(renderNextHistoryBatch, 1)
     else
-      itemBox.balance:setText("+" .. item.price)
-      itemBox.balance:setColor("$var-text-cip-color-green")
+      Offers.loadOffersEvent = nil
     end
-    itemBox.description:setText(short_text(item.name, 35))
-    itemBox.description.desc:setTooltip(item.name)
   end
+
+  Offers.loadOffersEvent = scheduleEvent(renderNextHistoryBatch, 1)
 
   if not StoreWindow:isVisible() then
     showStoreWindow()

--- a/modules/gamelib/items.lua
+++ b/modules/gamelib/items.lua
@@ -456,18 +456,20 @@ local function refreshTrackedRarityWidget(widget, expectedItemId)
   -- callback (notably while relogging or rebuilding the game panels). Even
   -- looking up a method on that stale userdata enters the C++ binding, so keep
   -- every widget access inside the protected call.
-  local ok, item = pcall(function()
+  local ok, refreshed = pcall(function()
     if (widget.isDestroyed and widget:isDestroyed()) or not widget.getItem then
-      return nil
+      return false
     end
-    return widget:getItem()
+    local item = widget:getItem()
+    if getRarityItemId(item) ~= expectedItemId then
+      return false
+    end
+    ItemsDatabase.setRarityItem(widget, item)
+    return true
   end)
-  if not ok or getRarityItemId(item) ~= expectedItemId then
+  if not ok or not refreshed then
     ItemsDatabase.untrackRarityWidget(widget)
-    return
   end
-
-  ItemsDatabase.setRarityItem(widget, item)
 end
 
 function ItemsDatabase.refreshVisibleRarityFrames(itemIds)

--- a/modules/gamelib/items.lua
+++ b/modules/gamelib/items.lua
@@ -447,12 +447,19 @@ function ItemsDatabase.trackRarityWidget(widget, item)
 end
 
 local function refreshTrackedRarityWidget(widget, expectedItemId)
-  if not widget or (widget.isDestroyed and widget:isDestroyed()) or not widget.getItem then
+  if not widget then
     ItemsDatabase.untrackRarityWidget(widget)
     return
   end
 
+  -- A widget can be destroyed between the weak-table iteration and this
+  -- callback (notably while relogging or rebuilding the game panels). Even
+  -- looking up a method on that stale userdata enters the C++ binding, so keep
+  -- every widget access inside the protected call.
   local ok, item = pcall(function()
+    if (widget.isDestroyed and widget:isDestroyed()) or not widget.getItem then
+      return nil
+    end
     return widget:getItem()
   end)
   if not ok or getRarityItemId(item) ~= expectedItemId then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Aprimorada a validação de widgets de raridade para lidar com segurança com referências destruídas ou obsoletas.
  * Evitadas falhas ao atualizar o widget quando o item monitorado não está mais disponível.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->