### PR TITLE
fix(protocol): support 8.60 melee attack marks

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -350,8 +350,9 @@ GameAstraQuiverCountU16 = 141
 GameAstraOutfitStoreMode = 142
 GameAstraItemMetadata = 143
 GameZoneWeather = 144
+GameAstraSingleCreatureMarks = 145
 
-LastGameFeature = 145
+LastGameFeature = 146
 
 TextColors = {
   red        = '#F55E5E',

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -503,8 +503,9 @@ namespace Otc
         GameAstraOutfitStoreMode = 142,
         GameAstraItemMetadata = 143,
         GameZoneWeather = 144,
+        GameAstraSingleCreatureMarks = 145,
 
-        LastGameFeature = 145
+        LastGameFeature = 146
     };
 
     enum PathFindResult {

--- a/src/client/effect.cpp
+++ b/src/client/effect.cpp
@@ -48,13 +48,20 @@ void Effect::draw(const Point& dest, int offsetX, int offsetY, bool animate, Lig
         }
     }
 
-    int xPattern = m_position.x % getNumPatternX();
-    if(xPattern < 0)
-        xPattern += getNumPatternX();
+    int xPattern;
+    int yPattern;
+    if (m_useDirectionPattern) {
+        xPattern = m_directionPatternX;
+        yPattern = m_directionPatternY;
+    } else {
+        xPattern = m_position.x % getNumPatternX();
+        if (xPattern < 0)
+            xPattern += getNumPatternX();
 
-    int yPattern = m_position.y % getNumPatternY();
-    if(yPattern < 0)
-        yPattern += getNumPatternY();
+        yPattern = m_position.y % getNumPatternY();
+        if (yPattern < 0)
+            yPattern += getNumPatternY();
+    }
 
     // Use OWN source alpha when no explicit source (server doesn't send GameEffectSource)
     auto source = m_source;
@@ -94,6 +101,22 @@ void Effect::setId(uint32 id)
     if(!g_things.isValidDatId(id, ThingCategoryEffect))
         id = 0;
     m_id = id;
+}
+
+void Effect::setDirection(Otc::Direction direction)
+{
+    m_useDirectionPattern = true;
+    switch (direction) {
+        case Otc::NorthWest: m_directionPatternX = 0; m_directionPatternY = 0; break;
+        case Otc::North: m_directionPatternX = 1; m_directionPatternY = 0; break;
+        case Otc::NorthEast: m_directionPatternX = 2; m_directionPatternY = 0; break;
+        case Otc::East: m_directionPatternX = 2; m_directionPatternY = 1; break;
+        case Otc::SouthEast: m_directionPatternX = 2; m_directionPatternY = 2; break;
+        case Otc::South: m_directionPatternX = 1; m_directionPatternY = 2; break;
+        case Otc::SouthWest: m_directionPatternX = 0; m_directionPatternY = 2; break;
+        case Otc::West: m_directionPatternX = 0; m_directionPatternY = 1; break;
+        default: m_directionPatternX = 1; m_directionPatternY = 1; break;
+    }
 }
 
 const ThingTypePtr& Effect::getThingType()

--- a/src/client/effect.h
+++ b/src/client/effect.h
@@ -40,6 +40,7 @@ public:
     
     void setId(uint32 id) override;
     uint32 getId() override { return m_id; }
+    void setDirection(Otc::Direction direction);
 
     EffectPtr asEffect() { return static_self_cast<Effect>(); }
     bool isEffect() override { return true; }
@@ -57,6 +58,9 @@ private:
     Timer m_animationTimer;
     int m_animationPhase = 0;
     uint32 m_randomSeed;
+    uint8 m_directionPatternX = 0;
+    uint8 m_directionPatternY = 0;
+    bool m_useDirectionPattern = false;
     Otc::MagicEffectSources m_source{ Otc::ME_SOURCE_DEFAULT };
 };
 

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -73,6 +73,30 @@ bool shouldDrawMagicEffect(int effectId)
     return shouldDraw;
 }
 
+constexpr uint8 CreatureMarkPlayerAttack = 3;
+
+// weaponType 1-6 maps to sword, club, axe, fist, monk staff and monk dagger effects.
+constexpr uint16 MeleeAttackEffectIds[] = { 0, 304, 305, 306, 309, 307, 308 };
+
+void playMeleeAttackEffect(const CreaturePtr& target, uint8 weaponType)
+{
+    if (!target || weaponType < 1 || weaponType > 6)
+        return;
+
+    const auto& localPlayer = g_game.getLocalPlayer();
+    if (!localPlayer || g_game.getAttackingCreature() != target)
+        return;
+
+    const uint16 effectId = MeleeAttackEffectIds[weaponType];
+    if (!g_things.isValidDatId(effectId, ThingCategoryEffect))
+        return;
+
+    const auto& effect = std::make_shared<Effect>();
+    effect->setId(effectId);
+    effect->setDirection(localPlayer->getPosition().getDirectionFromPosition(target->getPosition()));
+    g_map.addThing(effect, target->getPosition());
+}
+
 uint32_t getBoundedItemCount(const InputMessagePtr& msg, uint32_t count, const char* context)
 {
     const uint32_t unread = std::max(0, msg->getUnreadSize());
@@ -4557,6 +4581,36 @@ void ProtocolGame::parseFeatures(const InputMessagePtr& msg)
 
 void ProtocolGame::parseCreaturesMark(const InputMessagePtr& msg)
 {
+    // Astra 8.60 negotiates custom server features and receives a
+    // single-record melee mark: [creatureId][markType][weaponType]. Keep the
+    // standard counted 8.60 parser below for servers without Astra features.
+    if (g_game.getProtocolVersion() == 860 && g_game.getFeature(Otc::GameAstraCreatureIcons)) {
+        const uint32 id = msg->getU32();
+        const uint8 markType = msg->getU8();
+        const uint8 markValue = msg->getU8();
+        const CreaturePtr creature = g_map.getCreatureById(id);
+        if (!creature) {
+            g_logger.traceError("could not get creature");
+            return;
+        }
+
+        if (markType == CreatureMarkPlayerAttack) {
+            playMeleeAttackEffect(creature, markValue);
+            return;
+        }
+
+        const bool isPermanent = markType != 1;
+        if (isPermanent) {
+            if (markValue == 0xff)
+                creature->hideStaticSquare();
+            else
+                creature->showStaticSquare(Color::from8bit(markValue));
+        } else {
+            creature->addTimedSquare(markValue);
+        }
+        return;
+    }
+
     int len;
     if (g_game.getProtocolVersion() >= 1035) {
         len = 1;

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -4584,7 +4584,7 @@ void ProtocolGame::parseCreaturesMark(const InputMessagePtr& msg)
     // Astra 8.60 negotiates custom server features and receives a
     // single-record melee mark: [creatureId][markType][weaponType]. Keep the
     // standard counted 8.60 parser below for servers without Astra features.
-    if (g_game.getProtocolVersion() == 860 && g_game.getFeature(Otc::GameAstraCreatureIcons)) {
+    if (g_game.getProtocolVersion() == 860 && g_game.getFeature(Otc::GameAstraSingleCreatureMarks)) {
         const uint32 id = msg->getU32();
         const uint8 markType = msg->getU8();
         const uint8 markValue = msg->getU8();

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -33,6 +33,7 @@
 namespace {
 
 constexpr auto ASTRA_CLIENT_MARKER = "A";
+constexpr auto ASTRA_SINGLE_CREATURE_MARKS_MARKER = "AstraSingleCreatureMarks";
 constexpr uint32 ASTRA_CLIENT_SIGNATURE_SEED = 0xA57AC11E;
 constexpr uint32 ASTRA_CLIENT_SIGNATURE_FINAL = 0x4D415354;
 
@@ -164,6 +165,7 @@ void ProtocolGame::sendLoginPacket(uint challengeTimestamp, uint8 challengeRando
         msg->addString(std::string("OTCv8TierByte"));
         msg->addString(std::string(ASTRA_CLIENT_MARKER));
         msg->addU32(generateAstraClientSignature(g_game.getOs(), g_game.getCustomProtocolVersion(), m_xteaKey, challengeTimestamp, challengeRandom));
+        msg->addString(std::string(ASTRA_SINGLE_CREATURE_MARKS_MARKER));
     }
 
     // encrypt with RSA


### PR DESCRIPTION
Port the directional CreatureMark melee effects used by the server while preserving the standard parser for non-Astra 8.60 connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos recursos**
  - Efeitos visuais agora podem usar padrões específicos conforme a direção do personagem ou criatura.
  - Ataques corpo a corpo exibem efeitos visuais correspondentes ao tipo de arma utilizada.
  - O protocolo Astra 8.60 passa a interpretar marcas de criaturas e efeitos de ataque de forma compatível com seus recursos.

- **Correções**
  - Mantido o processamento padrão de marcas para servidores que não oferecem os recursos específicos do Astra 8.60.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->